### PR TITLE
ISSUE-513 Configuration: avoid alarmEmails null value

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
@@ -994,7 +994,7 @@ class TwakeCalendarGuiceServerTest  {
         String body = given()
             .auth().preemptive().basic(USERNAME.asString(), PASSWORD)
         .when()
-            .get("/api/user").prettyPeek()
+            .get("/api/user")
         .then()
             .statusCode(200)
             .extract()
@@ -1127,7 +1127,7 @@ class TwakeCalendarGuiceServerTest  {
                             "configurations": [
                                 {
                                     "name": "alarmEmails",
-                                    "value": null
+                                    "value": true
                                 }, {
                                     "name":"displayWeekNumbers",
                                     "value":true

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/UserConfigurationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/UserConfigurationRouteTest.java
@@ -428,6 +428,89 @@ class UserConfigurationRouteTest {
     }
 
     @Test
+    void postShouldReturnDefaultTrueForAlarmEmailsWhenNotConfigured() {
+        String body = given()
+            .auth().preemptive().basic(USERNAME.asString(), PASSWORD)
+            .body("""
+                [ {
+                  "name" : "calendar",
+                  "keys" : [ "alarmEmails" ]
+                } ]""")
+        .when()
+            .post("/api/configurations")
+        .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(body).isEqualTo("""
+            [
+                {
+                    "name": "calendar",
+                    "configurations": [
+                        {
+                            "name": "alarmEmails",
+                            "value": true
+                        }
+                    ]
+                }
+            ]""");
+    }
+
+    @Test
+    void postShouldReturnFalseForAlarmEmailsWhenConfiguredFalse() {
+        // Save user configuration with alarmEmails = false
+        given()
+            .body("""
+                [
+                  {
+                    "name": "calendar",
+                    "configurations": [
+                      {
+                        "name": "alarmEmails",
+                        "value": false
+                      }
+                    ]
+                  }
+                ]
+                """)
+        .when()
+            .put("/api/configurations?scope=user")
+        .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // Then
+        String body = given()
+            .auth().preemptive().basic(USERNAME.asString(), PASSWORD)
+            .body("""
+                [ {
+                  "name" : "calendar",
+                  "keys" : [ "alarmEmails" ]
+                } ]""")
+        .when()
+            .post("/api/configurations")
+        .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(body).isEqualTo("""
+            [
+                {
+                    "name": "calendar",
+                    "configurations": [
+                        {
+                            "name": "alarmEmails",
+                            "value": false
+                        }
+                    ]
+                }
+            ]""");
+    }
+
+    @Test
     void patchShouldReturn204WhenValidRequest() {
         given()
             .body("""

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/UserConfigurationsRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/UserConfigurationsRoute.java
@@ -54,7 +54,7 @@ public class UserConfigurationsRoute extends CalendarRoute {
     public static final Logger LOGGER = LoggerFactory.getLogger(UserConfigurationsRoute.class);
 
     public record ConfigurationEntryDTO(@JsonProperty(value = "name", required = true) String name,
-                                 @JsonProperty(value = "value", required = true)  JsonNode value) {
+                                        @JsonProperty(value = "value", required = true) JsonNode value) {
 
         public ConfigurationEntryDTO {
             Preconditions.checkArgument(StringUtils.isNotBlank(name), "Name cannot be blank");
@@ -63,7 +63,7 @@ public class UserConfigurationsRoute extends CalendarRoute {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record UserConfigDTO(@JsonProperty(value = "name", required = true) String name,
-                         @JsonProperty(value = "configurations", required = true) List<ConfigurationEntryDTO> configurations) {
+                                @JsonProperty(value = "configurations", required = true) List<ConfigurationEntryDTO> configurations) {
 
         public UserConfigDTO {
             Preconditions.checkArgument(StringUtils.isNotBlank(name), "Name cannot be blank");

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/configuration/StoredConfigurationEntryResolver.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/configuration/StoredConfigurationEntryResolver.java
@@ -69,6 +69,8 @@ public class StoredConfigurationEntryResolver implements ConfigurationEntryResol
         return Throwing.function(RestApiConfiguration::getDefaultBusinessHours);
     }
 
+    private static final BooleanNode DEFAULT_ALARM_ENABLED = BooleanNode.TRUE;
+
     private static final Table<ModuleName, ConfigurationKey, Function<RestApiConfiguration, JsonNode>> TABLE = ImmutableTable.<ModuleName, ConfigurationKey, Function<RestApiConfiguration, JsonNode>>builder()
         .put(new ModuleName("core"), new ConfigurationKey("language"), defaultLanguage())
         .put(new ModuleName("core"), new ConfigurationKey("datetime"), defaultTimezone())
@@ -76,7 +78,7 @@ public class StoredConfigurationEntryResolver implements ConfigurationEntryResol
         .put(new ModuleName("linagora.esn.calendar"), new ConfigurationKey("workingDays"), any -> NullNode.getInstance())
         .put(new ModuleName("linagora.esn.calendar"), new ConfigurationKey("hideDeclinedEvents"), any -> NullNode.getInstance())
         .put(new ModuleName("calendar"), new ConfigurationKey("displayWeekNumbers"), any -> BooleanNode.TRUE)
-        .put(new ModuleName("calendar"), new ConfigurationKey("alarmEmails"), any -> NullNode.getInstance())
+        .put(new ModuleName("calendar"), new ConfigurationKey("alarmEmails"), any -> DEFAULT_ALARM_ENABLED)
 
         .build();
 

--- a/docs/apis/openpaasApi.md
+++ b/docs/apis/openpaasApi.md
@@ -193,7 +193,7 @@ Will return user details and configuration:
         "configurations": [
             {
                 "name": "alarmEmails",
-                "value": null
+                "value": true
             }
         ],
         "name": "calendar"


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify alarm email configuration defaults and behavior.

* **Documentation**
  * Updated user profile documentation to reflect alarm email default value.

* **Chores**
  * Adjusted formatting in configuration declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->