### PR TITLE
FIX: disable commons-configuration2 delimiter for mongo.url

### DIFF
--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBConfiguration.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBConfiguration.java
@@ -20,10 +20,17 @@ package com.linagora.calendar.storage.mongodb;
 
 import java.util.Optional;
 
+import org.apache.commons.configuration2.AbstractConfiguration;
 import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.convert.DisabledListDelimiterHandler;
 
 public record MongoDBConfiguration(String mongoURL, String database) {
     public static MongoDBConfiguration parse(Configuration configuration) {
+        if (configuration instanceof AbstractConfiguration) {
+            ((AbstractConfiguration) configuration)
+                .setListDelimiterHandler(new DisabledListDelimiterHandler());
+        }
+
         return new MongoDBConfiguration(
             Optional.ofNullable(configuration.getString("mongo.url", null))
                 .orElseThrow(() -> new IllegalArgumentException("'mongo.url' is mandatory")),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MongoDB configuration handling to prevent unintended list delimiter processing in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->