### PR TITLE
Optimize collectEvents by replacing Reactor groupBy with `EventParseUtils.groupByUid`

### DIFF
--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/AlarmScheduleService.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/AlarmScheduleService.java
@@ -24,7 +24,6 @@ import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 
@@ -48,10 +47,7 @@ import com.linagora.calendar.storage.event.EventParseUtils;
 import com.linagora.calendar.storage.eventsearch.EventUid;
 
 import net.fortuna.ical4j.model.Calendar;
-import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.ComponentList;
-import net.fortuna.ical4j.model.Property;
-import net.fortuna.ical4j.model.component.VEvent;
 import net.fortuna.ical4j.model.property.DateProperty;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -210,9 +206,7 @@ public class AlarmScheduleService {
     }
 
     private Flux<ScheduledItem> collectEvents(Context context, OpenPaaSUser user, CalendarURL calendarURL, Calendar exportedCalendar) {
-        return Mono.fromCallable(() -> exportedCalendar.getComponents(Component.VEVENT).stream()
-                .map(VEvent.class::cast)
-                .collect(Collectors.groupingBy(v -> v.getProperty(Property.UID).get().getValue())))
+        return Mono.fromCallable(() -> EventParseUtils.groupByUid(exportedCalendar))
             .flatMapMany(map -> Flux.fromIterable(map.entrySet())
                 .map(entry -> new Calendar(new ComponentList<>(entry.getValue())))
                 .map(calendar -> new ScheduledItem(calendar, user.username(), calendarURL)))

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/EventParseUtils.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/EventParseUtils.java
@@ -31,8 +31,10 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import jakarta.mail.internet.AddressException;
 
@@ -55,6 +57,7 @@ import net.fortuna.ical4j.model.parameter.PartStat;
 import net.fortuna.ical4j.model.property.Description;
 import net.fortuna.ical4j.model.property.Location;
 import net.fortuna.ical4j.model.property.Summary;
+import net.fortuna.ical4j.model.property.Uid;
 
 public class EventParseUtils {
     public static final Logger LOGGER = LoggerFactory.getLogger(EventParseUtils.class);
@@ -273,6 +276,16 @@ public class EventParseUtils {
 
     public static boolean isCancelled(VEvent event) {
         return event.getStatus() != null && "CANCELLED".equalsIgnoreCase(event.getStatus().getValue());
+    }
+
+    public static Map<String, List<VEvent>> groupByUid(Calendar calendar) {
+        return calendar.getComponents(Component.VEVENT).stream()
+            .map(VEvent.class::cast)
+            .collect(Collectors.groupingBy(v ->
+                v.getUid()
+                    .map(Uid::getValue)
+                    .orElseThrow(() ->
+                        new IllegalArgumentException("VEVENT is missing UID, invalid ICS"))));
     }
 
 }


### PR DESCRIPTION
This improves performance and reduces overhead when handling calendars with thousands of VEVENTs

similar:
- https://github.com/linagora/twake-calendar-side-service/pull/304