### PR TITLE
ISSUE-263 Support admin creds

### DIFF
--- a/app/src/main/conf/configuration.properties
+++ b/app/src/main/conf/configuration.properties
@@ -1,5 +1,7 @@
 mongo.url=mongodb://login:password@51.210.186.235:27017/esn_docker?replicaSet=rs0&authSource=admin
 domains=linagora.com
+admin.username=admin@linagora.com
+admin.password=secret
 rest.api.port=80
 spa.calendar.url=https://e-calendrier.avocat.fr
 spa.contacts.url=https://e-contacts.avocat.fr

--- a/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
@@ -803,6 +803,49 @@ class TwakeCalendarGuiceServerTest  {
     }
 
     @Test
+    void shouldSupportAdminCreds(TwakeCalendarGuiceServer server) {
+        targetRestAPI(server);
+
+        String domainId = server.getProbe(CalendarDataProbe.class).domainId(DOMAIN).value();
+        String userId = server.getProbe(CalendarDataProbe.class).userId(USERNAME).value();
+        String body = given()
+            .auth().preemptive().basic("admin@linagora.com", "secret")
+            .queryParam("email", "btellier@linagora.com")
+        .when()
+            .get("/api/users")
+        .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(body)
+            .isEqualTo(String.format("""
+                [{
+                    "preferredEmail": "btellier@linagora.com",
+                    "_id": "%s",
+                    "state": [],
+                    "domains": [
+                        {
+                            "domain_id": "%s",
+                            "joined_at": "1970-01-01T00:00:00.000Z"
+                        }
+                    ],
+                    "main_phone": "",
+                    "followings": 0,
+                    "following": false,
+                    "followers": 0,
+                    "emails": [
+                        "btellier@linagora.com"
+                    ],
+                    "firstname": "btellier@linagora.com",
+                    "lastname": "btellier@linagora.com",
+                    "objectType": "user"
+                }]
+                """, userId, domainId));
+    }
+
+    @Test
     void userByEmailEndpointShouldReturnEmptyWHenNotFound(TwakeCalendarGuiceServer server) {
         targetRestAPI(server);
 

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/DownloadCalendarRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/DownloadCalendarRouteTest.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
@@ -67,7 +68,7 @@ public class DownloadCalendarRouteTest {
     private static final String PASSWORD = "secret";
     private static final String SECRET_LINK_BASE_URL = "https://mocked.url/xyz";
 
-    private static final RestApiConfiguration initialRestApiConfiguration = RestApiConfiguration.builder().build();
+    private static final RestApiConfiguration initialRestApiConfiguration = RestApiConfiguration.builder().adminPassword(Optional.of("secret")).build();
     private static final RestApiConfiguration spyRestApiConfiguration = Mockito.spy(initialRestApiConfiguration);
 
     @RegisterExtension

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/SecretLinkRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/SecretLinkRouteTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.apache.http.HttpStatus;
@@ -65,7 +66,7 @@ public class SecretLinkRouteTest {
     private static final String SECRET_LINK_BASE_URL = "https://mocked.url/xyz";
     private static final Username USERNAME = Username.fromLocalPartWithDomain("bob", DOMAIN);
 
-    private static final RestApiConfiguration initialRestApiConfiguration = RestApiConfiguration.builder().build();
+    private static final RestApiConfiguration initialRestApiConfiguration = RestApiConfiguration.builder().adminPassword(Optional.of("secret")).build();
     private static final RestApiConfiguration spyRestApiConfiguration = Mockito.spy(initialRestApiConfiguration);
 
     @RegisterExtension

--- a/app/src/test/resources/configuration.properties
+++ b/app/src/test/resources/configuration.properties
@@ -1,4 +1,6 @@
 default.business.hours.daysOfWeek=1,2,3,4,5
+admin.username=admin@linagora.com
+admin.password=secret
 
 ## SMTP configuration
 smtp.host=localhost

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiConfiguration.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiConfiguration.java
@@ -76,6 +76,8 @@ public class RestApiConfiguration {
         private Optional<String> defaultTimezone = Optional.empty();
         private Optional<JsonNode> defaultBusinessHours = Optional.empty();
         private Optional<Boolean> defaultUse24hFormat = Optional.empty();
+        private Optional<String> adminUsername = Optional.empty();
+        private Optional<String> adminPassword = Optional.empty();
 
         private Builder() {
 
@@ -196,6 +198,17 @@ public class RestApiConfiguration {
             return this;
         }
 
+        public Builder adminUsername(Optional<String> adminUsername) {
+            this.adminUsername = adminUsername;
+            return this;
+        }
+
+
+        public Builder adminPassword(Optional<String> adminPassword) {
+            this.adminPassword = adminPassword;
+            return this;
+        }
+
         public RestApiConfiguration build() {
             try {
                 ArrayNode arrayNode = defaultBusinessHours();
@@ -221,7 +234,9 @@ public class RestApiConfiguration {
                     defaultLanguage.orElse("en"),
                     defaultTimezone.orElse("Europe/Paris"),
                     defaultUse24hFormat.orElse(true),
-                    defaultBusinessHours.orElse(arrayNode));
+                    defaultBusinessHours.orElse(arrayNode),
+                    adminUsername.orElse("admin@open-paas.org"),
+                    adminPassword.orElseThrow(() -> new IllegalArgumentException("Expecting 'admin.password' to be specified")));
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
@@ -256,7 +271,6 @@ public class RestApiConfiguration {
         Optional<URL> calendarSpaUrl = urlParser.apply("spa.calendar.url");
         Optional<URL> contactSpaUrl = urlParser.apply("spa.contacts.url");
         Optional<URL> openpaasBackendURL = urlParser.apply("openpaas.backend.url");
-
         Optional<URL> davURL = urlParser.apply("dav.url");
         Optional<URL> selfURL = urlParser.apply("self.url");
         Optional<URL> visioURL = urlParser.apply("visio.url");
@@ -277,6 +291,8 @@ public class RestApiConfiguration {
         Optional<Boolean> defaultUse24hFormat = Optional.ofNullable(configuration.getBoolean("default.use.24h.format", null));
         Optional<String> defaultLanguage = Optional.ofNullable(configuration.getString("default.language", null));
         Optional<String> defaultTimezone = Optional.ofNullable(configuration.getString("default.timezone", null));
+        Optional<String> adminUsername = Optional.ofNullable(configuration.getString("admin.username", null));
+        Optional<String> adminPassword = Optional.ofNullable(configuration.getString("admin.password", null));
         ArrayNode arrayNode = readWorkingHours(configuration);
 
         Optional<IntrospectionEndpoint> introspectionEndpoint = oidcIntrospectUrl.map(url -> new IntrospectionEndpoint(url, oidcIntrospectCreds));
@@ -304,6 +320,8 @@ public class RestApiConfiguration {
             .defaultTimezone(defaultTimezone)
             .defaultUse24hFormat(defaultUse24hFormat)
             .defaultBusinessHours(Optional.of(arrayNode))
+            .adminUsername(adminUsername)
+            .adminPassword(adminPassword)
             .build();
     }
 
@@ -352,13 +370,15 @@ public class RestApiConfiguration {
     private final String defaultTimezone;
     private final boolean defaultUse24hFormat;
     private final JsonNode defaultBusinessHours;
+    private final String adminUsername;
+    private final String adminPassword;
 
     @VisibleForTesting
     RestApiConfiguration(Optional<Port> port, URL calendarSpaUrl,
                          URL contactSpaUrl, URL selfUrl, URL openpaasBackendURL, URL davURL, URL visioURL, boolean openpaasBackendTrustAllCerts,
                          String jwtPrivatePath, List<String> jwtPublicPath, Duration jwtValidity, URL oidcUserInfoUrl, IntrospectionEndpoint introspectionEndpoint,
                          String oidcIntrospectionClaim, Aud aud, boolean calendarSharingENabled, boolean sharingCalendarEnabled, boolean domainMembersAddressbookEnabled,
-                         String defaultLanguage, String defaultTimezone, boolean defaultUse24hFormat, JsonNode defaultBusinessHours) {
+                         String defaultLanguage, String defaultTimezone, boolean defaultUse24hFormat, JsonNode defaultBusinessHours, String adminUsername, String adminPassword) {
         this.port = port;
         this.calendarSpaUrl = calendarSpaUrl;
         this.contactSpaUrl = contactSpaUrl;
@@ -381,6 +401,8 @@ public class RestApiConfiguration {
         this.defaultTimezone = defaultTimezone;
         this.defaultUse24hFormat = defaultUse24hFormat;
         this.defaultBusinessHours = defaultBusinessHours;
+        this.adminUsername = adminUsername;
+        this.adminPassword = adminPassword;
     }
 
     public Optional<Port> getPort() {
@@ -469,5 +491,13 @@ public class RestApiConfiguration {
 
     public Aud getAud() {
         return aud;
+    }
+
+    public String getAdminUsername() {
+        return adminUsername;
+    }
+
+    public String getAdminPassword() {
+        return adminPassword;
     }
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -152,12 +152,8 @@ public class RestApiModule extends AbstractModule {
 
     @Provides
     @Singleton
-    RestApiConfiguration provideConf(PropertiesProvider propertiesProvider) throws ConfigurationException {
-        try {
-            return RestApiConfiguration.parseConfiguration(propertiesProvider);
-        } catch (FileNotFoundException e) {
-            return RestApiConfiguration.builder().build();
-        }
+    RestApiConfiguration provideConf(PropertiesProvider propertiesProvider) throws ConfigurationException, FileNotFoundException {
+        return RestApiConfiguration.parseConfiguration(propertiesProvider);
     }
 
     @ProvidesIntoSet


### PR DESCRIPTION
Used by Sabre and Twake Mail

Please note that for safety reasons the admin user password needs to be explicitly set in configuration.properties (no defaults) which in turn makes that file compulsory.