### PR TITLE
[ENHANCEMENT] Allows selecting OIDC strategy even when token is in JWT format

### DIFF
--- a/calendar-api/src/main/java/com/linagora/calendar/api/JwtSigner.java
+++ b/calendar-api/src/main/java/com/linagora/calendar/api/JwtSigner.java
@@ -83,6 +83,9 @@ public class JwtSigner {
         }
     }
 
+    public static final String AUTH_TYPE = "twake_calendar_auth_type";
+    public static final String JWT_AUTH_TYPE_VALUE = "jwt";
+
     private static final String SUB_CLAIM = "sub";
 
     private final Clock clock;
@@ -98,7 +101,8 @@ public class JwtSigner {
     }
 
     public Mono<String> generate(String sub) {
-        return generate(ImmutableMap.of(SUB_CLAIM, sub));
+        return generate(ImmutableMap.of(SUB_CLAIM, sub,
+            AUTH_TYPE, JWT_AUTH_TYPE_VALUE));
     }
 
     public Mono<String> generate(Map<String, Object> claims) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/auth/OidcAuthenticationStrategy.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/auth/OidcAuthenticationStrategy.java
@@ -18,6 +18,7 @@
 
 package com.linagora.calendar.restapi.auth;
 
+import static com.linagora.calendar.restapi.auth.JwtAuthenticationStrategy.isAuthTypeJwt;
 import static org.apache.james.jmap.http.JWTAuthenticationStrategy.AUTHORIZATION_HEADER_PREFIX;
 
 import java.time.Clock;
@@ -64,7 +65,7 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
         return Mono.fromCallable(() -> authHeaders(httpRequest))
             .filter(header -> header.startsWith(AUTHORIZATION_HEADER_PREFIX))
             .map(header -> header.substring(AUTHORIZATION_HEADER_PREFIX.length()))
-            .filter(token -> !token.startsWith("eyJ")) // Heuristic for detecting JWT
+            .filter(token -> !isAuthTypeJwt(token))
             .map(Token::new)
             .flatMap(oidcTokenCache::associatedInformation)
             .<TokenInfo>handle((tokenInfo, sink) -> {


### PR DESCRIPTION
- This allows easier integration with multiple OIDC identity providers, instead of being limited to Opac-issued tokens only.



// It also helps set up mock OIDC in the local development environment. linagora/twake-calendar-frontend#42

