### PR TITLE
ISSUE-176 Introduce SubjectRenderer

### DIFF
--- a/calendar-smtp/src/main/java/com/linagora/calendar/smtp/template/MessageGenerator.java
+++ b/calendar-smtp/src/main/java/com/linagora/calendar/smtp/template/MessageGenerator.java
@@ -147,7 +147,7 @@ public class MessageGenerator {
             inlinedAttachments.forEach(Throwing.consumer(attachment -> multipartBuilder.addBodyPart(attachment.asBodyPart())));
 
             return Message.Builder.of()
-                .setSubject(subject())
+                .setSubject(subject(scopedVariableFinal))
                 .setBody(multipartBuilder.build())
                 .setFrom(configuration.sender().asString())
                 .setTo(recipient.asString())
@@ -155,10 +155,11 @@ public class MessageGenerator {
         });
     }
 
-    private String subject() {
-        String subject = i18nTranslator.get(SUBJECT_KEY_NAME);
-        Preconditions.checkArgument(StringUtils.isNotBlank(subject),
+    private String subject(Map<String, Object> scopedVariable) throws IOException {
+        String subjectTemplate = i18nTranslator.get(SUBJECT_KEY_NAME);
+        Preconditions.checkArgument(StringUtils.isNotBlank(subjectTemplate),
             "Subject is empty, please check your translations for key: " + SUBJECT_KEY_NAME);
-        return subject;
+
+        return SubjectRenderer.of(subjectTemplate).render(scopedVariable);
     }
 }

--- a/calendar-smtp/src/main/java/com/linagora/calendar/smtp/template/SubjectRenderer.java
+++ b/calendar-smtp/src/main/java/com/linagora/calendar/smtp/template/SubjectRenderer.java
@@ -1,0 +1,53 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.smtp.template;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+
+import de.neuland.pug4j.Pug4J;
+import de.neuland.pug4j.PugConfiguration;
+import de.neuland.pug4j.template.PugTemplate;
+import de.neuland.pug4j.template.ReaderTemplateLoader;
+
+public class SubjectRenderer {
+    private static final String TEMPLATE_LOADER_NAME = "inline";
+    private static final String AVOID_HTML_TAG_CHARACTER = "|";
+
+    public static SubjectRenderer of(String templateString) throws IOException {
+        String safeTemplate = AVOID_HTML_TAG_CHARACTER + templateString;
+
+        ReaderTemplateLoader loader = new ReaderTemplateLoader(new StringReader(safeTemplate), TEMPLATE_LOADER_NAME);
+
+        PugConfiguration pugConfiguration = new PugConfiguration();
+        pugConfiguration.setTemplateLoader(loader);
+        return new SubjectRenderer(pugConfiguration.getTemplate(TEMPLATE_LOADER_NAME));
+    }
+
+    private final PugTemplate template;
+
+    private SubjectRenderer(PugTemplate template) {
+        this.template = template;
+    }
+
+    public String render(Map<String, Object> scopedValue) {
+        return Pug4J.render(template, scopedValue);
+    }
+}

--- a/calendar-smtp/src/test/java/com/linagora/calendar/smtp/template/SubjectRendererTest.java
+++ b/calendar-smtp/src/test/java/com/linagora/calendar/smtp/template/SubjectRendererTest.java
@@ -1,0 +1,71 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.smtp.template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.linagora.calendar.smtp.i18n.I18NTranslator;
+
+public class SubjectRendererTest {
+
+    @Test
+    void shouldRenderSubjectWhenNoAttributes() throws IOException {
+        SubjectRenderer subjectRenderer = SubjectRenderer.of("Report import");
+
+        assertThat(subjectRenderer.render(Map.of()))
+            .isEqualTo("Report import");
+    }
+
+    @Test
+    void shouldRenderSubjectWithInterpolatedVariables() throws IOException {
+        SubjectRenderer subjectRenderer = SubjectRenderer.of("Report import for #{user} on #{date}");
+
+        assertThat(subjectRenderer.render(Map.of("user", "John Doe", "date", "2023-10-01")))
+            .isEqualTo("Report import for John Doe on 2023-10-01");
+    }
+
+    @Test
+    void shouldRenderSubjectUsingI18NTranslator() throws IOException {
+        SubjectRenderer subjectRenderer = SubjectRenderer.of("!{translator.get('accepted')}: Sprint review");
+
+        I18NTranslator i18NTranslator = key -> {
+            if ("accepted".equals(key)) {
+                return "Đã chấp nhận";
+            }
+            return key;
+        };
+
+        Map<String, Object> scopedValue = Map.of("translator", i18NTranslator);
+
+        assertThat(subjectRenderer.render(scopedValue))
+            .isEqualTo("Đã chấp nhận: Sprint review");
+    }
+
+    @Test
+    void shouldRenderSubjectWithUnicodeCharacters() throws IOException {
+        SubjectRenderer subjectRenderer = SubjectRenderer.of("Báo cáo nhập sự kiện");
+        assertThat(subjectRenderer.render(Map.of()))
+            .isEqualTo("Báo cáo nhập sự kiện");
+    }
+}


### PR DESCRIPTION
In cases where the email subject is generated by injecting values into a pug template,


eg
`mail_subject=!{subject.partStat}: !{subject.summary} (!{subject.participant})` 
Sample value:
`Accepted: Sprint grooming Twake Calendar #4 (Benoît TELLIER)`