### PR TITLE
feat(amqp): EventITIPConsumer : forward requestURI header to IMIP callback path

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventITIPConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventITIPConsumer.java
@@ -29,7 +29,6 @@ import java.util.function.Supplier;
 
 import jakarta.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.backends.rabbitmq.QueueArguments;

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventITIPConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventITIPConsumer.java
@@ -24,10 +24,14 @@ import static org.apache.james.backends.rabbitmq.Constants.EMPTY_ROUTING_KEY;
 import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.io.Closeable;
+import java.net.URI;
 import java.util.function.Supplier;
 
 import jakarta.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.james.backends.rabbitmq.QueueArguments;
 import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
 import org.apache.james.backends.rabbitmq.ReceiverProvider;
@@ -56,7 +60,8 @@ public class EventITIPConsumer implements Closeable, Startable {
     public static final String EXCHANGE_NAME = "calendar:itip:deliver";
     public static final String QUEUE_NAME = "tcalendar:itip:deliver";
     public static final String DEAD_LETTER_QUEUE = "tcalendar:itip:deliver:dead-letter";
-    public static final String CONNECTED_USER = "connectedUser";
+    public static final String CONNECTED_USER_HEADER = "connectedUser";
+    public static final String REQUEST_URI_HEADER = "requestURI";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventITIPConsumer.class);
     private static final boolean REQUEUE_ON_NACK = true;
@@ -130,14 +135,23 @@ public class EventITIPConsumer implements Closeable, Startable {
     }
 
     private Mono<Void> consumeMessage(AcknowledgableDelivery ackDelivery) {
-        return Mono.fromCallable(() -> Username.of(ackDelivery.getProperties().getHeaders().get(CONNECTED_USER).toString()))
-                .flatMap(user -> calDavClient.sendIMIPCallback(user, ackDelivery.getBody()))
+        return Mono.fromCallable(() -> extractHeaderProperties(ackDelivery))
+            .flatMap(usernameURIPair -> calDavClient.sendIMIPCallback(usernameURIPair.getLeft(),
+                usernameURIPair.getRight(), ackDelivery.getBody()))
             .doOnSuccess(result -> ackDelivery.ack())
             .onErrorResume(error -> {
                 LOGGER.error("Error when consume calendar itip event message", error);
                 ackDelivery.nack(!REQUEUE_ON_NACK);
                 return Mono.empty();
             });
+    }
+
+    private Pair<Username, URI> extractHeaderProperties(AcknowledgableDelivery ackDelivery) {
+        Username user = Username.of(ackDelivery.getProperties().getHeaders().get(CONNECTED_USER_HEADER).toString());
+        String requestUriHeader = ackDelivery.getProperties().getHeaders().get(REQUEST_URI_HEADER).toString();
+        String normalizedUri = Strings.CS.startsWith(requestUriHeader, "/") ? requestUriHeader : "/" + requestUriHeader;
+        URI requestURI = URI.create(normalizedUri);
+        return Pair.of(user, requestURI);
     }
 }
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventITIPConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventITIPConsumerTest.java
@@ -19,7 +19,8 @@
 package com.linagora.calendar.amqp;
 
 import static com.linagora.calendar.amqp.CalendarAmqpModule.DEFAULT_ITIP_EVENT_MESSAGES_PREFETCH_COUNT;
-import static com.linagora.calendar.amqp.EventITIPConsumer.CONNECTED_USER;
+import static com.linagora.calendar.amqp.EventITIPConsumer.CONNECTED_USER_HEADER;
+import static com.linagora.calendar.amqp.EventITIPConsumer.REQUEST_URI_HEADER;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static com.rabbitmq.client.MessageProperties.PERSISTENT_TEXT_PLAIN;
 import static org.apache.james.backends.rabbitmq.Constants.EMPTY_ROUTING_KEY;
@@ -167,7 +168,8 @@ public class EventITIPConsumerTest {
             .deliveryMode(PERSISTENT_TEXT_PLAIN.getDeliveryMode())
             .priority(PERSISTENT_TEXT_PLAIN.getPriority())
             .contentType(PERSISTENT_TEXT_PLAIN.getContentType())
-            .headers(ImmutableMap.of(CONNECTED_USER, user))
+            .headers(ImmutableMap.of(CONNECTED_USER_HEADER, user,
+                REQUEST_URI_HEADER, "calendars/imipCallback"))
             .build();
 
         channel.basicPublish(EventITIPConsumer.EXCHANGE_NAME, EMPTY_ROUTING_KEY, basicProperties, message.getBytes(StandardCharsets.UTF_8));

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
@@ -471,14 +471,14 @@ public class CalDavClient extends DavClient {
             });
     }
 
-    public Mono<Void> sendIMIPCallback(Username connectedUser, byte[] payload) {
+    public Mono<Void> sendIMIPCallback(Username connectedUser, URI requestURI, byte[] payload) {
         return httpClientWithImpersonation(connectedUser)
             .responseTimeout(imipCallbackResponseTimeout)
             .headers(headers -> headers
                 .add(HttpHeaderNames.ACCEPT, CONTENT_TYPE_JSON)
                 .add(HttpHeaderNames.CONTENT_TYPE, CONTENT_TYPE_JSON))
             .request(HttpMethod.valueOf("IMIPCALLBACK"))
-            .uri("/calendars/imipCallback")
+            .uri(requestURI.toASCIIString())
             .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(payload)))
             .responseSingle((response, responseContent) -> {
                 if (response.status().code() == 204) {


### PR DESCRIPTION
EventITIPConsumer now passes the `requestURI` from AMQP headers to sendIMIPCallback, allowing CalDAV backend to identify the originating request path.

Why?
https://github.com/linagora/esn-sabre/pull/149#issuecomment-3514910639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * ITIP messages can carry both a connected user and a callback URI, enabling dynamic routing of callbacks.
  * Callback URIs are normalized to ensure correct addressing.
  * Dynamic callback URIs replace the previous fixed endpoint for IMIP delivery.
  * Enhanced debug logging surfaces payload details on successful (204) callback responses; ACK/NACK behavior remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->