### PR TITLE
ISSUE-105 Support optional LemonLdapCookie fallback and remove Host header check

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/MongoTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/MongoTest.java
@@ -74,7 +74,6 @@ class MongoTest {
         .configurationFromClasspath()
         .userChoice(TwakeCalendarConfiguration.UserChoice.MEMORY)
         .dbChoice(TwakeCalendarConfiguration.DbChoice.MONGODB),
-        AppTestHelper.LEMON_COOKIE_AUTHENTICATION_STRATEGY_BY_PASS_MODULE,
         DavModuleTestHelper.FROM_SABRE_EXTENSION.apply(sabreDavExtension),
         binder -> binder.bind(URL.class).annotatedWith(Names.named("userInfo"))
             .toProvider(MongoTest::getUserInfoTokenEndpoint));

--- a/app/src/test/java/com/linagora/calendar/app/TwakeCalendarAuthenticationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TwakeCalendarAuthenticationTest.java
@@ -87,7 +87,6 @@ class TwakeCalendarAuthenticationTest {
     private static LemonCookieAuthenticationStrategy.ResolutionConfiguration getResolutionConfiguration() {
         String resolutionURL = String.format("http://127.0.0.1:%s%s", mockServer.getLocalPort(), COOKIE_RESOLUTION_PATH);
         return new LemonCookieAuthenticationStrategy.ResolutionConfiguration(URI.create(resolutionURL),
-            Domain.of("localhost"),
             Domain.of(DOMAIN));
     }
 

--- a/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
@@ -97,7 +97,6 @@ class TwakeCalendarGuiceServerTest  {
             .dbChoice(TwakeCalendarConfiguration.DbChoice.MEMORY),
         DavModuleTestHelper.RABBITMQ_MODULE.apply(rabbitMQExtension),
         DavModuleTestHelper.BY_PASS_MODULE,
-        AppTestHelper.LEMON_COOKIE_AUTHENTICATION_STRATEGY_BY_PASS_MODULE,
         binder -> binder.bind(URL.class).annotatedWith(Names.named("userInfo")).toProvider(TwakeCalendarGuiceServerTest::getUserInfoTokenEndpoint),
         binder -> binder.bind(IntrospectionEndpoint.class).toProvider(() -> new IntrospectionEndpoint(getInrospectTokenEndpoint(), Optional.empty())));
 

--- a/app/src/test/java/com/linagora/calendar/app/oidc/TwakeCalendarOidcAuthenticationRedisTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/oidc/TwakeCalendarOidcAuthenticationRedisTest.java
@@ -94,9 +94,7 @@ public class TwakeCalendarOidcAuthenticationRedisTest {
 
     private static ResolutionConfiguration getResolutionConfiguration() {
         String resolutionURL = String.format("http://127.0.0.1:%s%s", mockServer.getLocalPort(), COOKIE_RESOLUTION_PATH);
-        return new ResolutionConfiguration(URI.create(resolutionURL),
-            Domain.of("localhost"),
-            Domain.of(DOMAIN));
+        return new ResolutionConfiguration(URI.create(resolutionURL), Domain.of(DOMAIN));
     }
 
     @Order(3)

--- a/app/src/test/java/com/linagora/calendar/app/oidc/TwakeCalendarOidcFallbackCookieAuthenticationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/oidc/TwakeCalendarOidcFallbackCookieAuthenticationTest.java
@@ -99,7 +99,6 @@ public class TwakeCalendarOidcFallbackCookieAuthenticationTest {
     private static LemonCookieAuthenticationStrategy.ResolutionConfiguration getResolutionConfiguration() {
         String resolutionURL = String.format("http://127.0.0.1:%s%s", mockServer.getLocalPort(), COOKIE_RESOLUTION_PATH);
         return new LemonCookieAuthenticationStrategy.ResolutionConfiguration(URI.create(resolutionURL),
-            Domain.of("localhost"),
             Domain.of(DOMAIN));
     }
 
@@ -243,48 +242,6 @@ public class TwakeCalendarOidcFallbackCookieAuthenticationTest {
     @Test
     void shouldFailAuthenticationWhenNoCookieAndNoBearerToken() {
             given()
-        .when()
-            .get("/api/user")
-        .then()
-            .statusCode(401);
-    }
-
-    @Test
-    void shouldSucceedAuthenticationWhenResolutionDomainMatchesParent() {
-        mockServer.when(HttpRequest.request()
-                .withMethod("GET")
-                .withPath(COOKIE_RESOLUTION_PATH))
-            .respond(HttpResponse.response()
-                .withStatusCode(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody("{\"result\":\"%s\"}".formatted(USERNAME.getLocalPart())));
-
-        String regexMatch = "prefix." + getResolutionConfiguration().resolutionDomain().name();
-
-        given()
-            .cookie("lemonldap", "123")
-            .header("Host", regexMatch)
-        .when()
-            .get("/api/user")
-        .then()
-            .statusCode(200);
-    }
-
-    @Test
-    void shouldFailAuthenticationWhenResolutionDomainDoesNotMatch() {
-        mockServer.when(HttpRequest.request()
-                .withMethod("GET")
-                .withPath(COOKIE_RESOLUTION_PATH))
-            .respond(HttpResponse.response()
-                .withStatusCode(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody("{\"result\":\"%s\"}".formatted(USERNAME.getLocalPart())));
-
-        String notMatchHost = "another-domain.ltd";
-
-        given()
-            .cookie("lemonldap", "123")
-            .header("Host", notMatchHost)
         .when()
             .get("/api/user")
         .then()

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/auth/OidcFallbackCookieAuthenticationStrategy.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/auth/OidcFallbackCookieAuthenticationStrategy.java
@@ -18,8 +18,6 @@
 
 package com.linagora.calendar.restapi.auth;
 
-import jakarta.inject.Inject;
-
 import org.apache.james.jmap.http.AuthenticationChallenge;
 import org.apache.james.jmap.http.AuthenticationScheme;
 import org.apache.james.jmap.http.AuthenticationStrategy;
@@ -35,7 +33,6 @@ public class OidcFallbackCookieAuthenticationStrategy implements AuthenticationS
     private final OidcAuthenticationStrategy oidcAuthenticationStrategy;
     private final LemonCookieAuthenticationStrategy lemonCookieAuthenticationStrategy;
 
-    @Inject
     public OidcFallbackCookieAuthenticationStrategy(OidcAuthenticationStrategy oidcAuthenticationStrategy, LemonCookieAuthenticationStrategy lemonCookieAuthenticationStrategy) {
         this.oidcAuthenticationStrategy = oidcAuthenticationStrategy;
         this.lemonCookieAuthenticationStrategy = lemonCookieAuthenticationStrategy;


### PR DESCRIPTION
- Introduce optional configuration for LemonLdapCookie fallback authentication. If not configured, it will gracefully skip fallback.
- Remove "Host" header validation from HTTP requests as it is no longer required. 