### PR TITLE
[ENHANCEMENT] Back-channel logout: 400 if invalid token

### DIFF
--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarChannelLogoutRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarChannelLogoutRoutesTest.java
@@ -122,10 +122,9 @@ class CalendarChannelLogoutRoutesTest {
     @ParameterizedTest
     @ValueSource(strings = {
         "invalidtoken123456",
-        "eyJblablabla",
-        "eyJ12345.eyJzaWQiOiJzaWQxIn0."
+        "eyJblablabla"
     })
-    void postShouldReturn200WhenCanNotExtractSidFromToken(String invalidToken) {
+    void postShouldReturn400WhenCanNotExtractSidFromToken(String invalidToken) {
         given().log().ifValidationFails()
             .contentType(ContentType.URLENC)
             .formParam("logout_token", invalidToken)
@@ -133,11 +132,11 @@ class CalendarChannelLogoutRoutesTest {
             .post()
         .then()
             .log().ifValidationFails()
-            .statusCode(200);
+            .statusCode(400);
     }
 
     @Test
-    void postShouldReturn200WhenJwtHasNoSidClaim() {
+    void postShouldReturn400WhenJwtHasNoSidClaim() {
         String payload = Base64.getUrlEncoder().withoutPadding()
             .encodeToString(("{\"notSid\":\"abc\"}").getBytes(StandardCharsets.UTF_8));
         String tokenWithoutSid = "eyJblablabla." + payload + ".signature";
@@ -149,11 +148,11 @@ class CalendarChannelLogoutRoutesTest {
         .when()
             .post()
         .then()
-            .statusCode(200);
+            .statusCode(400);
     }
 
     @Test
-    void postShouldReturn200WhenSidIsEmpty() {
+    void postShouldReturn400WhenSidIsEmpty() {
         String payload = Base64.getUrlEncoder().withoutPadding()
             .encodeToString("{\"sid\":\"\"}".getBytes(StandardCharsets.UTF_8));
         String tokenWithEmptySid = "header." + payload + ".signature";
@@ -164,7 +163,7 @@ class CalendarChannelLogoutRoutesTest {
         .when()
             .post()
         .then()
-            .statusCode(200);
+            .statusCode(400);
     }
 
     @Test

--- a/storage-api/src/main/java/com/linagora/calendar/storage/model/Sid.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/model/Sid.java
@@ -18,5 +18,10 @@
 
 package com.linagora.calendar.storage.model;
 
+import com.google.common.base.Preconditions;
+
 public record Sid(String value) {
+    public Sid {
+        Preconditions.checkArgument(!value.isEmpty(), "sid cannot be empty");
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Invalid logout token scenarios now properly return HTTP 400 (Bad Request) instead of incorrectly returning HTTP 200 (Success)
* Added validation to ensure required data fields are not empty
* Enhanced error handling with specific error messages for various invalid token conditions, including malformed tokens and missing required claims

<!-- end of auto-generated comment: release notes by coderabbit.ai -->