### PR TITLE
ISSUE-469 [WebSocket] feat: API retrieve SyncToken from Sabre

### DIFF
--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
@@ -605,6 +605,7 @@ public class CalDavClient extends DavClient {
     private Mono<SyncToken> parseSyncToken(String body, String uri) {
         return Mono.fromCallable(() -> OBJECT_MAPPER.readTree(body))
             .flatMap(jsonNode -> Mono.justOrEmpty(jsonNode.path(SYNC_TOKEN_PROPERTY).asText(null)))
+            .filter(StringUtils::isNotEmpty)
             .map(SyncToken::new)
             .switchIfEmpty(Mono.error(() -> new DavClientException("Missing '%s' when retrieving sync token for: %s".formatted(SYNC_TOKEN_PROPERTY, uri))));
     }

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
@@ -80,6 +80,8 @@ public class CalDavClient extends DavClient {
     public static final String JSON_CHARSET_UTF_8 = "application/json;charset=UTF-8";
     public static final String DEFAULT_JSON_ACCEPT = "application/json, text/plain, */*";
 
+    private static final String SYNC_TOKEN_PROPERTY = "calendarserver:ctag";
+
     protected static final Duration DEFAULT_IMIP_CALLBACK_RESPONSE_TIMEOUT = Duration.ofMinutes(3);
 
     public record NewCalendar(@JsonProperty("id") String id,
@@ -108,7 +110,7 @@ public class CalDavClient extends DavClient {
     private static final String CONTENT_TYPE_JSON = "application/json";
     private static final HttpMethod REPORT_METHOD = HttpMethod.valueOf("REPORT");
 
-    private Duration imipCallbackResponseTimeout;
+    private final Duration imipCallbackResponseTimeout;
 
     public CalDavClient(DavConfiguration config, TechnicalTokenService technicalTokenService) throws SSLException {
         super(config, technicalTokenService);
@@ -572,4 +574,39 @@ public class CalDavClient extends DavClient {
         CalendarURL calendarURL = CalendarURL.from(resourceId.asOpenPaaSId());
         return patchReadWriteDelegations(domainId, calendarURL, List.of(), administrators);
     }
+
+    public Mono<SyncToken> retrieveSyncToken(Username username, CalendarURL calendarUrl) {
+        String uri = calendarUrl.asUri() + ".json";
+
+        return httpClientWithImpersonation(username)
+            .headers(headers -> headers.add(HttpHeaderNames.ACCEPT, CONTENT_TYPE_JSON))
+            .request(HttpMethod.GET)
+            .uri(uri)
+            .responseSingle((response, content) -> {
+                int status = response.status().code();
+                return content.asString(StandardCharsets.UTF_8)
+                    .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                    .flatMap(body -> switch (status) {
+                        case HttpStatus.SC_OK -> parseSyncToken(body, uri);
+                        case HttpStatus.SC_NOT_FOUND -> Mono.error(new CalendarNotFoundException(calendarUrl));
+                        case HttpStatus.SC_FORBIDDEN -> {
+                            LOGGER.debug("User {} has no rights to read calendar {}", username.asString(), uri);
+                            yield Mono.empty();
+                        }
+                        default -> Mono.error(() -> new DavClientException("""
+                            Unexpected response when retrieving sync-token for '%s'
+                            Status: %d
+                            Body: %s
+                            """.formatted(uri, status, body)));
+                    });
+            });
+    }
+
+    private Mono<SyncToken> parseSyncToken(String body, String uri) {
+        return Mono.fromCallable(() -> OBJECT_MAPPER.readTree(body))
+            .flatMap(jsonNode -> Mono.justOrEmpty(jsonNode.path(SYNC_TOKEN_PROPERTY).asText(null)))
+            .map(SyncToken::new)
+            .switchIfEmpty(Mono.error(() -> new DavClientException("Missing '%s' when retrieving sync token for: %s".formatted(SYNC_TOKEN_PROPERTY, uri))));
+    }
+
 }

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/SyncToken.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/SyncToken.java
@@ -1,0 +1,30 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Preconditions;
+
+public record SyncToken(String value) {
+
+    public SyncToken {
+        Preconditions.checkArgument(StringUtils.isNotEmpty(value), "sync token value must not be empty");
+    }
+}


### PR DESCRIPTION
ref https://github.com/linagora/twake-calendar-side-service/issues/469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added calendar synchronization token retrieval with permission-aware behavior (owner, delegate, public, no-access) and improved HTTP error handling.
  * Introduced a SyncToken type that enforces a non-empty token value.

* **Tests**
  * Added comprehensive tests covering sync-token retrieval across multiple permission and not-found scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->