### PR TITLE
[FIX] exhange contacts:addressbook:* => sabre:addressbook:*

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/SabreResourceProvisioner.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/SabreResourceProvisioner.java
@@ -52,12 +52,12 @@ public class SabreResourceProvisioner implements Startable {
             "calendar:calendar:deleted",
             "calendar:calendar:updated",
             "calendar:event:reply",
-            "contacts:addressbook:created",
-            "contacts:addressbook:deleted",
-            "contacts:addressbook:subscription:created",
-            "contacts:addressbook:subscription:deleted",
-            "contacts:addressbook:subscription:updated",
-            "contacts:addressbook:updated")
+            "sabre:addressbook:created",
+            "sabre:addressbook:deleted",
+            "sabre:addressbook:subscription:created",
+            "sabre:addressbook:subscription:deleted",
+            "sabre:addressbook:subscription:updated",
+            "sabre:addressbook:updated")
             .block();
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for AMQP exchange naming to follow the Sabre addressbook family convention. Exchange names standardized to use the `sabre:addressbook:` prefix for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->