### PR TITLE
ISSUE-407 [AlarmEvent] Enforce unique index on eventUid + recipient to prevent duplicates

### DIFF
--- a/storage-api/src/main/java/com/linagora/calendar/storage/AlarmEvent.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/AlarmEvent.java
@@ -24,7 +24,10 @@ import java.util.Optional;
 import org.apache.james.core.MailAddress;
 
 import com.google.common.base.MoreObjects;
+import com.linagora.calendar.storage.event.AlarmInstantFactory.AlarmInstant;
 import com.linagora.calendar.storage.eventsearch.EventUid;
+
+import net.fortuna.ical4j.model.property.DateProperty;
 
 public record AlarmEvent(EventUid eventUid,
                          Instant alarmTime,
@@ -34,11 +37,22 @@ public record AlarmEvent(EventUid eventUid,
                          MailAddress recipient,
                          String ics) {
 
-   public String toShortString() {
-       return MoreObjects.toStringHelper(this)
-           .add("eventUid", eventUid.value())
-           .add("recipient", recipient.asString())
-           .add("alarmTime", alarmTime.getEpochSecond())
-           .toString();
-   }
+    public String toShortString() {
+        return MoreObjects.toStringHelper(this)
+            .add("eventUid", eventUid.value())
+            .add("recipient", recipient.asString())
+            .add("alarmTime", alarmTime.getEpochSecond())
+            .toString();
+    }
+
+    public AlarmEvent withNextOccurrence(AlarmInstant instant) {
+        return new AlarmEvent(
+            this.eventUid,
+            instant.alarmTime(),
+            instant.eventStartTime(),
+            this.recurring,
+            instant.recurrenceId().map(DateProperty::getValue),
+            this.recipient,
+            this.ics);
+    }
 }

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBAlarmEventDAO.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBAlarmEventDAO.java
@@ -60,7 +60,8 @@ public class MongoDBAlarmEventDAO implements AlarmEventDAO {
     @Inject
     public MongoDBAlarmEventDAO(MongoDatabase database) {
         this.collection = database.getCollection(COLLECTION);
-        Mono.from(collection.createIndex(ascending(EVENT_UID_FIELD, RECIPIENT_FIELD), new IndexOptions())).block();
+        Mono.from(collection.createIndex(ascending(EVENT_UID_FIELD, RECIPIENT_FIELD), new IndexOptions()
+            .unique(true))).block();
         Mono.from(collection.createIndex(ascending(ALARM_TIME_FIELD), new IndexOptions())).block();
     }
 


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * None.
* Bug Fixes
  * More reliable scheduling of recurring alarms, ensuring the next occurrence is correctly computed and delivered.
  * Prevents duplicate alarm entries per event and recipient, reducing redundant notifications.
* Refactor
  * Streamlined recurring alarm update logic for clearer, safer behavior.
* Chores
  * Enforced database uniqueness on alarm records per event and recipient to improve data integrity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->