### PR TITLE
Fix CI `java.lang.NoClassDefFoundError: eu/timepit/refined/package$`

### DIFF
--- a/storage-redis/pom.xml
+++ b/storage-redis/pom.xml
@@ -89,6 +89,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>eu.timepit</groupId>
+            <artifactId>refined_${scala.base}</artifactId>
+            <scope>test</scope>
+            <version>0.11.3</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
ref https://james-jenkins.lin-saas.com/blue/organizations/jenkins/Calendar%20Side%20Service%20build/detail/PR-385/3/tests/

`associatedUsernameShouldCachedWhenAbsentSidInTokenInfo – com.linagora.calendar.storage.redis.RedisClusterOIDCTokenCacheTest`
```
Error
eu/timepit/refined/package$
Stacktrace
java.lang.NoClassDefFoundError: eu/timepit/refined/package$
	at org.apache.james.backends.redis.RedisUris$.validate(RedisConfiguration.scala:83)
	at org.apache.james.backends.redis.RedisUris$.liftOrThrow(RedisConfiguration.scala:89)
	at org.apache.james.backends.redis.RedisUris$.from(RedisConfiguration.scala:96)
	at org.apache.james.backends.redis.ClusterRedisConfiguration$.from(RedisConfiguration.scala:211)
	at org.apache.james.backends.redis.ClusterRedisConfiguration$.from(RedisConfiguration.scala:202)
	at org.apache.james.backends.redis.ClusterRedisConfiguration.from(RedisConfiguration.scala)
	at org.apache.james.backends.redis.RedisClusterExtension$RedisClusterContainer.getRedisConfiguration(RedisClusterExtension.java:66)
	at com.linagora.calendar.storage.redis.RedisClusterOIDCTokenCacheTest.redisConfiguration(RedisClusterOIDCTokenCacheTest.java:64)
	at com.linagora.calendar.storage.redis.RedisOIDCTokenCacheContract.setUp(RedisOIDCTokenCacheContract.java:52)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
Caused by: java.lang.ClassNotFoundException: eu.timepit.refined.package$
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	... 12 more
```