### PR TITLE
ISSUE-459 [WebSocket] Implement WebSocket Ticket Authentication System

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/CalendarTicketRoutesTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/CalendarTicketRoutesTest.java
@@ -1,0 +1,193 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.app.restapi.routes;
+
+import static com.linagora.calendar.app.AppTestHelper.BY_PASS_MODULE;
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static io.restassured.config.EncoderConfig.encoderConfig;
+import static io.restassured.config.RestAssuredConfig.newConfig;
+import static io.restassured.http.ContentType.JSON;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.apache.james.backends.rabbitmq.RabbitMQExtension.IsolationPolicy.WEAK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+
+import org.apache.http.HttpStatus;
+import org.apache.james.backends.rabbitmq.RabbitMQExtension;
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.utils.GuiceProbe;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.calendar.app.TwakeCalendarConfiguration;
+import com.linagora.calendar.app.TwakeCalendarExtension;
+import com.linagora.calendar.app.TwakeCalendarGuiceServer;
+import com.linagora.calendar.app.modules.CalendarDataProbe;
+import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.restapi.RestApiServerProbe;
+import com.linagora.tmail.james.jmap.ticket.TicketManager;
+import com.linagora.tmail.james.jmap.ticket.TicketValue;
+
+import io.restassured.RestAssured;
+import io.restassured.authentication.PreemptiveBasicAuthScheme;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import reactor.core.publisher.Mono;
+
+public class CalendarTicketRoutesTest {
+
+    static class TicketManagerProbe implements GuiceProbe {
+        private final TicketManager ticketManager;
+
+        @Inject
+        TicketManagerProbe(TicketManager ticketManager) {
+            this.ticketManager = ticketManager;
+        }
+
+        public Username validate(String ticket, String inetAddressValue) throws UnknownHostException {
+            TicketValue ticketValue = new TicketValue(UUID.fromString(ticket));
+            InetAddress inetAddress = InetAddress.getByName(inetAddressValue);
+            return Mono.from(ticketManager.validate(ticketValue, inetAddress)).block();
+        }
+    }
+
+    private static final String DOMAIN = "open-paas.ltd";
+    private static final String PASSWORD = "secret";
+    private static final Username USERNAME = Username.fromLocalPartWithDomain("bob", DOMAIN);
+
+    @RegisterExtension
+    @Order(1)
+    private static RabbitMQExtension rabbitMQExtension = RabbitMQExtension.singletonRabbitMQ()
+        .isolationPolicy(WEAK);
+
+    @RegisterExtension
+    @Order(2)
+    static TwakeCalendarExtension extension = new TwakeCalendarExtension(
+        TwakeCalendarConfiguration.builder()
+            .configurationFromClasspath()
+            .userChoice(TwakeCalendarConfiguration.UserChoice.MEMORY)
+            .dbChoice(TwakeCalendarConfiguration.DbChoice.MEMORY),
+        BY_PASS_MODULE.apply(rabbitMQExtension),
+        DavModuleTestHelper.BY_PASS_MODULE,
+        binder -> Multibinder.newSetBinder(binder, GuiceProbe.class)
+            .addBinding().to(TicketManagerProbe.class));
+
+    @BeforeEach
+    void setUp(TwakeCalendarGuiceServer server) {
+        server.getProbe(CalendarDataProbe.class).addDomain(Domain.of(DOMAIN));
+        server.getProbe(CalendarDataProbe.class)
+            .addUserToRepository(USERNAME, PASSWORD);
+
+        int restApiPort = server.getProbe(RestApiServerProbe.class).getPort().getValue();
+        PreemptiveBasicAuthScheme auth = new PreemptiveBasicAuthScheme();
+        auth.setUserName(USERNAME.asString());
+        auth.setPassword(PASSWORD);
+
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+            .setContentType(ContentType.JSON)
+            .setAccept(ContentType.JSON)
+            .setAuth(auth)
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
+            .setPort(restApiPort)
+            .setBasePath("")
+            .build();
+    }
+
+    @Test
+    void shouldReturnTicketWhenAuthenticatedUserRequestsWs(TwakeCalendarGuiceServer server) throws UnknownHostException {
+        String response = given()
+            .when()
+            .post("/ws/ticket")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                     "clientAddress": "${json-unit.ignore}",
+                     "value": "${json-unit.ignore}",
+                     "generatedOn": "${json-unit.ignore}",
+                     "validUntil": "${json-unit.ignore}",
+                     "username": "${json-unit.ignore}"
+                 }""");
+
+        String ticketValue = JsonPath.from(response).getString("value");
+        String clientAddress = JsonPath.from(response).getString("clientAddress");
+
+        Username claimedUser = server.getProbe(TicketManagerProbe.class).validate(ticketValue, clientAddress);
+        assertThat(claimedUser).isEqualTo(USERNAME);
+    }
+
+    @Test
+    void shouldRejectTicketCreationWhenAuthenticationFails() {
+        String response = given()
+            .auth().preemptive().basic(USERNAME.asString(), "wrong-password")
+        .when()
+            .post("/ws/ticket")
+        .then()
+            .statusCode(HttpStatus.SC_UNAUTHORIZED)
+            .extract()
+            .body().asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                   {
+                    "type":"about:blank",
+                    "status":401,
+                    "detail":"Wrong credentials provided"
+                }""");
+    }
+
+    @Test
+    void shouldRevokeTicketSuccessfully() {
+        String responseBody = when()
+            .post("/ws/ticket")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .body()
+            .asString();
+
+        String ticketValue = JsonPath.from(responseBody).getString("value");
+
+        given()
+            .when()
+        .when()
+            .delete("/ws/ticket/" + ticketValue)
+            .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+}

