### PR TITLE
ISSUE-413 Implement webadmin task to reposition write rights for resources

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
@@ -307,6 +307,30 @@ class TwakeCalendarGuiceServerTest  {
     }
 
     @Test
+    void shouldExposeWebAdminRepositionResourceRightsTask() {
+        String taskId = given()
+            .when()
+            .post("/resources?task=repositionWriteRights")
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .body("status", is(notNullValue()))
+            .body("taskId", is(taskId))
+            .body("type", is("reposition-resource-rights"))
+            .body("additionalInformation.processedResourceCount", is(notNullValue()))
+            .body("additionalInformation.failedResourceCount", is(notNullValue()))
+            .body("additionalInformation.timestamp", is(notNullValue()))
+            .body("additionalInformation.type", is("reposition-resource-rights"))
+            .body("startedDate", is(notNullValue()))
+            .body("submitDate", is(notNullValue()));
+    }
+
+    @Test
     void shouldExposeMetrics() {
         String body = given()
         .when()

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/SabreDavExtension.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/SabreDavExtension.java
@@ -63,6 +63,7 @@ import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.TechnicalTokenService;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBResourceDAO;
 import com.linagora.calendar.storage.mongodb.MongoDBSecretLinkStore;
 import com.linagora.calendar.storage.mongodb.MongoDBUploadedFileDAO;
 import com.mongodb.reactivestreams.client.MongoDatabase;
@@ -78,7 +79,8 @@ public record SabreDavExtension(DockerSabreDavSetup dockerSabreDavSetup) impleme
         MongoDBOpenPaaSDomainDAO.COLLECTION,
         MongoDBOpenPaaSUserDAO.COLLECTION,
         MongoDBUploadedFileDAO.COLLECTION,
-        MongoDBSecretLinkStore.COLLECTION);
+        MongoDBSecretLinkStore.COLLECTION,
+        MongoDBResourceDAO.COLLECTION);
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static MockServerClient mockServerClient;
 

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/CalendarRoutesModule.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/CalendarRoutesModule.java
@@ -37,6 +37,7 @@ import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.linagora.calendar.webadmin.task.AlarmScheduleTaskAdditionalInformationDTO;
 import com.linagora.calendar.webadmin.task.CalendarEventsReindexTaskAdditionalInformationDTO;
