### PR TITLE
ISSUE-225 - Calendar email: Do not handle event update when `changes` is empty

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventEmailConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventEmailConsumer.java
@@ -157,8 +157,12 @@ public class EventEmailConsumer implements Closeable, Startable {
                     LOGGER.info("Received new calendar event message with method REQUEST and eventPath {}", calendarEventMessage.eventPath());
                     yield eventMailHandler.handInviteEvent(CalendarEventInviteNotificationEmail.from(calendarEventMessage));
                 } else {
-                    LOGGER.info("Received updated calendar event message with method REQUEST and eventPath {}", calendarEventMessage.eventPath());
-                    yield eventMailHandler.handleUpdateEvent(CalendarEventUpdateNotificationEmail.from(calendarEventMessage));
+                    if (calendarEventMessage.changes().isEmpty()) {
+                        yield Mono.empty();
+                    } else {
+                        LOGGER.info("Received updated calendar event message with method REQUEST and eventPath {}", calendarEventMessage.eventPath());
+                        yield eventMailHandler.handleUpdateEvent(CalendarEventUpdateNotificationEmail.from(calendarEventMessage));
+                    }
                 }
             }
             case Method.VALUE_REPLY -> {


### PR DESCRIPTION
In the case where an AQMP message in the queue `tcalendar:event:notificationEmail:send`
- Does not contain the property `isNewEvent` (which means isNewEvent = false by default),
- And also does not include a `changes` field,
then it leads to an ambiguous situation, we should skip it 

```json
{
    "senderEmail": "user1@open-paas.org",
    "recipientEmail": "user2@open-paas.org",
    "method": "REQUEST",
    "event": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-\/\/Sabre\/\/Sabre VObject 4.1.3\/\/EN\r\nCALSCALE:GREGORIAN\r\nMETHOD:REQUEST\r\nBEGIN:VTIMEZONE\r\nTZID:Asia\/Jakarta\r\nBEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:WIB\r\nDTSTART:19700101T000000\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nUID:532dab11-2c0b-4280-b423-7a18605ad239\r\nTRANSP:OPAQUE\r\nDTSTART:20250719T033000Z\r\nDTEND:20250719T040000Z\r\nCLASS:PUBLIC\r\nSUMMARY:Test1\r\nDESCRIPTION:123\r\nORGANIZER;CN=John1 Doe1:mailto:user1@open-paas.org\r\nDTSTAMP:20250718T100006Z\r\nATTENDEE;PARTSTAT=ACCEPTED;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL\r\n ;CN=John2 Doe2:mailto:user2@open-paas.org\r\nATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL;CN=John1\r\n  Doe1:mailto:user1@open-paas.org\r\nATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVI\r\n DUAL;CN=John3 Doe3:mailto:user3@open-paas.org\r\nSEQUENCE:0\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
    "notify": true,
    "calendarURI": "687a1a8eca65a100595b790c",
    "eventPath": "\/calendars\/687a1a8eca65a100595b790d\/687a1a8eca65a100595b790d\/sabredav-b08ef710-eafd-4f5c-8e67-db3d45e0f827.ics"
}
```