### PR TITLE
Provisioning for domains: Fix domain configuration parsing when multiple domains are specified

### DIFF
--- a/storage-api/src/main/java/com/linagora/calendar/storage/DomainConfiguration.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/DomainConfiguration.java
@@ -23,12 +23,12 @@ import java.util.List;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.james.core.Domain;
 
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
 public class DomainConfiguration {
     public static DomainConfiguration parseConfiguration(Configuration configuration) {
-        return new DomainConfiguration(Splitter.on(',').splitToStream(configuration.getString("domains", "linagora.com"))
+        List<String> domains = configuration.getList(String.class, "domains", List.of("linagora.com"));
+        return new DomainConfiguration(domains.stream()
             .map(Domain::of)
             .collect(ImmutableList.toImmutableList()));
     }


### PR DESCRIPTION
Previously, DomainConfiguration.parseConfiguration() used configuration.getString("domains"),
which only returned the first value when multiple domains were defined in the config file
(e.g., "domains=openpaas.org,domain.tld" → only "openpaas.org" was read).

This happened because Apache Commons Configuration automatically treats comma-separated
values as a list, and getString() only retrieves the first element.

This commit fixes the issue by reading the property as a list using getList(String.class, "domains"),
ensuring all configured domains are correctly parsed into Domain objects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized domain configuration parsing to use improved data handling methods, replacing the previous string splitting approach with direct list retrieval and mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->