+import com.linagora.calendar.webadmin.task.RepositionResourceRightsTaskAdditionalInformationDTO;
 
 public class CalendarRoutesModule extends AbstractModule {
     @Override
@@ -69,5 +70,11 @@ public class CalendarRoutesModule extends AbstractModule {
     @ProvidesIntoSet
     public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> alarmScheduleTaskAdditionalInformation() {
         return AlarmScheduleTaskAdditionalInformationDTO.module();
+    }
+
+    @Named(DTOModuleInjections.WEBADMIN_DTO)
+    @ProvidesIntoSet
+    public AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO> repositionResourceRightsTaskAdditionalInformation() {
+        return RepositionResourceRightsTaskAdditionalInformationDTO.module();
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceRoutes.java
@@ -57,7 +57,6 @@ import com.linagora.calendar.storage.model.Resource;
 import com.linagora.calendar.storage.model.ResourceAdministrator;
 import com.linagora.calendar.storage.model.ResourceId;
 import com.linagora.calendar.webadmin.task.RepositionResourceRightsTask;
-import com.linagora.calendar.webadmin.task.RepositionResourceRightsTask.RunningOptions;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -322,6 +321,6 @@ public class ResourceRoutes implements Routes {
     }
 
     private RepositionResourceRightsTask getRepositionResourceRightsTask(Request request) {
-        return new RepositionResourceRightsTask(resourceDAO, userDAO, calDavClient, RunningOptions.parse(request));
+        return new RepositionResourceRightsTask(resourceDAO, userDAO, calDavClient);
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceRoutes.java
@@ -25,10 +25,13 @@ import java.util.Optional;
 import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
+import org.apache.james.task.TaskManager;
 import org.apache.james.util.ReactorUtils;
 import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.tasks.TaskFromRequest;
 import org.apache.james.webadmin.utils.ErrorResponder;
 import org.apache.james.webadmin.utils.JsonExtractException;
 import org.apache.james.webadmin.utils.JsonExtractor;
@@ -40,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -52,6 +56,8 @@ import com.linagora.calendar.storage.ResourceUpdateRequest;
 import com.linagora.calendar.storage.model.Resource;
 import com.linagora.calendar.storage.model.ResourceAdministrator;
 import com.linagora.calendar.storage.model.ResourceId;
+import com.linagora.calendar.webadmin.task.RepositionResourceRightsTask;
+import com.linagora.calendar.webadmin.task.RepositionResourceRightsTask.RunningOptions;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -62,6 +68,8 @@ import spark.Service;
 
 public class ResourceRoutes implements Routes {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceRoutes.class);
+
+    private static final String TASK_REPOSITION_WRITE_RIGHTS = "repositionWriteRights";
 
     public static final String BASE_PATH = "resources";
 
@@ -133,18 +141,24 @@ public class ResourceRoutes implements Routes {
     private final ResourceAdministratorService  resourceAdministratorService;
     private final JsonExtractor<ResourceCreationDTO> creationDTOJsonExtractor;
     private final JsonExtractor<ResourceUpdateDTO> updateDTOJsonExtractor;
+    private final TaskManager taskManager;
+    private final CalDavClient calDavClient;
 
     @Inject
     public ResourceRoutes(ResourceDAO resourceDAO,
                           OpenPaaSDomainDAO domainDAO,
                           OpenPaaSUserDAO userDAO,
                           JsonTransformer jsonTransformer,
-                          ResourceAdministratorService resourceAdministratorService) {
+                          ResourceAdministratorService resourceAdministratorService,
+                          TaskManager taskManager,
+                          CalDavClient calDavClient) {
         this.resourceDAO = resourceDAO;
         this.domainDAO = domainDAO;
         this.userDAO = userDAO;
         this.jsonTransformer = jsonTransformer;
         this.resourceAdministratorService = resourceAdministratorService;
+        this.taskManager = taskManager;
+        this.calDavClient = calDavClient;
         creationDTOJsonExtractor = new JsonExtractor<>(ResourceCreationDTO.class);
         updateDTOJsonExtractor = new JsonExtractor<>(ResourceUpdateDTO.class);
     }
@@ -154,8 +168,21 @@ public class ResourceRoutes implements Routes {
         service.get(getBasePath(), (req, res) -> listResources(req), jsonTransformer);
         service.get(getBasePath() + "/:id", (req, res) -> getResource(req), jsonTransformer);
         service.delete(getBasePath() + "/:id", this::deleteResource);
-        service.post(getBasePath(), this::createResource);
         service.patch(getBasePath() + "/:id", this::updateResource);
+        service.post(getBasePath(), this::handlePostRequest, jsonTransformer);
+    }
+
+    private Object handlePostRequest(Request req, Response res) throws Exception {
+        String taskParam = req.queryParams("task");
+        if (StringUtils.isBlank(taskParam)) {
+            return createResource(req, res);
+        }
+        if (Strings.CI.equals(TASK_REPOSITION_WRITE_RIGHTS, taskParam)) {
+            TaskFromRequest repositionWriteRightsTask = this::getRepositionResourceRightsTask;
+            return repositionWriteRightsTask.asRoute(taskManager).handle(req, res);
+        }
+        LOGGER.warn("Unknown task: {}", taskParam);
+        throw new IllegalArgumentException("Unknown task: " + taskParam);
     }
 
     private List<ResourceDTO> listResources(Request req) {
@@ -292,5 +319,9 @@ public class ResourceRoutes implements Routes {
 
     private ResourceUpdateRequest buildUpdateRequest(ResourceUpdateDTO dto, Optional<List<ResourceAdministrator>> adminsOpt) {
         return new ResourceUpdateRequest(dto.name(), dto.description(), dto.icon(), adminsOpt);
+    }
+
+    private RepositionResourceRightsTask getRepositionResourceRightsTask(Request request) {
+        return new RepositionResourceRightsTask(resourceDAO, userDAO, calDavClient, RunningOptions.parse(request));
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/RepositionResourceRightsTask.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/RepositionResourceRightsTask.java
@@ -1,0 +1,164 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.webadmin.task;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.james.core.Username;
+import org.apache.james.task.Task;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskType;
+import org.apache.james.util.ReactorUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.ResourceDAO;
+import com.linagora.calendar.storage.model.Resource;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import spark.Request;
+
+public class RepositionResourceRightsTask implements Task {
+
+    public static class Context {
+        public record Snapshot(long processedResourceCount, long failedResourceCount) {
+        }
+
+        private final AtomicLong processedResourceCount = new AtomicLong();
+        private final AtomicLong failedResourceCount = new AtomicLong();
+
+        void incrementProcessed() {
+            processedResourceCount.incrementAndGet();
+        }
+
+        void incrementFailed() {
+            failedResourceCount.incrementAndGet();
+        }
+
+        long getProcessedResourceCount() {
+            return processedResourceCount.get();
+        }
+
+        long getFailedResourceCount() {
+            return failedResourceCount.get();
+        }
+
+        public Snapshot snapshot() {
+            return new Snapshot(processedResourceCount.get(), failedResourceCount.get());
+        }
+    }
+
+    public record Details(long processedResourceCount, long failedResourceCount, Instant timestamp) implements TaskExecutionDetails.AdditionalInformation {
+    }
+
+    public record RunningOptions(int resourcesPerSecond) {
+        public static final RunningOptions DEFAULT = new RunningOptions(1);
+
+        public static RunningOptions parse(Request request) {
+            String param = request.queryParams("resourcesPerSecond");
+            if (StringUtils.isBlank(param)) {
+                return DEFAULT;
+            }
+
+            try {
+                return new RunningOptions(Integer.parseInt(param));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid resourcesPerSecond: " + param, e);
+            }
+        }
+    }
+
+    public static final TaskType TYPE = TaskType.of("reposition-resource-rights");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepositionResourceRightsTask.class);
+
+    private final ResourceDAO resourceDAO;
+    private final OpenPaaSUserDAO userDAO;
+    private final CalDavClient calDavClient;
+    private final Context context;
+    private final RunningOptions runningOptions;
+
+    public RepositionResourceRightsTask(ResourceDAO resourceDAO,
+                                        OpenPaaSUserDAO userDAO,
+                                        CalDavClient calDavClient,
+                                        RunningOptions runningOptions) {
+        this.resourceDAO = resourceDAO;
+        this.userDAO = userDAO;
+        this.calDavClient = calDavClient;
+        this.context = new Context();
+        this.runningOptions = runningOptions;
+    }
+
+    @Override
+    public Result run() {
+        return Flux.from(resourceDAO.findAll())
+            .filter(resource -> !resource.deleted())
+            .transform(ReactorUtils.<Resource, Task.Result>throttle()
+                .elements(runningOptions.resourcesPerSecond())
+                .per(Duration.ofSeconds(1))
+                .forOperation(resource -> reapplyWriteRights(resource, context)))
+            .reduce(Task.Result.COMPLETED, Task::combine)
+            .doOnNext(result -> LOGGER.info("{} task result: {}. Processed: {}, Failed: {}", TYPE.asString(), result.name(), context.getProcessedResourceCount(), context.getFailedResourceCount()))
+            .onErrorResume(e -> {
+                LOGGER.error("Task {} is incomplete", TYPE.asString(), e);
+                return Mono.just(Task.Result.PARTIAL);
+            })
+            .block();
+    }
+
+    private Mono<Task.Result> reapplyWriteRights(Resource resource, Context context) {
+        return resolveAdministratorUsernames(resource)
+            .flatMap(usernames -> calDavClient.grantReadWriteRights(resource.domain(), resource.id(), usernames)
+                .thenReturn(Result.COMPLETED)
+                .onErrorResume(e -> {
+                    LOGGER.error("Error granting rights for resource {}", resource.id().value(), e);
+                    context.incrementFailed();
+                    return Mono.just(Result.PARTIAL);
+                })
+                .doOnNext(result -> context.incrementProcessed()));
+    }
+
+    @Override
+    public TaskType type() {
+        return TYPE;
+    }
+
+    @Override
+    public Optional<TaskExecutionDetails.AdditionalInformation> details() {
+        Context.Snapshot snapshot = context.snapshot();
+        return Optional.of(new Details(snapshot.processedResourceCount(), snapshot.failedResourceCount(), Clock.systemUTC().instant()));
+    }
+
+    private Mono<List<Username>> resolveAdministratorUsernames(Resource resource) {
+        return Flux.fromIterable(resource.administrators())
+            .flatMap(admin -> userDAO.retrieve(admin.refId()))
+            .map(OpenPaaSUser::username)
+            .collectList();
+    }
+}

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/RepositionResourceRightsTaskAdditionalInformationDTO.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/RepositionResourceRightsTaskAdditionalInformationDTO.java
@@ -1,0 +1,60 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.webadmin.task;
+
+import java.time.Instant;
+
+import org.apache.james.json.DTOModule;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+
+public record RepositionResourceRightsTaskAdditionalInformationDTO(String type,
+                                                                   Instant timestamp,
+                                                                   long processedResourceCount,
+                                                                   long failedResourceCount) implements AdditionalInformationDTO {
+
+    public static AdditionalInformationDTOModule<RepositionResourceRightsTask.Details, RepositionResourceRightsTaskAdditionalInformationDTO> module() {
+        return DTOModule.forDomainObject(RepositionResourceRightsTask.Details.class)
+            .convertToDTO(RepositionResourceRightsTaskAdditionalInformationDTO.class)
+            .toDomainObjectConverter(RepositionResourceRightsTaskAdditionalInformationDTO::toDomainObject)
+            .toDTOConverter(RepositionResourceRightsTaskAdditionalInformationDTO::fromDomainObject)
+            .typeName(RepositionResourceRightsTask.TYPE.asString())
+            .withFactory(AdditionalInformationDTOModule::new);
+    }
+
+
+    private static RepositionResourceRightsTaskAdditionalInformationDTO fromDomainObject(RepositionResourceRightsTask.Details details, String type) {
+        return new RepositionResourceRightsTaskAdditionalInformationDTO(type, details.timestamp(),
+            details.processedResourceCount(), details.failedResourceCount());
+    }
+
+    private RepositionResourceRightsTask.Details toDomainObject() {
+        return new RepositionResourceRightsTask.Details(processedResourceCount, failedResourceCount, timestamp);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/RepositionResourceRightsTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/RepositionResourceRightsTest.java
@@ -1,0 +1,480 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.webadmin;
+
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+import static io.restassured.RestAssured.given;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.spy;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.UUID;
+
+import javax.net.ssl.SSLException;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.json.DTOConverter;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
+import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
+import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.task.TaskExecutionDetails;
+import org.apache.james.task.TaskManager;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.apache.james.webadmin.routes.TasksRoutes;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.ImmutableSet;
+import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.DavClientException;
+import com.linagora.calendar.dav.DavTestHelper;
+import com.linagora.calendar.dav.DockerSabreDavSetup;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSDomain;
+import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.model.ResourceId;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBResourceDAO;
+import com.linagora.calendar.webadmin.task.RepositionResourceRightsTaskAdditionalInformationDTO;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import reactor.core.publisher.Mono;
+
+public class RepositionResourceRightsTest {
+
+    @RegisterExtension
+    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+
+    private WebAdminServer webAdminServer;
+    private OpenPaaSUserDAO userDAO;
+    private MongoDBOpenPaaSDomainDAO domainDAO;
+    private MongoDBResourceDAO resourceDAO;
+    private CalDavClient calDavClient;
+    private DavTestHelper davTestHelper;
+
+    private OpenPaaSUser creator;
+    private OpenPaaSId domainId;
+   
+    @BeforeEach
+    void setUp() throws SSLException {
+        MongoDatabase mongoDB = sabreDavExtension.dockerSabreDavSetup().getMongoDB();
+        domainDAO = new MongoDBOpenPaaSDomainDAO(mongoDB);
+        userDAO = new MongoDBOpenPaaSUserDAO(mongoDB, domainDAO);
+        resourceDAO = new MongoDBResourceDAO(mongoDB, Clock.system(UTC));
+        CalDavClient realCalDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        calDavClient = spy(realCalDavClient);
+        davTestHelper = sabreDavExtension.davTestHelper();
+
+        TaskManager taskManager = new MemoryTaskManager(new Hostname("foo"));
+        ResourceAdministratorService resourceAdministratorService = new ResourceAdministratorService(calDavClient, userDAO);
+        ResourceRoutes resourceRoutes = new ResourceRoutes(resourceDAO, domainDAO, userDAO, new JsonTransformer(), resourceAdministratorService, taskManager, calDavClient);
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(resourceRoutes,
+                new TasksRoutes(taskManager, new JsonTransformer(), new DTOConverter<>(ImmutableSet.<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>>builder()
+                    .add(RepositionResourceRightsTaskAdditionalInformationDTO.module())
+                    .build())))
+            .start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
+            .setBasePath(ResourceRoutes.BASE_PATH)
+            .build();
+
+        creator = sabreDavExtension.newTestUser();
+        domainId = domainDAO.retrieve(creator.username().getDomainPart().get())
+            .map(OpenPaaSDomain::id).block();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+        Mockito.reset(calDavClient);
+    }
+
+    @Test
+    void shouldShowAllInformationInResponse() {
+        String taskId = given()
+            .queryParam("task", "repositionWriteRights")
+        .when()
+            .post()
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .body("status", is("completed"))
+            .body("taskId", is(taskId))
+            .body("type", is("reposition-resource-rights"))
+            .body("additionalInformation.processedResourceCount", is(0))
+            .body("additionalInformation.failedResourceCount", is(0))
+            .body("additionalInformation.timestamp", is(notNullValue()))
+            .body("additionalInformation.type", is("reposition-resource-rights"))
+            .body("startedDate", is(notNullValue()))
+            .body("submitDate", is(notNullValue()))
+            .body("completedDate", is(notNullValue()));
+    }
+
+    @Test
+    void shouldReturnErrorWhenTaskNameIsInvalid() {
+        given()
+            .queryParam("task", "invalidTaskName")
+        .when()
+            .post()
+        .then()
+            .statusCode(400)
+            .body("details", is("Unknown task: invalidTaskName"));
+    }
+
+    @Test
+    void shouldRestoreWriteRightsForAllAdmins() {
+        // Given
+        OpenPaaSUser admin1 = sabreDavExtension.newTestUser();
+        OpenPaaSUser admin2 = sabreDavExtension.newTestUser();
+
+        // Create resource with 2 admins
+        ResourceId resourceId = createNewResource(creator, List.of(admin1, admin2));
+
+        // Sanity check — initial invites include both admins
+        ArrayNode before = davTestHelper.getCalendarDelegateInvites(domainId, resourceId).block();
+
+        assertThat(before.findValuesAsText("href"))
+            .contains("mailto:" + admin1.username().asString(), "mailto:" + admin2.username().asString());
+
+        // WHEN — Manually revoke rights on DAV to simulate drift
+        calDavClient.revokeWriteRights(domainId, resourceId, List.of(admin1.username(), admin2.username())).block();
+
+        // Assert they are indeed removed
+        ArrayNode afterRevoke = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domainId, resourceId)
+            .block();
+
+        assertThat(afterRevoke.findValuesAsText("href"))
+            .doesNotContain("mailto:" + admin1.username().asString(),
+                "mailto:" + admin2.username().asString());
+
+        // WHEN — Run the repositionWriteRights task
+        runRepositionTaskAndAwait()
+            .body("status", is("completed"))
+            .body("additionalInformation.processedResourceCount", is(1))
+            .body("additionalInformation.failedResourceCount", is(0));
+
+        // THEN — rights should be restored on DAV
+        ArrayNode afterTask = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domainId, resourceId)
+            .block();
+
+        assertThat(afterTask.findValuesAsText("href"))
+            .contains("mailto:" + admin1.username().asString(),
+                "mailto:" + admin2.username().asString());
+    }
+
+    @Test
+    void shouldRestoreWriteRightsForMultipleResources() {
+        // Given
+        OpenPaaSUser admin1 = sabreDavExtension.newTestUser();
+        OpenPaaSUser admin2 = sabreDavExtension.newTestUser();
+
+        ResourceId resourceId1 = createNewResource(creator, List.of(admin1));
+        ResourceId resourceId2 = createNewResource(creator, List.of(admin2));
+
+        // Sanity check — both resources have their admins
+        ArrayNode before1 = davTestHelper.getCalendarDelegateInvites(domainId, resourceId1).block();
+        ArrayNode before2 = davTestHelper.getCalendarDelegateInvites(domainId, resourceId2).block();
+
+        assertThat(before1.findValuesAsText("href"))
+            .contains("mailto:" + admin1.username().asString());
+        assertThat(before2.findValuesAsText("href"))
+            .contains("mailto:" + admin2.username().asString());
+
+        // WHEN — revoke rights on DAV
+        calDavClient.revokeWriteRights(domainId, resourceId1, List.of(admin1.username())).block();
+        calDavClient.revokeWriteRights(domainId, resourceId2, List.of(admin2.username())).block();
+
+        // Assert they are removed
+        ArrayNode afterRevoke1 = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domainId, resourceId1).block();
+        ArrayNode afterRevoke2 = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domainId, resourceId2).block();
+
+        assertThat(afterRevoke1.findValuesAsText("href"))
+            .doesNotContain("mailto:" + admin1.username().asString());
+        assertThat(afterRevoke2.findValuesAsText("href"))
+            .doesNotContain("mailto:" + admin2.username().asString());
+
+        // WHEN — run task
+        runRepositionTaskAndAwait()
+            .body("status", is("completed"))
+            .body("additionalInformation.processedResourceCount", is(2))
+            .body("additionalInformation.failedResourceCount", is(0));
+
+        // THEN — both resources restored
+        ArrayNode afterTask1 = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domainId, resourceId1).block();
+        ArrayNode afterTask2 = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domainId, resourceId2).block();
+
+        assertThat(afterTask1.findValuesAsText("href"))
+            .contains("mailto:" + admin1.username().asString());
+        assertThat(afterTask2.findValuesAsText("href"))
+            .contains("mailto:" + admin2.username().asString());
+    }
+
+    @Test
+    void shouldHandlePartialFailureDuringRepositionRights() {
+        // Given
+        OpenPaaSUser admin1 = sabreDavExtension.newTestUser();
+        OpenPaaSUser admin2 = sabreDavExtension.newTestUser();
+
+        // Create 2 resources
+        ResourceId resourceId1 = createNewResource(creator, List.of(admin1));
+        ResourceId resourceId2 = createNewResource(creator, List.of(admin2));
+
+        Mockito.doReturn(Mono.error(() -> new DavClientException("Simulated failure for resourceId1")))
+            .when(calDavClient)
+            .grantReadWriteRights(Mockito.any(),
+                Mockito.argThat(resourceId1::equals),
+                Mockito.any());
+
+        // When — trigger reposition task
+        String taskId = given()
+            .queryParam("task", "repositionWriteRights")
+            .post()
+            .jsonPath()
+            .get("taskId");
+
+        // Then — await completion
+        given()
+            .basePath(TasksRoutes.BASE)
+            .get(taskId + "/await")
+        .then()
+            .statusCode(200)
+            .body("status", is("failed"))
+            .body("additionalInformation.processedResourceCount", is(2))
+            .body("additionalInformation.failedResourceCount", is(1));
+
+        Mockito.verify(calDavClient, Mockito.atLeast(2))
+            .grantReadWriteRights(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void shouldBeIdempotentWhenRunningRepositionRightsTaskMultipleTimes() {
+        // Given
+        OpenPaaSUser admin1 = sabreDavExtension.newTestUser();
+        OpenPaaSUser admin2 = sabreDavExtension.newTestUser();
+
+        ResourceId resourceId = createNewResource(creator, List.of(admin1, admin2));
+
+        // Sanity check — initial rights
+        ArrayNode before = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domainId, resourceId)
+            .block();
+        assertThat(before.findValuesAsText("href"))
+            .contains("mailto:" + admin1.username().asString(), "mailto:" + admin2.username().asString());
+
+        // WHEN — Run task first time
+        runRepositionTaskAndAwait()
+            .statusCode(200)
+            .body("status", is("completed"))
+            .body("additionalInformation.processedResourceCount", is(1))
+            .body("additionalInformation.failedResourceCount", is(0));
+
+        // Run task second time — should still succeed without error
+        runRepositionTaskAndAwait()
+            .statusCode(200)
+            .body("status", is("completed"))
+            .body("additionalInformation.processedResourceCount", is(1))
+            .body("additionalInformation.failedResourceCount", is(0));
+
+        // THEN — Rights should remain unchanged
+        ArrayNode after = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domainId, resourceId)
+            .block();
+
+        assertThat(after.findValuesAsText("href"))
+            .contains("mailto:" + admin1.username().asString(), "mailto:" + admin2.username().asString());
+    }
+
+    @Test
+    void shouldReapplyRightsForResourcesAcrossMultipleDomains() {
+        // Given
+        // Create two distinct domains
+        OpenPaaSDomain domain1 = domainDAO.add(Domain.of("linagora.com")).block();
+        OpenPaaSDomain domain2 = domainDAO.add(Domain.of("twake.app")).block();
+
+        // Create users for each domain
+        OpenPaaSUser creator1 = userDAO.add(Username.of("creator1@linagora.com")).block();
+        OpenPaaSUser creator2 = userDAO.add(Username.of("creator2@twake.app" )).block();
+        OpenPaaSUser admin1 = userDAO.add(Username.of("admin1@linagora.com")).block();
+        OpenPaaSUser admin2 = userDAO.add(Username.of("admin2@twake.app" )).block();
+
+        // Create resources in each domain
+        ResourceId resourceId1 = createNewResource(creator1, List.of(admin1));
+        ResourceId resourceId2 = createNewResource(creator2, List.of(admin2));
+
+        // Sanity check — ensure both admins exist initially
+        ArrayNode before1 = davTestHelper.getCalendarDelegateInvites(domain1.id(), resourceId1).block();
+        ArrayNode before2 = davTestHelper.getCalendarDelegateInvites(domain2.id(), resourceId2).block();
+        assertThat(before1.findValuesAsText("href"))
+            .contains("mailto:" + admin1.username().asString());
+        assertThat(before2.findValuesAsText("href"))
+            .contains("mailto:" + admin2.username().asString());
+
+        // WHEN — revoke rights manually
+        calDavClient.revokeWriteRights(domain1.id(), resourceId1, List.of(admin1.username())).block();
+        calDavClient.revokeWriteRights(domain2.id(), resourceId2, List.of(admin2.username())).block();
+
+        // Confirm both removed
+        ArrayNode afterRevoke1 = davTestHelper.getCalendarDelegateInvites(domain1.id(), resourceId1).block();
+        ArrayNode afterRevoke2 = davTestHelper.getCalendarDelegateInvites(domain2.id(), resourceId2).block();
+        assertThat(afterRevoke1.findValuesAsText("href"))
+            .doesNotContain("mailto:" + admin1.username().asString());
+        assertThat(afterRevoke2.findValuesAsText("href"))
+            .doesNotContain("mailto:" + admin2.username().asString());
+
+        // WHEN — run reposition task
+        runRepositionTaskAndAwait()
+            .statusCode(200)
+            .body("status", is("completed"))
+            .body("additionalInformation.processedResourceCount", is(2))
+            .body("additionalInformation.failedResourceCount", is(0));
+
+        // Both rights restored
+        ArrayNode afterTask1 = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domain1.id(), resourceId1).block();
+        ArrayNode afterTask2 = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(domain2.id(), resourceId2).block();
+        assertThat(afterTask1.findValuesAsText("href"))
+            .contains("mailto:" + admin1.username().asString());
+        assertThat(afterTask2.findValuesAsText("href"))
+            .contains("mailto:" + admin2.username().asString());
+    }
+
+    @Test
+    void shouldCompleteSuccessfullyWhenNoResourcesPresent() {
+        String taskId = given()
+            .queryParam("task", "repositionWriteRights")
+        .when()
+            .post()
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .statusCode(200)
+            .body("status", is("completed"))
+            .body("additionalInformation.processedResourceCount", is(0))
+            .body("additionalInformation.failedResourceCount", is(0));
+    }
+
+    @Test
+    void shouldSkipDeletedResources() {
+        OpenPaaSUser admin = sabreDavExtension.newTestUser();
+        ResourceId resourceId = createNewResource(creator, List.of(admin));
+
+        // Mark resource as deleted
+        resourceDAO.softDelete(resourceId).block();
+
+        String taskId = given()
+            .queryParam("task", "repositionWriteRights")
+        .when()
+            .post()
+            .jsonPath()
+            .get("taskId");
+
+        given()
+            .basePath(TasksRoutes.BASE)
+        .when()
+            .get(taskId + "/await")
+        .then()
+            .statusCode(200)
+            .body("status", is("completed"))
+            .body("additionalInformation.processedResourceCount", is(0))
+            .body("additionalInformation.failedResourceCount", is(0));
+    }
+
+    private ResourceId createNewResource(OpenPaaSUser creator, List<OpenPaaSUser> admins) {
+        String adminsJson = String.join(", ",
+            admins.stream()
+                .map(admin -> "{ \"email\": \"" + admin.username().asString() + "\" }")
+                .toList());
+        String body = """
+            {
+                "name": "%s",
+                "description": "%s",
+                "creator": "%s",
+                "icon": "door",
+                "domain": "%s",
+                "administrators": [
+                    %s
+                ]
+            }
+            """.formatted(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            creator.username().asString(),
+            creator.username().getDomainPart().get().asString(),
+            adminsJson.toString());
+
+        String location = given()
+            .body(body)
+            .post()
+        .then()
+            .statusCode(201)
+            .extract()
+            .header("Location");
+        String resourceId = location.substring(location.lastIndexOf('/') + 1);
+        return new ResourceId(resourceId);
+    }
+
+    private ValidatableResponse runRepositionTaskAndAwait() {
+        String taskId = given()
+            .queryParam("task", "repositionWriteRights")
+            .post()
+            .jsonPath()
+            .get("taskId");
+        return given()
+            .basePath(TasksRoutes.BASE)
+            .get(taskId + "/await")
+            .then();
+    }
+
+}

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/ResourceRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/ResourceRoutesTest.java
@@ -33,6 +33,9 @@ import javax.net.ssl.SSLException;
 
 import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
+import org.apache.james.task.Hostname;
+import org.apache.james.task.MemoryTaskManager;
+import org.apache.james.task.TaskManager;
 import org.apache.james.webadmin.WebAdminServer;
 import org.apache.james.webadmin.WebAdminUtils;
 import org.apache.james.webadmin.utils.JsonTransformer;
@@ -80,11 +83,12 @@ class ResourceRoutesTest {
         userDAO = new MongoDBOpenPaaSUserDAO(mongoDB, domainDAO);
         resourceDAO = new MongoDBResourceDAO(mongoDB, Clock.system(UTC));
         CalDavClient calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        TaskManager taskManager = new MemoryTaskManager(new Hostname("foo"));
 
         ResourceAdministratorService resourceAdministratorService = new ResourceAdministratorService(calDavClient, userDAO);
         webAdminServer = WebAdminUtils.createWebAdminServer(
             new ResourceRoutes(resourceDAO, domainDAO, userDAO,
-                new JsonTransformer(), resourceAdministratorService)).start();
+                new JsonTransformer(), resourceAdministratorService, taskManager, calDavClient)).start();
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
             .setBasePath(ResourceRoutes.BASE_PATH)


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web admin: POST /resources?task=repositionWriteRights to trigger a background task that repositions resource write rights; exposes task status, timestamps, and processed/failed counters.
  * New background task implementation to scan resources and reapply admin rights.

* **Tests**
  * Comprehensive integration tests covering success, partial failures, idempotence, cross-domain behavior, edge cases, and task lifecycle responses.

* **Documentation / DTO**
  * Added DTO-backed payload for task additional information (type, timestamp, counts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->