### PR TITLE
[AlarmEvent] Consumer: Skip processing when event has no VALARM component

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmConsumer.java
@@ -163,7 +163,7 @@ public class EventAlarmConsumer implements Closeable, Startable {
     }
 
     private PersistAlarmHandler handlerAdd() {
-        return eventAlarmHandler::handleCreateOrUpdate;
+        return eventAlarmHandler::handleCreate;
     }
 
     private PersistAlarmHandler handlerAddOrUpdate() {

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
@@ -75,12 +75,17 @@ public class EventAlarmHandler {
         this.eventEmailFilter = eventEmailFilter;
     }
 
+    public Mono<Void> handleCreate(CalendarAlarmMessageDTO alarmMessageDTO) {
+        if (!hasVALARMComponent(alarmMessageDTO)) {
+            return Mono.empty();
+        }
+        return handleCreateOrUpdate(alarmMessageDTO);
+    }
+
     public Mono<Void> handleCreateOrUpdate(CalendarAlarmMessageDTO alarmMessageDTO) {
-        return Mono.just(alarmMessageDTO)
-            .filter(this::hasVALARMComponent)
-            .flatMap(dto -> openPaaSUserDAO.retrieve(dto.extractCalendarURL().base()))
-            .filterWhen(user -> isUserAlarmEnabled(user.username()))
-            .flatMap(user -> processCreateOrUpdate(user.username(), alarmMessageDTO));
+        return openPaaSUserDAO.retrieve(alarmMessageDTO.extractCalendarURL().base())
+            .filterWhen(openPaaSUser -> isUserAlarmEnabled(openPaaSUser.username()))
+            .flatMap(openPaaSUser -> processCreateOrUpdate(openPaaSUser.username(), alarmMessageDTO));
     }
 
     private boolean hasVALARMComponent(CalendarAlarmMessageDTO alarmMessageDTO) {

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
@@ -32,6 +32,7 @@ import org.apache.james.core.Username;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.storage.AlarmEvent;
@@ -75,9 +76,19 @@ public class EventAlarmHandler {
     }
 
     public Mono<Void> handleCreateOrUpdate(CalendarAlarmMessageDTO alarmMessageDTO) {
-        return openPaaSUserDAO.retrieve(alarmMessageDTO.extractCalendarURL().base())
-            .filterWhen(openPaaSUser -> isUserAlarmEnabled(openPaaSUser.username()))
-            .flatMap(openPaaSUser -> processCreateOrUpdate(openPaaSUser.username(), alarmMessageDTO));
+        return Mono.just(alarmMessageDTO)
+            .filter(this::hasVALARMComponent)
+            .flatMap(dto -> openPaaSUserDAO.retrieve(dto.extractCalendarURL().base()))
+            .filterWhen(user -> isUserAlarmEnabled(user.username()))
+            .flatMap(user -> processCreateOrUpdate(user.username(), alarmMessageDTO));
+    }
+
+    private boolean hasVALARMComponent(CalendarAlarmMessageDTO alarmMessageDTO) {
+        JsonNode event = alarmMessageDTO.calendarEvent();
+        return event != null
+            && event.isArray()
+            && event.size() > 2
+            && event.get(2).toString().contains("\"valarm\"");
     }
 
     private Mono<Void> processCreateOrUpdate(Username username, CalendarAlarmMessageDTO alarmMessageDTO) {

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
@@ -32,7 +32,6 @@ import org.apache.james.core.Username;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.storage.AlarmEvent;
@@ -76,7 +75,7 @@ public class EventAlarmHandler {
     }
 
     public Mono<Void> handleCreate(CalendarAlarmMessageDTO alarmMessageDTO) {
-        if (!hasVALARMComponent(alarmMessageDTO)) {
+        if (!alarmMessageDTO.hasVALARMComponent()) {
             return Mono.empty();
         }
         return handleCreateOrUpdate(alarmMessageDTO);
@@ -86,14 +85,6 @@ public class EventAlarmHandler {
         return openPaaSUserDAO.retrieve(alarmMessageDTO.extractCalendarURL().base())
             .filterWhen(openPaaSUser -> isUserAlarmEnabled(openPaaSUser.username()))
             .flatMap(openPaaSUser -> processCreateOrUpdate(openPaaSUser.username(), alarmMessageDTO));
-    }
-
-    private boolean hasVALARMComponent(CalendarAlarmMessageDTO alarmMessageDTO) {
-        JsonNode event = alarmMessageDTO.calendarEvent();
-        return event != null
-            && event.isArray()
-            && event.size() > 2
-            && event.get(2).toString().contains("\"valarm\"");
     }
 
     private Mono<Void> processCreateOrUpdate(Username username, CalendarAlarmMessageDTO alarmMessageDTO) {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarAlarmMessageDTOTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarAlarmMessageDTOTest.java
@@ -1,0 +1,71 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class CalendarAlarmMessageDTOTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void shouldReturnTrueWhenValarmExists() throws Exception {
+        String json = """
+            ["vcalendar", [],
+              [["vevent", [],
+                [["valarm", [], []]]
+              ]]
+            ]
+            """;
+        JsonNode node = mapper.readTree(json);
+        assertThat(CalendarAlarmMessageDTO.hasVALARMComponent(node)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenNoValarm() throws Exception {
+        String json = """
+            ["vcalendar", [],
+              [["vevent", [],
+                [["summary", {}, "text", "Meeting"]]
+              ]]
+            ]
+            """;
+        JsonNode node = mapper.readTree(json);
+        assertThat(CalendarAlarmMessageDTO.hasVALARMComponent(node)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseForNullNode() {
+        assertThat(CalendarAlarmMessageDTO.hasVALARMComponent(null)).isFalse();
+    }
+
+    @Test
+    void shouldWorkWithObjectMixedStructure() throws Exception {
+        String json = """
+            {"vcalendar": ["vevent", [], [["valarm", [], []]]]}
+            """;
+        JsonNode node = mapper.readTree(json);
+        assertThat(CalendarAlarmMessageDTO.hasVALARMComponent(node)).isTrue();
+    }
+}


### PR DESCRIPTION
When a new event without a `VALARM` component is PUT to SabreDAV,
it still publishes a message to `calendar:event:alarm:created`.
By **skipping early** from the AMQP JSON message,
we avoid unnecessary processing for events without alarms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - CREATE events without an alarm component are no longer processed, reducing false or redundant alarm handling.

- **Performance**
  - Non-alarm events are short-circuited earlier in the create flow, lowering wasted work and improving efficiency.

- **Tests**
  - Added tests to verify detection of alarm components across varied event JSON structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->