--- a/calendar-rest-api/pom.xml
+++ b/calendar-rest-api/pom.xml
@@ -53,6 +53,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>james-server-jmap</artifactId>
         </dependency>

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -64,6 +64,7 @@ import com.linagora.calendar.restapi.auth.OidcEndpointsInfoResolver;
 import com.linagora.calendar.restapi.auth.OidcFallbackCookieAuthenticationStrategy;
 import com.linagora.calendar.restapi.routes.AvatarRoute;
 import com.linagora.calendar.restapi.routes.CalendarSearchRoute;
+import com.linagora.calendar.restapi.routes.CalendarTicketRoutes;
 import com.linagora.calendar.restapi.routes.CheckTechnicalUserTokenRoute;
 import com.linagora.calendar.restapi.routes.ConfigurationRoute;
 import com.linagora.calendar.restapi.routes.DomainRoute;
@@ -103,6 +104,8 @@ import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolve
 import com.linagora.calendar.storage.model.Aud;
 import com.linagora.calendar.storage.secretlink.SecretLinkPermissionChecker;
 import com.linagora.calendar.storage.secretlink.SecretLinkPermissionChecker.NoopPermissionChecker;
+import com.linagora.tmail.james.jmap.ticket.TicketManager;
+import com.linagora.tmail.james.jmap.ticket.TicketStore;
 
 public class RestApiModule extends AbstractModule {
 
@@ -142,6 +145,7 @@ public class RestApiModule extends AbstractModule {
         routes.addBinding().to(ResourceIconRoute.class);
         routes.addBinding().to(ResourceParticipationRoute.class);
         routes.addBinding().to(ResourceRoute.class);
+        routes.addBinding().to(CalendarTicketRoutes.class);
 
         Multibinder<AuthenticationStrategy> authenticationStrategies = Multibinder.newSetBinder(binder(), AuthenticationStrategy.class);
         authenticationStrategies.addBinding().to(BasicAuthenticationStrategy.class);
@@ -296,5 +300,11 @@ public class RestApiModule extends AbstractModule {
     @Named("language")
     SettingsBasedResolver provideLocaleResolver(ConfigurationResolver configurationResolver, SimpleSessionProvider sessionProvider) {
         return SettingsBasedResolver.of(configurationResolver, sessionProvider, Set.of(SettingsBasedResolver.LanguageSettingReader.INSTANCE));
+    }
+
+    @Provides
+    @Singleton
+    TicketManager provideTicketManager(Clock clock, TicketStore ticketStore) {
+        return new TicketManager(clock, ticketStore, false);
     }
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -109,6 +109,8 @@ import com.linagora.tmail.james.jmap.ticket.TicketStore;
 
 public class RestApiModule extends AbstractModule {
 
+    private static final boolean TICKET_IP_VALIDATION_DISABLED = false;
+
     public interface Audiences {
         List<Aud> get();
     }
@@ -305,6 +307,6 @@ public class RestApiModule extends AbstractModule {
     @Provides
     @Singleton
     TicketManager provideTicketManager(Clock clock, TicketStore ticketStore) {
-        return new TicketManager(clock, ticketStore, false);
+        return new TicketManager(clock, ticketStore, TICKET_IP_VALIDATION_DISABLED);
     }
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CalendarTicketRoutes.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CalendarTicketRoutes.java
@@ -1,0 +1,40 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.jmap.http.Authenticator;
+
+import com.linagora.tmail.james.jmap.ticket.TicketManager;
+import com.linagora.tmail.james.jmap.ticket.TicketRoutes;
+
+public class CalendarTicketRoutes extends TicketRoutes {
+
+    @Inject
+    public CalendarTicketRoutes(Authenticator authenticator,
+                                TicketManager ticketManager) {
+        super(authenticator, ticketManager);
+    }
+
+    @Override
+    public String baseEndpoint() {
+        return "ws/ticket";
+    }
+}

--- a/docs/apis/ticketAuthentication.md
+++ b/docs/apis/ticketAuthentication.md
@@ -1,0 +1,47 @@
+# Ticket Authentication API
+
+This document describes the Ticket Authentication endpoints introduced in the side service.  
+---
+
+## 1. Purpose
+
+Ticket Authentication provides a lightweight API for generating short‑lived tickets.  
+These tickets are used mainly for authenticating WebSocket connections.
+
+---
+
+## 2. Endpoints
+
+### **POST /ws/ticket**
+Generate a new ticket for the authenticated user.
+
+**Sample request**
+```
+POST /ws/ticket
+Authorization: Bearer <oidc-token>
+```
+
+**Sample response**
+```
+HTTP/1.1 200 OK
+{
+    "clientAddress": "127.0.0.1",
+    "value": "e7321534-b843-45aa-bca7-157f84dca424",
+    "generatedOn": "2025-11-21T03:17:08Z",
+    "validUntil": "2025-11-21T03:18:08Z",
+    "username": "bob@open-paas.ltd"
+}
+```
+
+### **DELETE /ws/ticket**
+Invalidate an existing ticket
+
+**Sample request**
+```
+DELETE /ws/ticket?ticket=TICKET_v1_xxx
+```
+
+**Sample response**
+```
+204 No Content
+```

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -30,6 +30,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>apache-james-mailbox-store</artifactId>
         </dependency>

--- a/storage-api/src/main/java/com/linagora/calendar/storage/MemoryStorageModule.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/MemoryStorageModule.java
@@ -37,6 +37,8 @@ import com.linagora.calendar.storage.eventsearch.CalendarSearchService;
 import com.linagora.calendar.storage.eventsearch.MemoryCalendarSearchService;
 import com.linagora.calendar.storage.secretlink.MemorySecretLinkStore;
 import com.linagora.calendar.storage.secretlink.SecretLinkStore;
+import com.linagora.tmail.james.jmap.ticket.MemoryTicketStore;
+import com.linagora.tmail.james.jmap.ticket.TicketStore;
 
 public class MemoryStorageModule extends AbstractModule {
     @Override
@@ -71,6 +73,9 @@ public class MemoryStorageModule extends AbstractModule {
 
         bind(MemoryResourceDAO.class).in(Scopes.SINGLETON);
         bind(ResourceDAO.class).to(MemoryResourceDAO.class);
+
+        bind(MemoryTicketStore.class).in(Scopes.SINGLETON);
+        bind(TicketStore.class).to(MemoryTicketStore.class);
     }
 
     @Provides

--- a/storage-mongodb/pom.xml
+++ b/storage-mongodb/pom.xml
@@ -40,6 +40,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jmap-extensions-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>${james.groupId}</groupId>
             <artifactId>testing-base</artifactId>
             <scope>test</scope>

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBCollectionFactory.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBCollectionFactory.java
@@ -36,12 +36,14 @@ public class MongoDBCollectionFactory {
     public static final String DOMAINS = MongoDBOpenPaaSDomainDAO.COLLECTION;
     public static final String SECRETLINKS = MongoDBSecretLinkStore.COLLECTION;
     public static final String ALARM_EVENT_LEDGE = MongoDBAlarmEventLedgerDAO.COLLECTION;
+    public static final String AUTH_TICKETS = MongoDBTicketDAO.COLLECTION;
 
     public static void initialize(MongoDatabase database) {
         createUsersCollection(database);
         createDomainsCollection(database);
         createSecretLinksCollection(database);
         createAlarmEventLedgeCollection(database);
+        createAuthTicketsCollection(database);
     }
 
     private static void createUsersCollection(MongoDatabase database) {
@@ -110,6 +112,13 @@ public class MongoDBCollectionFactory {
             Mono.from(database.createCollection(ALARM_EVENT_LEDGE)).block();
         }
         MongoDBAlarmEventLedgerDAO.declareIndex(database.getCollection(ALARM_EVENT_LEDGE)).block();
+    }
+
+    private static void createAuthTicketsCollection(MongoDatabase database) {
+        if (!collectionExists(database, AUTH_TICKETS)) {
+            Mono.from(database.createCollection(AUTH_TICKETS)).block();
+        }
+        MongoDBTicketDAO.declareIndex(database.getCollection(AUTH_TICKETS)).block();
     }
 
     private static boolean collectionExists(MongoDatabase database, String collectionName) {

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBStorageModule.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBStorageModule.java
@@ -46,6 +46,7 @@ import com.linagora.calendar.storage.ResourceDAO;
 import com.linagora.calendar.storage.UploadedFileDAO;
 import com.linagora.calendar.storage.configuration.UserConfigurationDAO;
 import com.linagora.calendar.storage.secretlink.SecretLinkStore;
+import com.linagora.tmail.james.jmap.ticket.TicketStore;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 
 public class MongoDBStorageModule extends AbstractModule {
@@ -76,6 +77,9 @@ public class MongoDBStorageModule extends AbstractModule {
         bind(AlarmEventLeaseProvider.class).to(MongoAlarmEventLeaseProvider.class);
 
         bind(ResourceDAO.class).to(MongoDBResourceDAO.class);
+
+        bind(MongoDBTicketDAO.class).in(Scopes.SINGLETON);
+        bind(TicketStore.class).to(MongoDBTicketDAO.class);
 
         Multibinder.newSetBinder(binder(), HealthCheck.class)
             .addBinding()

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBTicketDAO.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBTicketDAO.java
@@ -1,0 +1,109 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage.mongodb;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.apache.james.jmap.core.UTCDate;
+import org.bson.Document;
+
+import com.github.fge.lambdas.Throwing;
+import com.linagora.tmail.james.jmap.ticket.Ticket;
+import com.linagora.tmail.james.jmap.ticket.TicketStore;
+import com.linagora.tmail.james.jmap.ticket.TicketValue;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scala.publisher.SMono;
+import scala.runtime.BoxedUnit;
+
+public class MongoDBTicketDAO implements TicketStore {
+    public static final String COLLECTION = "auth_tickets";
+
+    private static final String FIELD_ID = "_id";
+    private static final String FIELD_USERNAME = "username";
+    private static final String FIELD_CLIENT_ADDRESS = "clientAddress";
+    private static final String FIELD_GENERATED_ON = "generatedOn";
+    private static final String FIELD_VALID_UNTIL = "validUntil";
+    private static final ZoneId ZONE_UTC = ZoneId.of("UTC");
+
+    private final MongoCollection<Document> collection;
+
+    @Inject
+    public MongoDBTicketDAO(MongoDatabase database) {
+        this.collection = database.getCollection(COLLECTION);
+    }
+
+    public static Mono<Void> declareIndex(MongoCollection<Document> collection) {
+        return Mono.from(collection.createIndex(
+                Indexes.ascending(FIELD_VALID_UNTIL),
+                new IndexOptions().expireAfter(0L, TimeUnit.SECONDS)
+                    .name("auth_tickets_ttl_validUntil")))
+            .then();
+    }
+
+    private Document toDocument(Ticket ticket) {
+        return new Document()
+            .append(FIELD_ID, ticket.value().value().toString())
+            .append(FIELD_USERNAME, ticket.username().asString())
+            .append(FIELD_CLIENT_ADDRESS, ticket.clientAddress().getHostAddress())
+            .append(FIELD_GENERATED_ON, Date.from(ticket.generatedOn().date().toInstant()))
+            .append(FIELD_VALID_UNTIL, Date.from(ticket.validUntil().date().toInstant()));
+    }
+
+    private Ticket toTicket(Document doc) throws UnknownHostException {
+        return new Ticket(InetAddress.getByName(doc.getString(FIELD_CLIENT_ADDRESS)),
+            new TicketValue(UUID.fromString(doc.getString(FIELD_ID))),
+            UTCDate.from(doc.getDate(FIELD_GENERATED_ON), ZONE_UTC),
+            UTCDate.from(doc.getDate(FIELD_VALID_UNTIL), ZONE_UTC),
+            Username.of(doc.getString(FIELD_USERNAME)));
+    }
+
+    @Override
+    public SMono<BoxedUnit> persist(Ticket ticket) {
+        Mono<Void> mono = Mono.from(collection.insertOne(toDocument(ticket))).then();
+        return SMono.fromPublisher(mono).map(any -> BoxedUnit.UNIT);
+    }
+
+    @Override
+    public SMono<Ticket> retrieve(TicketValue ticketValue) {
+        return SMono.fromPublisher(Mono.from(collection.find(Filters.eq(FIELD_ID, ticketValue.value().toString()))
+                .first())
+            .map(Throwing.function(this::toTicket)));
+    }
+
+    @Override
+    public SMono<BoxedUnit> delete(TicketValue ticketValue) {
+        Mono<Void> mono = Mono.from(collection.deleteOne(Filters.eq(FIELD_ID, ticketValue.value().toString())))
+            .then();
+        return SMono.fromPublisher(mono).map(any -> BoxedUnit.UNIT);
+    }
+}

--- a/storage-mongodb/src/test/java/com/linagora/calendar/storage/mongodb/MongoDBTicketDAOTest.java
+++ b/storage-mongodb/src/test/java/com/linagora/calendar/storage/mongodb/MongoDBTicketDAOTest.java
@@ -1,0 +1,45 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage.mongodb;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.tmail.james.jmap.ticket.TicketStore;
+import com.linagora.tmail.james.jmap.ticket.TicketStoreContract;
+
+public class MongoDBTicketDAOTest implements TicketStoreContract {
+
+    @RegisterExtension
+    static DockerMongoDBExtension mongo = new DockerMongoDBExtension(List.of(MongoDBTicketDAO.COLLECTION));
+
+    private MongoDBTicketDAO mongoDBTicketDAO;
+
+    @BeforeEach
+    void setUp() {
+        mongoDBTicketDAO = new MongoDBTicketDAO(mongo.getDb());
+    }
+
+    @Override
+    public TicketStore testee() {
+        return mongoDBTicketDAO;
+    }
+}


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/459

require tmail-backend upstream: 
- https://github.com/linagora/tmail-backend/pull/2018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ticket-based WebSocket authentication: create and revoke short-lived tickets; REST endpoints exposed under ws/ticket.
  * Pluggable ticket storage with in-memory and MongoDB-backed implementations.

* **Tests**
  * New integration and storage tests validating ticket lifecycle: creation, authentication failure, validation, and revocation.

* **Documentation**
  * Added API docs describing ticket authentication endpoints and examples.

* **Chores**
  * Wiring to register ticket manager and stores across modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->