### PR TITLE
ISSUE-423 Fix download ICS via secret link for subscribed calendars

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/DownloadCalendarRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/DownloadCalendarRouteTest.java
@@ -18,6 +18,7 @@
 
 package com.linagora.calendar.app.restapi.routes;
 
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
@@ -31,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -49,11 +51,15 @@ import com.linagora.calendar.app.TwakeCalendarConfiguration;
 import com.linagora.calendar.app.TwakeCalendarExtension;
 import com.linagora.calendar.app.TwakeCalendarGuiceServer;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
+import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.dav.dto.SubscribedCalendarRequest;
 import com.linagora.calendar.restapi.RestApiConfiguration;
 import com.linagora.calendar.restapi.RestApiServerProbe;
+import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 
@@ -63,6 +69,7 @@ import io.restassured.authentication.PreemptiveBasicAuthScheme;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
 
 class DownloadCalendarRouteTest {
 
@@ -100,15 +107,21 @@ class DownloadCalendarRouteTest {
     }
 
     private OpenPaaSUser openPaaSUser;
+    private OpenPaaSUser openPaaSUser2;
 
     private int restApiPort;
+    private DavTestHelper davTestHelper;
+    private CalDavClient calDavClient;
 
     @BeforeEach
-    void setUp(TwakeCalendarGuiceServer server) {
-        this.openPaaSUser = sabreDavExtension.newTestUser();
+    void setUp(TwakeCalendarGuiceServer server) throws Exception {
+        this.openPaaSUser = sabreDavExtension.newTestUser(Optional.of("bob"));
+        this.openPaaSUser2 = sabreDavExtension.newTestUser(Optional.of("alice"));
 
-        server.getProbe(CalendarDataProbe.class).addDomain(openPaaSUser.username().getDomainPart().get());
-        server.getProbe(CalendarDataProbe.class).addUserToRepository(openPaaSUser.username(), PASSWORD);
+        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
+        calendarDataProbe.addDomain(openPaaSUser.username().getDomainPart().get());
+        calendarDataProbe.addUserToRepository(openPaaSUser.username(), PASSWORD);
+        calendarDataProbe.addUserToRepository(openPaaSUser2.username(), PASSWORD);
 
         PreemptiveBasicAuthScheme basicAuthScheme = new PreemptiveBasicAuthScheme();
         basicAuthScheme.setUserName(openPaaSUser.username().asString());
@@ -124,6 +137,8 @@ class DownloadCalendarRouteTest {
             .setBasePath("")
             .setAuth(basicAuthScheme)
             .build();
+        davTestHelper = new DavTestHelper(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
     }
 
     @Test
@@ -173,7 +188,7 @@ class DownloadCalendarRouteTest {
                 "error": {
                     "code": 403,
                     "message": "Forbidden",
-                    "details": "Forbidden"
+                    "details": "Token validation failed"
                 }
             }
             """);
@@ -203,7 +218,7 @@ class DownloadCalendarRouteTest {
             "error": {
                 "code": 403,
                 "message": "Forbidden",
-                "details": "Forbidden"
+                "details": "Token validation failed"
             }
         }
         """);
@@ -236,7 +251,7 @@ class DownloadCalendarRouteTest {
         {
             "error": {
                 "code": 400,
-                "message": "Bad request",
+                "message": "Bad Request",
                 "details": "Invalid token: only letters, digits, hyphen, and underscore are allowed."
             }
         }
@@ -280,7 +295,7 @@ class DownloadCalendarRouteTest {
             "error": {
                 "code": 403,
                 "message": "Forbidden",
-                "details": "Forbidden"
+                "details": "Token validation failed"
             }
         }
         """);
@@ -293,7 +308,7 @@ class DownloadCalendarRouteTest {
 
         OpenPaaSId openPaaSId = server.getProbe(CalendarDataProbe.class).addUser(newUser, PASSWORD);
 
-        String secretLink = getSecretLink(newUser.asString(), PASSWORD, openPaaSId.value());
+        String secretLink = getSecretLink(newUser, CalendarURL.from(openPaaSId));
 
         String response = RestAssured
             .given()
@@ -317,14 +332,416 @@ class DownloadCalendarRouteTest {
                 }""");
     }
 
-    private String getSecretLink() {
-        return getSecretLink(openPaaSUser.username().asString(), PASSWORD, openPaaSUser.id().value());
+    @Test
+    void downloadDefaultCalendarShouldReturnStoredEvent() {
+        // GIVEN
+        String eventUid = "event-" + UUID.randomUUID();
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20251008T090000Z
+            DTSTART:20251008T100000Z
+            DTEND:20251008T110000Z
+            SUMMARY:Integration test event
+            DESCRIPTION:This event should appear in downloaded ICS
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid);
+
+        URI eventURI = URI.create("/calendars/" + openPaaSUser.id().value() + "/" + openPaaSUser.id().value() + "/" + eventUid + ".ics");
+        davTestHelper.upsertCalendar(openPaaSUser.username(), eventURI, ics).block();
+
+        String secretLinkUrl = getSecretLink();
+
+        // WHEN
+        Response response = RestAssured
+            .given()
+        .when()
+            .get(secretLinkUrl)
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .response();
+
+        String body = StringUtils.trim(response.getBody().asString());
+
+        // THEN
+        assertSoftly(softly -> {
+            softly.assertThat(response.getHeader("Content-Type")).isEqualTo("text/calendar; charset=utf-8");
+            softly.assertThat(body).contains("BEGIN:VCALENDAR");
+            softly.assertThat(body).contains("UID:" + eventUid);
+            softly.assertThat(body).contains("SUMMARY:Integration test event");
+        });
     }
 
-    private String getSecretLink(String username, String password, String calendarId) {
+    @Test
+    void downloadCustomCalendarShouldReturnStoredEvent() {
+        // GIVEN
+        String customCalendarId = "custom-" + UUID.randomUUID();
+        CalDavClient.NewCalendar newCalendar = new CalDavClient.NewCalendar(
+            customCalendarId,
+            "Custom Calendar",
+            "#00AACC",
+            "Calendar created for integration test");
+
+        // Create a custom calendar
+        calDavClient.createNewCalendar(openPaaSUser.username(), openPaaSUser.id(), newCalendar).block();
+
+        // Insert an event into that custom calendar
+        String eventUid = "event-" + UUID.randomUUID();
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20251008T090000Z
+            DTSTART:20251008T100000Z
+            DTEND:20251008T110000Z
+            SUMMARY:Custom calendar event
+            DESCRIPTION:This event should appear in downloaded ICS from custom calendar
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid);
+
+        URI eventURI = URI.create("/calendars/" + openPaaSUser.id().value() + "/" + customCalendarId + "/" + eventUid + ".ics");
+        davTestHelper.upsertCalendar(openPaaSUser.username(), eventURI, ics).block();
+
+        // Generate the secret link for the custom calendar
+        String secretLinkUrl = getSecretLink(openPaaSUser.username(),
+            new CalendarURL(openPaaSUser.id(), new OpenPaaSId(customCalendarId)));
+
+        // WHEN
+        Response response = RestAssured
+            .given()
+        .when()
+            .get(secretLinkUrl)
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .response();
+
+        String body = StringUtils.trim(response.getBody().asString());
+
+        // THEN
+        assertSoftly(softly -> {
+            softly.assertThat(response.getHeader("Content-Type")).isEqualTo("text/calendar; charset=utf-8");
+            softly.assertThat(body).contains("BEGIN:VCALENDAR");
+            softly.assertThat(body).contains("UID:" + eventUid);
+            softly.assertThat(body).contains("SUMMARY:Custom calendar event");
+            softly.assertThat(body).contains("END:VCALENDAR");
+        });
+    }
+
+    @Test
+    void downloadDelegatedCalendarShouldReturnStoredEvent() {
+        // GIVEN
+        OpenPaaSUser bob = openPaaSUser;     // Bob
+        OpenPaaSUser alice = openPaaSUser2; // Alice
+
+        // Create an event in Bob's default calendar
+        String eventUid = "event-" + UUID.randomUUID();
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20251008T090000Z
+            DTSTART:20251008T100000Z
+            DTEND:20251008T110000Z
+            SUMMARY:Delegated calendar event
+            DESCRIPTION:This event should appear when alice downloads shared calendar
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid);
+
+        URI eventURI = URI.create("/calendars/" + bob.id().value() + "/" + bob.id().value() + "/" + eventUid + ".ics");
+        davTestHelper.upsertCalendar(bob.username(), eventURI, ics).block();
+
+        // Delegate Bob's calendar to Alice with read right
+        davTestHelper.grantDelegation(bob, CalendarURL.from(bob.id()), alice, "dav:read");
+
+        // Find delegated calendar (where baseId != calendarId)
+        CalendarURL aliceDelegatedCalendar = findFirstDelegatedCalendarURL(alice);
+
+        // Generate a secret link for Alice’s delegated calendar
+        String secretLinkUrl = getSecretLink(alice.username(), aliceDelegatedCalendar);
+
+        // WHEN
+        Response response = RestAssured
+            .given()
+        .when()
+            .get(secretLinkUrl)
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .response();
+
+        String body = StringUtils.trim(response.getBody().asString());
+
+        // THEN
+        assertSoftly(softly -> {
+            softly.assertThat(body).contains("BEGIN:VCALENDAR");
+            softly.assertThat(body).contains("UID:" + eventUid);
+            softly.assertThat(body).contains("SUMMARY:Delegated calendar event");
+            softly.assertThat(body).contains("END:VCALENDAR");
+        });
+    }
+
+    @Test
+    void downloadDelegatedCalendarShouldFailAfterRevoked() {
+        // GIVEN
+        OpenPaaSUser bob = openPaaSUser;     // Owner
+        OpenPaaSUser alice = openPaaSUser2; // Delegate
+
+        CalendarURL bobDefaultCalendar = new CalendarURL(bob.id(), bob.id());
+
+        // Bob grants delegation to Alice (read-only)
+        davTestHelper.grantDelegation(bob, bobDefaultCalendar, alice, "dav:read");
+
+        // Alice lists her calendars and identifies the delegated one
+        CalendarURL aliceDelegatedCalendar = findFirstDelegatedCalendarURL(alice);
+
+        // Step 4: Generate a secret link for Alice’s delegated calendar
+        String secretLinkUrl = getSecretLink(alice.username(), aliceDelegatedCalendar);
+
+        // Step 5: Verify Alice can initially download the delegated calendar successfully
+        Supplier<ValidatableResponse> downloadBySecretLinkSupplier = () -> RestAssured
+            .given()
+        .when()
+            .get(secretLinkUrl)
+        .then();
+
+        downloadBySecretLinkSupplier.get()
+            .statusCode(HttpStatus.SC_OK);
+
+        // Step 6: Bob revokes delegation from Alice
+        davTestHelper.revokeDelegation(bob, bobDefaultCalendar, alice);
+
+        // Step 7: Alice attempts to download again after revocation
+        String response = downloadBySecretLinkSupplier.get()
+            .statusCode(HttpStatus.SC_NOT_FOUND)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 404,
+                        "message": "Not Found",
+                        "details": "${json-unit.ignore}"
+                    }
+                }""");
+    }
+
+    @Test
+    void downloadDelegatedCustomCalendarShouldReturnStoredEvent() {
+        // GIVEN
+        OpenPaaSUser bob = openPaaSUser;     // Owner
+        OpenPaaSUser alice = openPaaSUser2; // Delegate
+
+        // Bob creates a custom calendar
+        String customCalendarId = "custom-" + UUID.randomUUID();
+        CalDavClient.NewCalendar newCalendar = new CalDavClient.NewCalendar(
+            customCalendarId,
+            "Custom Delegated Calendar",
+            "#3366FF",
+            "Custom calendar for delegation test");
+
+        calDavClient.createNewCalendar(bob.username(), bob.id(), newCalendar).block();
+
+        // Bob creates an event in that custom calendar
+        String eventUid = "event-" + UUID.randomUUID();
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20251008T090000Z
+            DTSTART:20251008T100000Z
+            DTEND:20251008T110000Z
+            SUMMARY:Delegated custom calendar event
+            DESCRIPTION:This event should appear when Alice downloads the delegated custom calendar
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid);
+
+        URI eventURI = URI.create("/calendars/" + bob.id().value() + "/" + customCalendarId + "/" + eventUid + ".ics");
+        davTestHelper.upsertCalendar(bob.username(), eventURI, ics).block();
+
+        // Bob grants delegation to Alice (read-only)
+        CalendarURL bobCustomCalendar = new CalendarURL(bob.id(), new OpenPaaSId(customCalendarId));
+        davTestHelper.grantDelegation(bob, bobCustomCalendar, alice, "dav:read");
+
+        // Alice lists her calendars and identifies the delegated one (baseId != calendarId)
+        CalendarURL aliceDelegatedCalendar = findFirstDelegatedCalendarURL(alice);
+
+        // Generate a secret link for Alice’s delegated custom calendar
+        String secretLinkUrl = getSecretLink(alice.username(), aliceDelegatedCalendar);
+
+        // WHEN
+        Response response = RestAssured
+            .given()
+        .when()
+            .get(secretLinkUrl)
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .response();
+
+        String body = StringUtils.trim(response.getBody().asString());
+
+        // THEN
+        assertSoftly(softly -> {
+            softly.assertThat(body).contains("BEGIN:VCALENDAR");
+            softly.assertThat(body).contains("UID:" + eventUid);
+            softly.assertThat(body).contains("SUMMARY:Delegated custom calendar event");
+        });
+    }
+
+    @Test
+    void downloadSubscribedCalendarShouldReturnStoredEvent() {
+        // GIVEN
+        OpenPaaSUser bob = openPaaSUser;     // Owner
+        OpenPaaSUser alice = openPaaSUser2; // Subscriber
+
+        // Create an event in Bob's default calendar
+        String eventUid = "event-" + UUID.randomUUID();
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20251008T090000Z
+            DTSTART:20251008T100000Z
+            DTEND:20251008T110000Z
+            SUMMARY:Subscribed calendar event
+            DESCRIPTION:This event should appear when Alice downloads the subscribed calendar
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid);
+
+        URI eventURI = URI.create("/calendars/" + bob.id().value() + "/" + bob.id().value() + "/" + eventUid + ".ics");
+        davTestHelper.upsertCalendar(bob.username(), eventURI, ics).block();
+
+        // Bob updates ACL: make calendar publicly readable
+        URI bobCalendarUri = URI.create("/calendars/" + bob.id().value() + "/" + bob.id().value() + ".json");
+        davTestHelper.updateCalendarAcl(bob, bobCalendarUri, "{DAV:}read");
+
+        // Alice subscribes to Bob's shared calendar
+        SubscribedCalendarRequest subscribedCalendarRequest = SubscribedCalendarRequest.builder()
+            .id(UUID.randomUUID().toString())
+            .sourceUserId(bob.id().value())
+            .name("Bob readonly shared")
+            .color("#00FF00")
+            .readOnly(true)
+            .build();
+
+        davTestHelper.subscribeToSharedCalendar(alice, subscribedCalendarRequest);
+
+        // Generate a secret link for the subscribed calendar
+        CalendarURL subscribedCalendar = new CalendarURL(alice.id(), new OpenPaaSId(subscribedCalendarRequest.id()));
+        String secretLinkUrl = getSecretLink(alice.username(), subscribedCalendar);
+
+        // WHEN
+        Response response = RestAssured
+            .given()
+        .when()
+            .get(secretLinkUrl)
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .response();
+
+        String body = StringUtils.trim(response.getBody().asString());
+
+        // THEN
+        assertSoftly(softly -> {
+            softly.assertThat(body).contains("BEGIN:VCALENDAR");
+            softly.assertThat(body).contains("UID:" + eventUid);
+            softly.assertThat(body).contains("SUMMARY:Subscribed calendar event");
+            softly.assertThat(body).contains("END:VCALENDAR");
+        });
+    }
+
+    @Test
+    void downloadSubscribedCalendarShouldFailAfterOwnerHidesCalendar() {
+        // GIVEN
+        OpenPaaSUser bob = openPaaSUser;     // Owner
+        OpenPaaSUser alice = openPaaSUser2; // Subscriber
+
+        // Bob sets calendar ACL to readable so Alice can subscribe
+        URI bobCalendarUri = URI.create("/calendars/" + bob.id().value() + "/" + bob.id().value() + ".json");
+        davTestHelper.updateCalendarAcl(bob, bobCalendarUri, "{DAV:}read");
+
+        // Alice subscribes to Bob's calendar successfully
+        SubscribedCalendarRequest subscribedCalendarRequest = SubscribedCalendarRequest.builder()
+            .id(UUID.randomUUID().toString())
+            .sourceUserId(bob.id().value())
+            .name("Bob readonly shared")
+            .color("#FF8800")
+            .readOnly(true)
+            .build();
+
+        davTestHelper.subscribeToSharedCalendar(alice, subscribedCalendarRequest);
+
+        // Step 4: Generate secret link for Alice’s subscribed calendar
+        CalendarURL subscribedCalendar = new CalendarURL(alice.id(), new OpenPaaSId(subscribedCalendarRequest.id()));
+        String secretLinkUrl = getSecretLink(alice.username(), subscribedCalendar);
+
+        // Sanity check: download initially succeeds (before ACL change)
+        Supplier<ValidatableResponse> downloadBySecretLinkSupplier = () -> RestAssured
+            .given()
+        .when()
+            .get(secretLinkUrl)
+        .then();
+
+        downloadBySecretLinkSupplier.get().statusCode(HttpStatus.SC_OK);
+
+        // Step 5: Bob hides his calendar (no longer public)
+        davTestHelper.updateCalendarAcl(bob, bobCalendarUri, "");
+
+        // WHEN – Alice tries to download again after ACL revoked
+        String response = downloadBySecretLinkSupplier.get()
+            .statusCode(HttpStatus.SC_NOT_FOUND)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 404,
+                        "message": "Not Found",
+                        "details": "${json-unit.ignore}"
+                    }
+                }""");
+    }
+
+    private String getSecretLink() {
+        return getSecretLink(openPaaSUser.username(), CalendarURL.from(openPaaSUser.id()));
+    }
+
+    private String getSecretLink(Username username, CalendarURL calendarURL) {
         PreemptiveBasicAuthScheme basicAuthScheme = new PreemptiveBasicAuthScheme();
-        basicAuthScheme.setUserName(username);
-        basicAuthScheme.setPassword(password);
+        basicAuthScheme.setUserName(username.asString());
+        basicAuthScheme.setPassword(DownloadCalendarRouteTest.PASSWORD);
 
         String secretLink = given(new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
@@ -334,7 +751,7 @@ class DownloadCalendarRouteTest {
             .setBasePath("")
             .setAuth(basicAuthScheme)
             .build())
-            .get(String.format("/calendar/api/calendars/%s/%s/secret-link", calendarId, calendarId))
+            .get(String.format("/calendar/api/calendars/%s/secret-link", calendarURL.serialize()))
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(JSON)
@@ -344,6 +761,14 @@ class DownloadCalendarRouteTest {
             .getString("secretLink");
 
         return Strings.CS.replace(secretLink, SECRET_LINK_BASE_URL, "http://localhost:" + restApiPort);
+    }
+
+    private CalendarURL findFirstDelegatedCalendarURL(OpenPaaSUser openPaaSUser) {
+        return calDavClient.findUserCalendars(openPaaSUser.username(), openPaaSUser.id())
+            .filter(url -> !url.base().equals(url.calendarId()))
+            .next()
+            .blockOptional()
+            .orElseThrow(() -> new AssertionError("No delegated custom calendar found"));
     }
 
 }

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalendarNotFoundException.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalendarNotFoundException.java
@@ -16,20 +16,19 @@
  *  more details.                                                   *
  ********************************************************************/
 
-package com.linagora.calendar.storage;
+package com.linagora.calendar.dav;
 
-import org.apache.commons.lang3.StringUtils;
+import com.linagora.calendar.storage.CalendarURL;
 
-import com.google.common.base.Preconditions;
+public class CalendarNotFoundException extends RuntimeException {
+    private final CalendarURL calendarURL;
 
-public record OpenPaaSId(String value) {
-
-    public OpenPaaSId {
-        Preconditions.checkArgument(StringUtils.isNotEmpty(value), "OpenPaaSId must not be empty");
+    public CalendarNotFoundException(CalendarURL calendarURL) {
+        super("Calendar not found: " + calendarURL.serialize());
+        this.calendarURL = calendarURL;
     }
 
-    @Override
-    public String toString() {
-        return value;
+    public CalendarURL calendarURL() {
+        return calendarURL;
     }
 }

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/dto/SubscribedCalendarRequest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/dto/SubscribedCalendarRequest.java
@@ -1,0 +1,212 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav.dto;
+
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public record SubscribedCalendarRequest(String id,
+                                        @JsonProperty("calendarserver:source") Source source) {
+
+    public static final ObjectMapper MAPPER = new ObjectMapper()
+        .setSerializationInclusion(JsonInclude.Include.ALWAYS);
+
+    @JsonProperty("acl")
+    public List<Map<String, Object>> acl() {
+        return source.acl();
+    }
+
+    @JsonProperty("invite")
+    public List<Map<String, Object>> invite() {
+        return source.invite();
+    }
+
+    @JsonProperty("apple:color")
+    public String appleColor() {
+        return source.color();
+    }
+
+    @JsonProperty("caldav:description")
+    public String calDavDescription() {
+        return "";
+    }
+
+    @JsonProperty("dav:name")
+    public String davName() {
+        return source.name();
+    }
+
+    public String serialize() {
+        try {
+            return MAPPER.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public record Source(String name,
+                         String color,
+                         @JsonIgnore String userId,
+                         @JsonProperty("id") String calendarId,
+                         List<Map<String, Object>> invite,
+                         List<Map<String, Object>> acl,
+                         Map<String, Object> rights,
+                         boolean readOnly) {
+
+        @JsonProperty("description")
+        public String description() {
+            return "";
+        }
+
+        @JsonProperty("calendarHomeId")
+        public String calendarHomeId() {
+            return userId;
+        }
+
+        @JsonProperty("href")
+        public String href() {
+            return "/calendars/%s/%s.json".formatted(userId, calendarId());
+        }
+
+        @JsonProperty("selected")
+        public boolean selected() {
+            return false;
+        }
+
+        @JsonProperty("type")
+        public String type() {
+            return "user";
+        }
+    }
+
+    public static class Builder {
+        private String id;
+        private String name;
+        private String color;
+        private List<Map<String, Object>> invite;
+        private List<Map<String, Object>> acl;
+        private Map<String, Object> rights;
+        private boolean readOnly;
+        private String sourceUserId;
+        private String sourceCalendarId;
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder sourceUserId(String sourceId) {
+            this.sourceUserId = sourceId;
+            this.invite = buildInvite(sourceId);
+            return this;
+        }
+
+        public Builder sourceCalendarId(String sourceCalendarId) {
+            this.sourceCalendarId = sourceCalendarId;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder color(String color) {
+            this.color = color;
+            return this;
+        }
+
+        public Builder readOnly(boolean readOnly) {
+            this.readOnly = readOnly;
+            this.acl = buildAcl(sourceUserId, readOnly);
+            this.rights = buildRights(sourceUserId, readOnly);
+            return this;
+        }
+
+        public static List<Map<String, Object>> buildAcl(String sourceId, boolean readOnly) {
+            List<Map<String, Object>> acl = new ArrayList<>();
+
+            acl.add(aclEntry("{DAV:}share", "principals/users/" + sourceId));
+            acl.add(aclEntry("{DAV:}share", "principals/users/" + sourceId + "/calendar-proxy-write"));
+            acl.add(aclEntry("{DAV:}write", "principals/users/" + sourceId));
+            acl.add(aclEntry("{DAV:}write", "principals/users/" + sourceId + "/calendar-proxy-write"));
+            acl.add(aclEntry("{DAV:}write-properties", "principals/users/" + sourceId));
+            acl.add(aclEntry("{DAV:}write-properties", "principals/users/" + sourceId + "/calendar-proxy-write"));
+            acl.add(aclEntry("{DAV:}read", "principals/users/" + sourceId));
+            acl.add(aclEntry("{DAV:}read", "principals/users/" + sourceId + "/calendar-proxy-read"));
+            acl.add(aclEntry("{DAV:}read", "principals/users/" + sourceId + "/calendar-proxy-write"));
+            acl.add(aclEntry("{DAV:}read", "{DAV:}authenticated"));
+
+            if (!readOnly) {
+                acl.add(aclEntry("{DAV:}write", "{DAV:}authenticated"));
+            }
+
+            return acl;
+        }
+
+        private static Map<String, Object> aclEntry(String privilege, String principal) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("privilege", privilege);
+            entry.put("principal", principal);
+            entry.put("protected", true);
+            return entry;
+        }
+
+        public static Map<String, Object> buildRights(String sourceId, boolean readOnly) {
+            return Map.of(
+                "_userEmails", Map.of(sourceId, "principals/users/" + sourceId),
+                "_ownerId", sourceId,
+                "_public", readOnly ? "{DAV:}read" : "{DAV:}write",
+                "_sharee", Map.of(),
+                "_type", "user"
+            );
+        }
+
+        public static List<Map<String, Object>> buildInvite(String sourceId) {
+            Map<String, Object> invite = new LinkedHashMap<>();
+            invite.put("href", "principals/users/" + sourceId);
+            invite.put("principal", "principals/users/" + sourceId);
+            invite.put("properties", List.of());
+            invite.put("access", 1);
+            invite.put("comment", null);
+            invite.put("inviteStatus", 2);
+
+            return List.of(invite);
+        }
+
+        public SubscribedCalendarRequest build() {
+            sourceCalendarId = sourceCalendarId == null ? sourceUserId : sourceCalendarId;
+            Source source = new Source(name, color, sourceUserId, sourceCalendarId, invite, acl, rights, readOnly);
+            return new SubscribedCalendarRequest(id, source);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+}


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Secret-link downloads now support delegated and subscribed calendars, with automatic resolution of the correct source when needed.

* Bug Fixes
  * Clearer, more precise errors: Bad Request, Forbidden (“Token validation failed”), Not Found for missing calendars, and 503 propagated from the calendar service.
  * Access correctly blocked after delegation revocation or when an owner hides a shared calendar.
  * Improved handling across default and custom calendars.

* Tests
  * Extensive integration tests covering default, custom, delegated, and subscribed calendar download scenarios and failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->