### PR TITLE
ISSUE-293 [Resource] ResourceParticipationRoute: Update Location redirect URI

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/ResourceParticipationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/ResourceParticipationRouteTest.java
@@ -177,7 +177,7 @@ public class ResourceParticipationRouteTest {
             .get(endpoint)
         .then()
             .statusCode(302)
-            .header("Location", equalTo("https://e-calendrier.avocat.fr/#/calendar"));
+            .header("Location", equalTo("https://e-calendrier.avocat.fr/calendar"));
     }
 
     @Test

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ResourceParticipationRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ResourceParticipationRoute.java
@@ -94,7 +94,7 @@ public class ResourceParticipationRoute implements JMAPRoutes {
         this.calDavEventRepository = calDavEventRepository;
         this.resourceDAO = resourceDAO;
         this.openPaaSDomainDAO = openPaaSDomainDAO;
-        this.locationRedirectUri = URI.create(Strings.CS.removeEnd(calendarBaseUrl.toString(), "/") + "/#/calendar");
+        this.locationRedirectUri = URI.create(Strings.CS.removeEnd(calendarBaseUrl.toString(), "/") + "/calendar");
         this.jwtVerifier = jwtVerifier;
         this.metricFactory = metricFactory;
     }


### PR DESCRIPTION
After clicking the link to update the resource partstat,
the website hangs on the page: `https://calendar.linagora.com/#/calendar`.

It might be caused by a specific Nginx configuration for the path (`/#/calendar`) somewhere, 
Simple way is update it to `/calendar`

<img width="2032" height="1476" alt="image" src="https://github.com/user-attachments/assets/8ccee603-5999-4136-83f7-42101e6a3376" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated post-participation redirect to “/calendar” (removed hash fragment) for cleaner URLs and improved navigation, bookmarking, and sharing.
* **Tests**
  * Updated test expectations to reflect the new redirect URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->