### PR TITLE
ISSUE-470 FIX: race condition in EventIndexerConsumer leading to outdated data being indexed

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventFieldConverter.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventFieldConverter.java
@@ -45,6 +45,7 @@ import com.linagora.calendar.amqp.EventProperty.DateProperty;
 import com.linagora.calendar.amqp.EventProperty.DtStampProperty;
 import com.linagora.calendar.amqp.EventProperty.EventUidProperty;
 import com.linagora.calendar.amqp.EventProperty.OrganizerProperty;
+import com.linagora.calendar.amqp.EventProperty.SequenceProperty;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.event.EventFields;
@@ -108,6 +109,7 @@ public class EventFieldConverter {
                 }
                 case EventProperty.RECURRENCE_ID_PROPERTY -> builder.isRecurrentMaster(false);
                 case EventProperty.RRULE_PROPERTY -> builder.isRecurrentMaster(true);
+                case EventProperty.SEQUENCE_PROPERTY -> builder.sequence(((SequenceProperty) property).getSequence());
                 default -> {
                 }
             }
@@ -153,7 +155,8 @@ public class EventFieldConverter {
             EventProperty.DTSTART_PROPERTY, DateProperty::new,
             EventProperty.DTEND_PROPERTY, DateProperty::new,
             EventProperty.DTSTAMP_PROPERTY, DtStampProperty::new,
-            EventProperty.DURATION_PROPERTY, EventProperty.DurationProperty::new);
+            EventProperty.DURATION_PROPERTY, EventProperty.DurationProperty::new,
+            EventProperty.SEQUENCE_PROPERTY, EventProperty.SequenceProperty::new);
 
         private void validateNode(JsonNode node) throws JsonMappingException {
             if (!node.isArray()) {

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventProperty.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventProperty.java
@@ -58,6 +58,7 @@ public class EventProperty {
     public static final String DESCRIPTION_PROPERTY = "description";
     public static final String LOCATION_PROPERTY = "location";
     public static final String ORGANIZER_PROPERTY = "organizer";
+    public static final String SEQUENCE_PROPERTY = "sequence";
     public static final String ATTENDEE_PROPERTY = "attendee";
     public static final String RECURRENCE_ID_PROPERTY = "recurrence-id";
     public static final String RRULE_PROPERTY = "rrule";
@@ -202,6 +203,27 @@ public class EventProperty {
 
         public EventUid getEventUid() {
             return eventUid;
+        }
+    }
+
+    public static class SequenceProperty extends EventProperty {
+        private static final String INTEGER = "integer";
+
+        private final Integer sequence;
+
+        public SequenceProperty(EventProperty base) {
+            super(base.name, base.attributes, base.valueType, base.value);
+            if (!INTEGER.equalsIgnoreCase(base.valueType)) {
+                throw new CalendarEventDeserializeException("Invalid value type for sequence property, expected 'integer' but got " + base.valueType);
+            }
+
+            this.sequence = Optional.ofNullable(base.value)
+                .map(Integer::valueOf)
+                .orElse(null);
+        }
+
+        public Integer getSequence() {
+            return sequence;
         }
     }
 

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventProperty.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventProperty.java
@@ -39,6 +39,8 @@ import org.apache.commons.lang3.Strings;
 import org.apache.james.core.MailAddress;
 import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.field.address.LenientAddressParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
@@ -48,6 +50,7 @@ import net.fortuna.ical4j.model.TimeZone;
 import net.fortuna.ical4j.model.property.Duration;
 
 public class EventProperty {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventProperty.class);
 
     public static final String UID_PROPERTY = "uid";
     public static final String DTSTART_PROPERTY = "dtstart";
@@ -218,7 +221,14 @@ public class EventProperty {
             }
 
             this.sequence = Optional.ofNullable(base.value)
-                .map(Integer::valueOf)
+                .map(rawValue -> {
+                    try {
+                        return Integer.valueOf(rawValue);
+                    } catch (NumberFormatException e) {
+                        LOGGER.warn("Invalid SEQUENCE value '{}', treating as null", rawValue);
+                        return null;
+                    }
+                })
                 .orElse(null);
         }
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventFieldConverterTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventFieldConverterTest.java
@@ -1383,6 +1383,7 @@ public class EventFieldConverterTest {
             .organizer(EventFields.Person.of("John1 Doe1", "user1@open-paas.org"))
             .addAttendee(EventFields.Person.of("John1 Doe1", "user1@open-paas.org"))
             .dtStamp(Instant.parse("2025-05-14T06:08:28Z"))
+            .sequence(1)
             .build();
 
         assertThat(calendarEvents)

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
@@ -380,6 +380,7 @@ public class EventIndexerConsumerTest {
             .organizer(EventFields.Person.of("John1 Doe1", openPaasUser.username().asString()))
             .addAttendee(EventFields.Person.of("John2 Doe2", attendee1.username().asString()))
             .addAttendee(EventFields.Person.of("John1 Doe1", openPaasUser.username().asString()))
+            .sequence(1)
             .build();
 
         assertThat(eventFields)

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
@@ -717,8 +717,8 @@ public class EventIndexerConsumerTest {
         assertEventExistsInSearch(attendee1.username(), originalSummary, eventUid);
         assertEventExistsInSearch(attendee2.username(), originalSummary, eventUid);
 
-        String updatedCalendar = originalCalendar.replace(originalSummary, updatedSummary);
-
+        String updatedCalendar = originalCalendar.replace(originalSummary, updatedSummary)
+            .replace("END:VEVENT", "SEQUENCE:1\nEND:VEVENT");
         davTestHelper.updateCalendar(openPaasUser, updatedCalendar, eventUid);
 
         assertEventNotInSearch(attendee1.username(), originalSummary, eventUid);

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/CalendarEventsReindexService.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/CalendarEventsReindexService.java
@@ -137,7 +137,7 @@ public class CalendarEventsReindexService {
     }
 
     private Mono<Task.Result> reindex(Context context, IndexItem indexItem) {
-        return calendarSearchService.index(AccountId.fromUsername(indexItem.user().username()), indexItem.calendarEvents())
+        return calendarSearchService.reindex(AccountId.fromUsername(indexItem.user().username()), indexItem.calendarEvents())
             .then(Mono.fromCallable(() -> {
                 context.incrementProcessedEvent();
                 return Task.Result.COMPLETED;

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
@@ -350,6 +350,7 @@ public class CalendarRoutesTest {
             .attendees(List.of(person))
             .resources(List.of())
             .calendarURL(calendarURL)
+            .sequence(1)
             .build();
 
         EventFields expected3 = EventFields.builder()
@@ -493,7 +494,7 @@ public class CalendarRoutesTest {
                 return Mono.error(new RuntimeException("Simulated failure for uid2"));
             }
             return Mono.empty();
-        }).when(calendarSearchService).index(any(), any());
+        }).when(calendarSearchService).reindex(any(), any());
 
         String taskId = given()
             .queryParam("task", "reindex")

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/EventFields.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/EventFields.java
@@ -55,6 +55,7 @@ public record EventFields(EventUid uid,
                           List<Person> attendees,
                           List<Person> resources,
                           String videoconferenceUrl,
+                          Integer sequence,
                           CalendarURL calendarURL) {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(EventFields.class);
@@ -99,6 +100,7 @@ public record EventFields(EventUid uid,
         private List<EventFields.Person> resources = new ArrayList<>();
         private String videoconferenceUrl;
         private CalendarURL calendarURL;
+        private Integer sequence;
 
         public Builder uid(String uid) {
             return uid(new EventUid(uid));
@@ -189,6 +191,11 @@ public record EventFields(EventUid uid,
             return this;
         }
 
+        public Builder sequence(Integer sequence) {
+            this.sequence = sequence;
+            return this;
+        }
+
         int calculateDurationInDays() {
             if (start == null || end == null || !end.isAfter(start)) {
                 return 0;
@@ -218,6 +225,7 @@ public record EventFields(EventUid uid,
                 attendees,
                 resources,
                 videoconferenceUrl,
+                sequence,
                 calendarURL);
         }
     }
@@ -242,6 +250,9 @@ public record EventFields(EventUid uid,
         builder.organizer(EventParseUtils.getOrganizer(vEvent));
         builder.attendees(EventParseUtils.getAttendees(vEvent));
         builder.resources(EventParseUtils.getResources(vEvent));
+        vEvent.getProperty(Property.SEQUENCE)
+            .ifPresent(prop -> builder.sequence(Integer.valueOf(prop.getValue())));
+
         return builder.build();
     }
 

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/EventFields.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/EventFields.java
@@ -55,7 +55,7 @@ public record EventFields(EventUid uid,
                           List<Person> attendees,
                           List<Person> resources,
                           String videoconferenceUrl,
-                          Integer sequence,
+                          Optional<Integer> sequence,
                           CalendarURL calendarURL) {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(EventFields.class);
@@ -100,7 +100,7 @@ public record EventFields(EventUid uid,
         private List<EventFields.Person> resources = new ArrayList<>();
         private String videoconferenceUrl;
         private CalendarURL calendarURL;
-        private Integer sequence;
+        private Optional<Integer> sequence = Optional.empty();
 
         public Builder uid(String uid) {
             return uid(new EventUid(uid));
@@ -192,7 +192,7 @@ public record EventFields(EventUid uid,
         }
 
         public Builder sequence(Integer sequence) {
-            this.sequence = sequence;
+            this.sequence = Optional.of(sequence);
             return this;
         }
 
@@ -250,11 +250,16 @@ public record EventFields(EventUid uid,
         builder.organizer(EventParseUtils.getOrganizer(vEvent));
         builder.attendees(EventParseUtils.getAttendees(vEvent));
         builder.resources(EventParseUtils.getResources(vEvent));
-        vEvent.getProperty(Property.SEQUENCE)
-            .ifPresent(prop -> builder.sequence(Integer.valueOf(prop.getValue())));
 
+        vEvent.getProperty(Property.SEQUENCE)
+            .ifPresent(prop -> {
+                try {
+                    builder.sequence(Integer.valueOf(prop.getValue()));
+                } catch (NumberFormatException e) {
+                    LOGGER.warn("Invalid SEQUENCE value: {}", prop.getValue(), e);
+                }
+            });
         return builder.build();
     }
-
 
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/CalendarSearchService.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/CalendarSearchService.java
@@ -29,6 +29,8 @@ public interface CalendarSearchService {
 
     Mono<Void> index(AccountId accountId, CalendarEvents fields);
 
+    Mono<Void> reindex(AccountId accountId, CalendarEvents fields);
+
     Mono<Void> delete(AccountId accountId, EventUid eventUid);
 
     Flux<EventFields> search(AccountId accountId, EventSearchQuery query);

--- a/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
@@ -145,7 +145,6 @@ public class MemoryCalendarSearchService implements CalendarSearchService {
     record CalendarEventsDTO(CalendarURL calendarURL,
                              HashMap<String, EventEntry> eventsByKey) {
         static final boolean DELETED = true;
-        static final boolean SHOULD_REPLACE = true;
 
         record EventEntry(EventFields event, boolean deleted, Optional<Integer> lastSequence) {
             static EventEntry from(EventFields event) {
@@ -177,13 +176,10 @@ public class MemoryCalendarSearchService implements CalendarSearchService {
             Optional<Integer> oldSeq = existing.flatMap(EventFields::sequence);
             Optional<Integer> newSeq = incoming.sequence();
 
-            if (oldSeq.isEmpty()) {
-                return SHOULD_REPLACE;
-            }
-            if (newSeq.isEmpty()) {
-                return SHOULD_REPLACE;
-            }
-            return newSeq.get() > oldSeq.get();
+            boolean hasNoExistingSequence = oldSeq.isEmpty();
+            boolean hasNoIncomingSequence = newSeq.isEmpty();
+            boolean incomingIsNewer = oldSeq.isPresent() && newSeq.isPresent() && newSeq.get() > oldSeq.get();
+            return hasNoExistingSequence || hasNoIncomingSequence || incomingIsNewer;
         }
 
         List<EventFields> visibleEvents() {

--- a/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
@@ -70,6 +70,11 @@ public class MemoryCalendarSearchService implements CalendarSearchService {
     }
 
     @Override
+    public Mono<Void> reindex(AccountId accountId, CalendarEvents calendarEvents) {
+        return Mono.fromRunnable(() -> indexStore.put(accountId, calendarEvents.eventUid(), CalendarEventsDTO.from(calendarEvents)));
+    }
+
+    @Override
     public Mono<Void> delete(AccountId accountId, EventUid eventUid) {
         return Mono.fromRunnable(() -> indexStore.remove(accountId, eventUid));
     }

--- a/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
@@ -1367,7 +1367,7 @@ public interface CalendarSearchServiceContract {
             .build();
 
         testee().index(accountId, CalendarEvents.of(masterV1, recurrence)).block();
-        testee().index(accountId, CalendarEvents.of(masterV2)).block();
+        testee().index(accountId, CalendarEvents.of(masterV2, recurrence)).block();
 
         CALMLY_AWAIT.untilAsserted(() -> {
             List<EventFields> results = testee().search(accountId, simpleQuery(""))

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
@@ -76,6 +76,7 @@ public class CalendarEventIndexMappingFactory {
         String IS_RECURRENT_MASTER = "isRecurrentMaster";
         String CLAZZ = "clazz";
         String VIDEOCONFERENCE_URL = "videoconferenceUrl";
+        String SEQUENCE = "sequence";
     }
 
     interface CalendarAnalyzers {

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
@@ -40,6 +40,7 @@ import org.opensearch.client.opensearch._types.analysis.TokenFilter;
 import org.opensearch.client.opensearch._types.analysis.TokenFilterDefinition;
 import org.opensearch.client.opensearch._types.mapping.BooleanProperty;
 import org.opensearch.client.opensearch._types.mapping.DateProperty;
+import org.opensearch.client.opensearch._types.mapping.IntegerNumberProperty;
 import org.opensearch.client.opensearch._types.mapping.KeywordProperty;
 import org.opensearch.client.opensearch._types.mapping.ObjectProperty;
 import org.opensearch.client.opensearch._types.mapping.Property;
@@ -142,6 +143,7 @@ public class CalendarEventIndexMappingFactory {
         Property nonIndexedDateProperty = new Property(new DateProperty.Builder().index(false).build());
         Property nonIndexedKeywordProperty = new Property(new KeywordProperty.Builder().index(false).build());
         Property nonIndexedBooleanProperty = new Property(new BooleanProperty.Builder().index(false).build());
+        Property nonIndexedIntegerProperty = new Property(new IntegerNumberProperty.Builder().index(false).build());
         Property indexedKeywordProperty = new Property(new KeywordProperty.Builder().index(true).build());
 
         Property emailTextProperty = new TextProperty.Builder()
@@ -183,6 +185,7 @@ public class CalendarEventIndexMappingFactory {
                 .put(CalendarFields.ALL_DAY, nonIndexedBooleanProperty)
                 .put(CalendarFields.IS_RECURRENT_MASTER, nonIndexedBooleanProperty)
                 .put(CalendarFields.VIDEOCONFERENCE_URL, nonIndexedKeywordProperty)
+                .put(CalendarFields.SEQUENCE, nonIndexedIntegerProperty)
                 .build())
             .build();
     }

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
@@ -95,7 +95,7 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.ACCOUNT_ID) St
                 .toList(),
             eventFields.videoconferenceUrl(),
             eventFields.calendarURL().serialize(),
-            eventFields.sequence());
+            eventFields.sequence().orElse(null));
     }
 
     public EventFields toEventFields() {

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
@@ -46,7 +46,8 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.ACCOUNT_ID) St
                                      @JsonProperty(CalendarFields.ATTENDEES) List<SimplePerson> attendees,
                                      @JsonProperty(CalendarFields.RESOURCES) List<SimplePerson> resources,
                                      @JsonProperty(CalendarFields.VIDEOCONFERENCE_URL) String videoconferenceUrl,
-                                     @JsonProperty(CalendarFields.CALENDAR_URL) String calendarURL) {
+                                     @JsonProperty(CalendarFields.CALENDAR_URL) String calendarURL,
+                                     @JsonProperty(CalendarFields.SEQUENCE) Integer sequence) {
 
     public static class DeserializeException extends RuntimeException {
         public DeserializeException(String message, Throwable cause) {
@@ -93,7 +94,8 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.ACCOUNT_ID) St
                 .map(SimplePerson::from)
                 .toList(),
             eventFields.videoconferenceUrl(),
-            eventFields.calendarURL().serialize());
+            eventFields.calendarURL().serialize(),
+            eventFields.sequence());
     }
 
     public EventFields toEventFields() {
@@ -123,6 +125,9 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.ACCOUNT_ID) St
         }
         if (isRecurrentMaster != null) {
             builder.isRecurrentMaster(isRecurrentMaster);
+        }
+        if (sequence != null) {
+            builder.sequence(sequence);
         }
 
         return builder.build();

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchModule.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchModule.java
@@ -107,7 +107,6 @@ public class OpensearchCalendarSearchModule extends AbstractModule {
             .doOnError(e -> LOGGER.warn("Error establishing OpenSearch connection. Next retry scheduled in {}",
                 DurationFormatUtils.formatDurationWords(waitDelay.toMillis(), suppressLeadingZeroElements, suppressTrailingZeroElements), e))
             .retryWhen(Retry.backoff(configuration.getMaxRetries(), waitDelay).scheduler(Schedulers.boundedElastic()))
-            .publishOn(Schedulers.boundedElastic())
             .block();
     }
 }

--- a/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpenSearchCalendarDeletionTaskStepTest.java
+++ b/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpenSearchCalendarDeletionTaskStepTest.java
@@ -26,6 +26,10 @@ import org.apache.james.backends.opensearch.OpenSearchConfiguration;
 import org.apache.james.backends.opensearch.ReactorOpenSearchClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
 
 import com.linagora.calendar.storage.eventsearch.CalendarSearchService;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchDeletionTaskStep;
@@ -52,7 +56,11 @@ public class OpenSearchCalendarDeletionTaskStepTest implements CalendarSearchDel
             .createIndexAndAliases(client, Optional.of(calendarEventIndexMappingFactory.indexSettings(CALENDAR_EVENT_OPENSEARCH_CONFIGURATION)),
                 Optional.of(calendarEventIndexMappingFactory.createTypeMapping()));
 
-        calendarSearchService = new OpensearchCalendarSearchService(client, CALENDAR_EVENT_OPENSEARCH_CONFIGURATION);
+        RestClient lowLevelClient = client.getLowLevelClient();
+        RestClientTransport transport = new RestClientTransport(lowLevelClient, new JacksonJsonpMapper());
+        OpenSearchAsyncClient openSearchAsyncClient = new OpenSearchAsyncClient(transport);
+
+        calendarSearchService = new OpensearchCalendarSearchService(client, openSearchAsyncClient, CALENDAR_EVENT_OPENSEARCH_CONFIGURATION);
         testee = new CalendarSearchDeletionTaskStep(calendarSearchService);
     }
 

--- a/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchServiceTest.java
+++ b/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchServiceTest.java
@@ -26,6 +26,10 @@ import org.apache.james.backends.opensearch.OpenSearchConfiguration;
 import org.apache.james.backends.opensearch.ReactorOpenSearchClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
 
 import com.linagora.calendar.storage.eventsearch.CalendarSearchService;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchServiceContract;
@@ -50,7 +54,11 @@ public class OpensearchCalendarSearchServiceTest implements CalendarSearchServic
             .createIndexAndAliases(client, Optional.of(calendarEventIndexMappingFactory.indexSettings(CALENDAR_EVENT_OPENSEARCH_CONFIGURATION)),
                 Optional.of(calendarEventIndexMappingFactory.createTypeMapping()));
 
-        calendarSearchService = new OpensearchCalendarSearchService(client, CALENDAR_EVENT_OPENSEARCH_CONFIGURATION);
+        RestClient lowLevelClient = client.getLowLevelClient();
+        RestClientTransport transport = new RestClientTransport(lowLevelClient, new JacksonJsonpMapper());
+        OpenSearchAsyncClient openSearchAsyncClient = new OpenSearchAsyncClient(transport);
+
+        calendarSearchService = new OpensearchCalendarSearchService(client, openSearchAsyncClient, CALENDAR_EVENT_OPENSEARCH_CONFIGURATION);
     }
 
     @Override

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -4,6 +4,30 @@ This document describes breaking changes and migration steps required when upgra
 
 ## [UNRELEASED]
 
+### Added sequence field to Calendar Event index mapping
+
+Date: 03/12/2025
+
+We added the `sequence` field to support proper event versioning and conflict resolution during indexing.  
+This field must be declared in the OpenSearch mapping as an `integer` (non‑indexed).
+
+If you have an existing OpenSearch index for calendar events, you need to add the `sequence` field to your
+index mapping:
+
+Add the new field to your existing index using the OpenSearch API:
+
+```bash
+PUT /calendar_events/_mapping
+{
+  "properties": {
+    "sequence": {
+      "type": "integer",
+      "index": false
+    }
+  }
+}
+```
+
 ### Added videoconferenceUrl field to Event Search API
 
 Date: 01/12/2025


### PR DESCRIPTION


resolve https://github.com/linagora/twake-calendar-side-service/issues/470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an event sequence field propagated through ingestion, storage, indexing and search; indexing now supports sequence-aware upserts and a new reindex operation.
  * Event Search API now returns a videoconferenceUrl when available.

* **Bug Fixes**
  * Safer parsing and validation of sequence values with guarded handling and logged warnings for malformed input.

* **Tests**
  * Extensive tests for sequence precedence, update rules, recurrence master/instance behavior and reindex semantics.

* **Documentation**
  * Upgrade notes: new non-indexed integer sequence mapping and sample API usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->