### PR TITLE
Update theme logo URL

### DIFF
--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/LogoRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/LogoRoute.java
@@ -51,7 +51,7 @@ public class LogoRoute extends CalendarRoute {
     @Override
     Mono<Void> handleRequest(HttpServerRequest req, HttpServerResponse res, MailboxSession session) {
         return res.status(HttpResponseStatus.MOVED_PERMANENTLY)
-            .header(HttpHeaderNames.LOCATION, configuration.getCalendarSpaUrl().toString() + "/assets/images/white-logo.svg")
+            .header(HttpHeaderNames.LOCATION, configuration.getCalendarSpaUrl().toString() + "/calendar/assets/images/white-logo.svg")
             .header("Cache-Control", "public, max-age=86400")
             .send();
     }

--- a/docs/apis/openpaasApi.md
+++ b/docs/apis/openpaasApi.md
@@ -445,7 +445,7 @@ Used by SPAs for auto-complete.
 
 ### /api/themes/{domainId}/logo
 
-Redirect to the SPA `/assets/images/white-logo.svg` own image.
+Redirect to the SPA `/calendar/assets/images/white-logo.svg` own image.
 
 Here to satisfy OpenPaaS SPAs.
 


### PR DESCRIPTION
Can not load `logo.svg` from URL
`https://calendar.linagora.com/assets/images/white-logo.svg`

The correct should be 
`https://calendar.linagora.com/calendar/assets/images/white-logo.svg`

<img width="2558" height="652" alt="image" src="https://github.com/user-attachments/assets/11684278-fa6e-4b87-8b68-7aaf9464b0cc" />
