### PR TITLE
Validate several audiences (prod & preprod)

### DIFF
--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -105,6 +105,11 @@ import com.linagora.calendar.storage.secretlink.SecretLinkPermissionChecker;
 import com.linagora.calendar.storage.secretlink.SecretLinkPermissionChecker.NoopPermissionChecker;
 
 public class RestApiModule extends AbstractModule {
+
+    public interface Audiences {
+        List<Aud> get();
+    }
+
     @Override
     protected void configure() {
         install(new AssetModule());
@@ -192,9 +197,10 @@ public class RestApiModule extends AbstractModule {
         return configuration.getIntrospectionEndpoint();
     }
 
+
     @Provides
-    Aud provideAudience(RestApiConfiguration configuration) {
-        return configuration.getAud();
+    Audiences provideAudience(RestApiConfiguration configuration) {
+        return configuration::getAud;
     }
 
     @Provides


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for multiple OIDC audiences; the system now accepts a list of allowed audiences and provides them dynamically at runtime.

- Improvements
  - Authentication error messages now list all accepted audiences to simplify troubleshooting.

- Configuration
  - You can configure multiple audiences (existing setups without changes keep the default audience).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->