### PR TITLE
ISSUE-211 Fix attendee calendar URI when generate action links

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventMailHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventMailHandler.java
@@ -18,6 +18,7 @@
 
 package com.linagora.calendar.amqp;
 
+import static com.linagora.calendar.amqp.EventFieldConverter.extractCalendarURL;
 import static com.linagora.calendar.smtp.template.MimeAttachment.ATTACHMENT_DISPOSITION_TYPE;
 
 import java.util.List;
@@ -55,6 +56,7 @@ import com.linagora.calendar.smtp.template.MessageGenerator;
 import com.linagora.calendar.smtp.template.MimeAttachment;
 import com.linagora.calendar.smtp.template.TemplateType;
 import com.linagora.calendar.smtp.template.content.model.EventInCalendarLinkFactory;
+import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.SimpleSessionProvider;
 import com.linagora.calendar.storage.configuration.resolver.ConfigurationResolver;
 import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
@@ -144,7 +146,8 @@ public class EventMailHandler {
                     MailAddress organizerMail = EventParseUtils.getOrganizer(vEvent).email();
                     MailAddress attendeeMail = event.recipientEmail();
                     String eventUid = vEvent.getUid().map(Uid::getValue).orElseThrow();
-                    return participationActionLinkFactory.generateLinks(organizerMail, attendeeMail, eventUid, event.calendarURI());
+                    OpenPaaSId attendeeCalendarBaseId = extractCalendarURL(event.eventPath()).base();
+                    return participationActionLinkFactory.generateLinks(organizerMail, attendeeMail, eventUid, attendeeCalendarBaseId.value());
                 });
         }
     }


### PR DESCRIPTION
Why bug `403`?

Here is a sample of the AMQP invite message:


```json
{
    "senderEmail": "user1@open-paas.org",
    "recipientEmail": "user2@open-paas.org",
    "method": "REQUEST",
    "event": "BEGIN:VCALENDAR...",
    "notify": true,
    "calendarURI": "687748a3c1045500547f83ee",
    "eventPath": "\/calendars\/687748a3c1045500547f83ef\/687748a3c1045500547f83ef\/sabredav-9eaab726-44c4-4596-ada5-046189605fa7.ics",
    "isNewEvent": true
}
```

Currently, the code uses `687748a3c1045500547f83ee` (the organizer's calendar base URI) as the value to sign the Participation token.
And the `EventParticipationRoute` use it for build URI to update events, 
-> 403 (attendee could not update organizer resource)


Here should be `687748a3c1045500547f83ef` (extract from `eventhPath`)

### Notice
- In legacy OpenPaaS, the `calendarURI` inside the JWT also refers to the organizer's calendar.
If we accept this PR, it will change the meaning of `calendarURI` in the JWT to refer to the attendee's calendar instead.

### Alternative
- if we want to keep calendarURI of organizer in jwt payload, we can add one more property in jwt. eg : `attendeeCalendarURI` 



