### PR TITLE
ISSUE-533 [SaaS] common settings - Update REST API to block updating language when SaaS settings enabled 

### DIFF
--- a/app/src/main/java/com/linagora/calendar/app/TwakeCalendarConfiguration.java
+++ b/app/src/main/java/com/linagora/calendar/app/TwakeCalendarConfiguration.java
@@ -37,7 +37,11 @@ import com.github.fge.lambdas.Throwing;
 public record TwakeCalendarConfiguration(ConfigurationPath configurationPath, JamesDirectoriesProvider directories,
                                          UserChoice userChoice, DbChoice dbChoice, AutoCompleteChoice autoCompleteChoice,
                                          CalendarEventSearchChoice calendarEventSearchChoice,
-                                         boolean redisEnabled) implements Configuration {
+                                         boolean redisEnabled,
+                                         boolean twpSettingEnabled) implements Configuration {
+
+    public static final boolean ENABLED = true;
+
     public static class Builder {
         private Optional<String> rootDirectory;
         private Optional<ConfigurationPath> configurationPath;
@@ -45,6 +49,7 @@ public record TwakeCalendarConfiguration(ConfigurationPath configurationPath, Ja
         private Optional<DbChoice> dbChoice;
         private Optional<AutoCompleteChoice> autoCompleteChoice;
         private Optional<Boolean> redisEnabled;
+        private Optional<Boolean> twpSettingEnabled;
         private Optional<CalendarEventSearchChoice> calendarEventSearchChoice;
 
         private Builder() {
@@ -54,6 +59,7 @@ public record TwakeCalendarConfiguration(ConfigurationPath configurationPath, Ja
             dbChoice = Optional.empty();
             autoCompleteChoice = Optional.empty();
             redisEnabled = Optional.empty();
+            twpSettingEnabled = Optional.empty();
             calendarEventSearchChoice = Optional.empty();
         }
 
@@ -84,6 +90,11 @@ public record TwakeCalendarConfiguration(ConfigurationPath configurationPath, Ja
 
         public Builder enableRedis() {
             redisEnabled = Optional.of(true);
+            return this;
+        }
+
+        public Builder enableTwpSetting() {
+            twpSettingEnabled = Optional.of(true);
             return this;
         }
 
@@ -145,6 +156,11 @@ public record TwakeCalendarConfiguration(ConfigurationPath configurationPath, Ja
 
             boolean redisEnabledValue = redisEnabled.orElseGet(Throwing.supplier(() -> redisConfigurationFileExists(propertiesProvider)));
 
+            boolean twpSettingEnabledValue = this.twpSettingEnabled.orElseGet(Throwing.supplier(() -> {
+                var configuration = propertiesProvider.getConfiguration("configuration");
+                return configuration.getBoolean("twp.settings.enabled", !ENABLED);
+            }));
+
             CalendarEventSearchChoice calendarEventSearchChoice = this.calendarEventSearchChoice.orElseGet(Throwing.supplier(() -> {
                 try {
                     propertiesProvider.getConfiguration("opensearch");
@@ -161,7 +177,8 @@ public record TwakeCalendarConfiguration(ConfigurationPath configurationPath, Ja
                 dbChoice,
                 autoCompleteChoice,
                 calendarEventSearchChoice,
-                redisEnabledValue);
+                redisEnabledValue,
+                twpSettingEnabledValue);
         }
 
         private boolean redisConfigurationFileExists(PropertiesProvider propertiesProvider) throws ConfigurationException {

--- a/app/src/main/java/com/linagora/calendar/app/TwakeCalendarMain.java
+++ b/app/src/main/java/com/linagora/calendar/app/TwakeCalendarMain.java
@@ -76,6 +76,7 @@ import com.linagora.calendar.storage.OIDCTokenCache;
 import com.linagora.calendar.storage.OIDCTokenCacheConfigurationModule;
 import com.linagora.calendar.storage.OpenPaaSUserDeletionTaskStep;
 import com.linagora.calendar.storage.TechnicalUserTokenModule;
+import com.linagora.calendar.storage.configuration.ReadOnlyPropertyProviderModule;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchDeletionTaskStep;
 import com.linagora.calendar.storage.eventsearch.MemoryCalendarSearchService;
 import com.linagora.calendar.storage.ldap.LdapStorageModule;
@@ -136,6 +137,7 @@ public class TwakeCalendarMain {
                     .calendarEventSearch(configuration.calendarEventSearchChoice()),
                 chooseUsersModule(configuration.userChoice()),
                 chooseCacheAndPubSub(configuration.redisEnabled()),
+                chooseTWPCalendarSetting(configuration.twpSettingEnabled()),
                 new FileUploadConfigurationModule(),
                 new RestApiModule(),
                 new TaskManagerModule(),
@@ -145,8 +147,7 @@ public class TwakeCalendarMain {
                 new TechnicalUserTokenModule(),
                 new AlarmEventModule(),
                 new SmtpModule(),
-                WEBADMIN,
-                TWP_CALENDAR_SETTINGS_AGGREGATE_MODULE));
+                WEBADMIN));
     }
 
     @FunctionalInterface
@@ -224,4 +225,14 @@ public class TwakeCalendarMain {
             }
         };
     }
+
+    public static Module chooseTWPCalendarSetting(boolean enabled) {
+        if (enabled) {
+            return Modules.combine(TWP_CALENDAR_SETTINGS_AGGREGATE_MODULE,
+                ReadOnlyPropertyProviderModule.WITH_READ_ONLY_LANGUAGE);
+        }
+
+        return ReadOnlyPropertyProviderModule.EMPTY;
+    }
+
 }

--- a/app/src/test/java/com/linagora/calendar/app/LdapTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/LdapTest.java
@@ -49,7 +49,6 @@ import com.google.inject.Module;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.TechnicalTokenService;
 
@@ -116,62 +115,50 @@ class LdapTest {
 
     @Test
     void shouldExposeWebAdminHealthcheck() {
-        Fixture.awaitAtMost.untilAsserted(() -> {
-            String body = given()
-            .when()
-                .get("/healthcheck")
-            .then()
-                .extract()
-                .body()
-                .asString();
+        String body = given()
+        .when()
+            .get("/healthcheck")
+        .then()
+            .extract()
+            .body()
+            .asString();
 
-            assertThatJson(body).withOptions(IGNORING_ARRAY_ORDER).isEqualTo("""
-                {
-                   "status" : "healthy",
-                   "checks" : [ {
-                     "componentName" : "Guice application lifecycle",
-                     "escapedComponentName" : "Guice%20application%20lifecycle",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "MongoDB",
-                     "escapedComponentName" : "MongoDB",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "LDAP User Server",
-                     "escapedComponentName" : "LDAP%20User%20Server",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "RabbitMQ backend",
-                     "escapedComponentName" : "RabbitMQ%20backend",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "CalendarQueueConsumers",
-                     "escapedComponentName" : "CalendarQueueConsumers",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "RabbitMQDeadLetterQueueEmptiness",
-                     "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                   "componentName": "TWPSettingsDeadLetterQueueHealthCheck",
-                   "escapedComponentName": "TWPSettingsDeadLetterQueueHealthCheck",
-                   "status": "healthy",
-                   "cause": null
-                  }, {
-                   "componentName": "TWPSettingsQueueConsumerHealthCheck",
-                   "escapedComponentName": "TWPSettingsQueueConsumerHealthCheck",
-                   "status": "healthy",
-                   "cause": null
-                  }]
-                }
-                """);
-        });
+        assertThatJson(body).withOptions(IGNORING_ARRAY_ORDER).isEqualTo("""
+            {
+               "status" : "healthy",
+               "checks" : [ {
+                 "componentName" : "Guice application lifecycle",
+                 "escapedComponentName" : "Guice%20application%20lifecycle",
+                 "status" : "healthy",
+                 "cause" : null
+               }, {
+                 "componentName" : "MongoDB",
+                 "escapedComponentName" : "MongoDB",
+                 "status" : "healthy",
+                 "cause" : null
+               }, {
+                 "componentName" : "LDAP User Server",
+                 "escapedComponentName" : "LDAP%20User%20Server",
+                 "status" : "healthy",
+                 "cause" : null
+               }, {
+                 "componentName" : "RabbitMQ backend",
+                 "escapedComponentName" : "RabbitMQ%20backend",
+                 "status" : "healthy",
+                 "cause" : null
+               }, {
+                 "componentName" : "CalendarQueueConsumers",
+                 "escapedComponentName" : "CalendarQueueConsumers",
+                 "status" : "healthy",
+                 "cause" : null
+               }, {
+                 "componentName" : "RabbitMQDeadLetterQueueEmptiness",
+                 "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
+                 "status" : "healthy",
+                 "cause" : null
+               } ]
+            }
+            """);
     }
 
     @Test

--- a/app/src/test/java/com/linagora/calendar/app/MongoTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/MongoTest.java
@@ -42,7 +42,6 @@ import com.google.inject.name.Names;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -129,57 +128,45 @@ class MongoTest {
 
     @Test
     void shouldExposeWebAdminHealthcheck() {
-        Fixture.awaitAtMost.untilAsserted(() -> {
-            String body = given()
+        String body = given()
             .when()
-                .get("/healthcheck")
+            .get("/healthcheck")
             .then()
-                .extract()
-                .body()
-                .asString();
+            .extract()
+            .body()
+            .asString();
 
-            assertThatJson(body).withOptions(IGNORING_ARRAY_ORDER).isEqualTo("""
-                {
-                  "status" : "healthy",
-                  "checks" : [ {
-                    "componentName" : "Guice application lifecycle",
-                    "escapedComponentName" : "Guice%20application%20lifecycle",
-                    "status" : "healthy",
-                    "cause" : null
-                  }, {
-                    "componentName" : "MongoDB",
-                    "escapedComponentName" : "MongoDB",
-                    "status" : "healthy",
-                    "cause" : null
-                  }, {
-                    "componentName" : "RabbitMQ backend",
-                    "escapedComponentName" : "RabbitMQ%20backend",
-                    "status" : "healthy",
-                    "cause" : null
-                  }, {
-                    "componentName" : "RabbitMQDeadLetterQueueEmptiness",
-                    "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
-                    "status" : "healthy",
-                    "cause" : null
-                  }, {
-                    "componentName" : "CalendarQueueConsumers",
-                    "escapedComponentName" : "CalendarQueueConsumers",
-                    "status" : "healthy",
-                    "cause" : null
-                  }, {
-                    "componentName": "TWPSettingsDeadLetterQueueHealthCheck",
-                    "escapedComponentName": "TWPSettingsDeadLetterQueueHealthCheck",
-                    "status": "healthy",
-                    "cause": null
-                  }, {
-                    "componentName": "TWPSettingsQueueConsumerHealthCheck",
-                    "escapedComponentName": "TWPSettingsQueueConsumerHealthCheck",
-                    "status": "healthy",
-                    "cause": null
-                  }]
-                }
-                """);
-        });
+        assertThatJson(body).withOptions(IGNORING_ARRAY_ORDER).isEqualTo("""
+            {
+              "status" : "healthy",
+              "checks" : [ {
+                "componentName" : "Guice application lifecycle",
+                "escapedComponentName" : "Guice%20application%20lifecycle",
+                "status" : "healthy",
+                "cause" : null
+              }, {
+                "componentName" : "MongoDB",
+                "escapedComponentName" : "MongoDB",
+                "status" : "healthy",
+                "cause" : null
+              }, {
+                "componentName" : "RabbitMQ backend",
+                "escapedComponentName" : "RabbitMQ%20backend",
+                "status" : "healthy",
+                "cause" : null
+              }, {
+                "componentName" : "RabbitMQDeadLetterQueueEmptiness",
+                "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
+                "status" : "healthy",
+                "cause" : null
+              }, {
+                "componentName" : "CalendarQueueConsumers",
+                "escapedComponentName" : "CalendarQueueConsumers",
+                "status" : "healthy",
+                "cause" : null
+              } ]
+            }
+            """);
     }
 
     private static void targetRestAPI(TwakeCalendarGuiceServer server) {

--- a/app/src/test/java/com/linagora/calendar/app/TWPSyncSettingsIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TWPSyncSettingsIntegrationTest.java
@@ -23,6 +23,7 @@ import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 import static io.restassured.http.ContentType.JSON;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.apache.james.backends.rabbitmq.RabbitMQExtension.IsolationPolicy.WEAK;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -99,7 +100,8 @@ class TWPSyncSettingsIntegrationTest {
         TwakeCalendarConfiguration.builder()
             .configurationFromClasspath()
             .userChoice(TwakeCalendarConfiguration.UserChoice.MEMORY)
-            .dbChoice(TwakeCalendarConfiguration.DbChoice.MEMORY),
+            .dbChoice(TwakeCalendarConfiguration.DbChoice.MEMORY)
+            .enableTwpSetting(),
         DavModuleTestHelper.RABBITMQ_MODULE.apply(rabbitMQExtension),
         DavModuleTestHelper.BY_PASS_MODULE,
         AppTestHelper.OIDC_BY_PASS_MODULE,
@@ -275,6 +277,108 @@ class TWPSyncSettingsIntegrationTest {
 
             assertThat(updatedLanguage).isEqualTo(LANGUAGE_FR);
         });
+    }
+
+    @Test
+    void shouldRejectLanguageUpdateViaAPIWhenTWPSyncEnabled() {
+        // When: try to manually update language via REST API while TWP sync is enabled
+        given()
+            .body("""
+                [
+                  {
+                    "name": "core",
+                    "configurations": [
+                      {
+                        "name": "language",
+                        "value": "vi"
+                      }
+                    ]
+                  }
+                ]
+                """)
+        .when()
+            .patch("/api/configurations?scope=user")
+        .then()
+            .statusCode(400)
+            .body("error.details", equalTo("Cannot modify read-only settings: language"));
+
+        String languageAfterReject =
+            given()
+                .body(QUERY_LANGUAGE)
+            .when()
+                .post("/api/configurations")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("[0].configurations.find { it.name == 'language' }.value");
+
+        assertThat(languageAfterReject)
+            .as("Language must not be updated when PATCH is rejected")
+            .isEqualTo(LANGUAGE_EN);
+    }
+
+    @Test
+    void shouldAllowPatchNonReadOnlySettingWhenTWPSyncEnabled() {
+        // When: patch another setting (datetime)
+        given()
+            .body("""
+                [
+                  {
+                    "name": "core",
+                    "configurations": [
+                      {
+                        "name": "datetime",
+                        "value": {
+                          "timeZone": "Asia/Ho_Chi_Minh",
+                          "use24hourFormat": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """)
+        .when()
+            .patch("/api/configurations?scope=user")
+        .then()
+            .statusCode(204);
+
+        // Then: datetime is updated, and language is still unchanged
+        String response =
+            given()
+                .body("""
+                    [
+                      {
+                        "name": "core",
+                        "keys": [ "datetime", "language" ]
+                      }
+                    ]
+                    """)
+            .when()
+                .post("/api/configurations")
+            .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                [{
+                    "name": "core",
+                    "configurations": [
+                        {
+                            "name": "datetime",
+                            "value": {
+                                "timeZone": "Asia/Ho_Chi_Minh",
+                                "use24hourFormat": true
+                            }
+                        },
+                        {
+                            "name": "language",
+                            "value": "en"
+                        }
+                    ]
+                }]
+                """);
     }
 
     private void publishAmqpSettingsMessage(String message) {

--- a/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
@@ -61,7 +61,6 @@ import com.google.inject.name.Names;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.app.modules.MemoryAutoCompleteModule;
 import com.linagora.calendar.dav.DavModuleTestHelper;
-import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -133,52 +132,40 @@ class TwakeCalendarGuiceServerTest  {
 
     @Test
     void shouldExposeWebAdminHealthcheck() {
-        Fixture.awaitAtMost.untilAsserted(() -> {
-            String body = given()
-                .when()
-                .get("/healthcheck")
-            .then()
-                .extract()
-                .body()
-                .asString();
+        String body = given()
+        .when()
+            .get("/healthcheck")
+        .then()
+            .extract()
+            .body()
+            .asString();
 
-            assertThatJson(body).withOptions(Option.IGNORING_ARRAY_ORDER).isEqualTo("""
-                {
-                  "status" : "healthy",
-                  "checks" : [ {
-                    "componentName" : "Guice application lifecycle",
-                    "escapedComponentName" : "Guice%20application%20lifecycle",
-                    "status" : "healthy",
-                    "cause" : null
-                  }, {
-                    "componentName" : "RabbitMQDeadLetterQueueEmptiness",
-                    "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
-                    "status" : "healthy",
-                    "cause" : null
-                  }, {
-                    "componentName" : "CalendarQueueConsumers",
-                    "escapedComponentName" : "CalendarQueueConsumers",
-                    "status" : "healthy",
-                    "cause" : null
-                  }, {
-                    "componentName" : "RabbitMQ backend",
-                    "escapedComponentName" : "RabbitMQ%20backend",
-                    "status" : "healthy",
-                    "cause" : null
-                  }, {
-                   "componentName": "TWPSettingsDeadLetterQueueHealthCheck",
-                   "escapedComponentName": "TWPSettingsDeadLetterQueueHealthCheck",
-                   "status": "healthy",
-                   "cause": null
-                  }, {
-                   "componentName": "TWPSettingsQueueConsumerHealthCheck",
-                   "escapedComponentName": "TWPSettingsQueueConsumerHealthCheck",
-                   "status": "healthy",
-                   "cause": null
-                  }]
-                }
-                """);
-        });
+        assertThatJson(body).withOptions(Option.IGNORING_ARRAY_ORDER).isEqualTo("""
+            {
+              "status" : "healthy",
+              "checks" : [ {
+                "componentName" : "Guice application lifecycle",
+                "escapedComponentName" : "Guice%20application%20lifecycle",
+                "status" : "healthy",
+                "cause" : null
+              }, {
+                "componentName" : "RabbitMQDeadLetterQueueEmptiness",
+                "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
+                "status" : "healthy",
+                "cause" : null
+              }, {
+                "componentName" : "CalendarQueueConsumers",
+                "escapedComponentName" : "CalendarQueueConsumers",
+                "status" : "healthy",
+                "cause" : null
+              }, {
+                "componentName" : "RabbitMQ backend",
+                "escapedComponentName" : "RabbitMQ%20backend",
+                "status" : "healthy",
+                "cause" : null
+              } ]
+            }
+            """);
     }
 
     @Test

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteTest.java
@@ -47,7 +47,6 @@ import com.linagora.calendar.app.TwakeCalendarGuiceServer;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.OpenPaaSUser;
 
@@ -259,64 +258,52 @@ class OpensearchDavCalendarSearchRouteTest implements CalendarSearchRouteContrac
 
     @Test
     void shouldExposeWebAdminHealthcheck(TwakeCalendarGuiceServer server) {
-        Fixture.awaitAtMost.untilAsserted(() -> {
-            String body = given(webAdminSpec(server))
+        String body = given(webAdminSpec(server))
             .when()
-                .get("/healthcheck")
-            .then()
-                .extract()
-                .body()
-                .asString();
+            .get("/healthcheck")
+        .then()
+            .extract()
+            .body()
+            .asString();
 
-            assertThatJson(body)
-                .withOptions(Option.IGNORING_ARRAY_ORDER)
-                .isEqualTo("""
-                    {
-                       "status" : "healthy",
-                       "checks" : [ {
-                         "componentName" : "Guice application lifecycle",
-                         "escapedComponentName" : "Guice%20application%20lifecycle",
-                         "status" : "healthy",
-                         "cause" : null
-                       }, {
-                         "componentName" : "MongoDB",
-                         "escapedComponentName" : "MongoDB",
-                         "status" : "healthy",
-                         "cause" : null
-                       }, {
-                         "componentName" : "OpenSearch Backend",
-                         "escapedComponentName" : "OpenSearch%20Backend",
-                         "status" : "healthy",
-                         "cause" : null
-                       }, {
-                         "componentName" : "RabbitMQ backend",
-                         "escapedComponentName" : "RabbitMQ%20backend",
-                         "status" : "healthy",
-                         "cause" : null
-                       }, {
-                         "componentName" : "CalendarQueueConsumers",
-                         "escapedComponentName" : "CalendarQueueConsumers",
-                         "status" : "healthy",
-                         "cause" : null
-                       }, {
-                         "componentName" : "RabbitMQDeadLetterQueueEmptiness",
-                         "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
-                         "status" : "healthy",
-                         "cause" : null
-                       }, {
-                         "componentName": "TWPSettingsDeadLetterQueueHealthCheck",
-                         "escapedComponentName": "TWPSettingsDeadLetterQueueHealthCheck",
-                         "status": "healthy",
-                         "cause": null
-                      }, {
-                         "componentName": "TWPSettingsQueueConsumerHealthCheck",
-                         "escapedComponentName": "TWPSettingsQueueConsumerHealthCheck",
-                         "status": "healthy",
-                         "cause": null
-                      }]
-                    }
-                    """);
-        });
+        assertThatJson(body)
+            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .isEqualTo("""
+                {
+                   "status" : "healthy",
+                   "checks" : [ {
+                     "componentName" : "Guice application lifecycle",
+                     "escapedComponentName" : "Guice%20application%20lifecycle",
+                     "status" : "healthy",
+                     "cause" : null
+                   }, {
+                     "componentName" : "MongoDB",
+                     "escapedComponentName" : "MongoDB",
+                     "status" : "healthy",
+                     "cause" : null
+                   }, {
+                     "componentName" : "OpenSearch Backend",
+                     "escapedComponentName" : "OpenSearch%20Backend",
+                     "status" : "healthy",
+                     "cause" : null
+                   }, {
+                     "componentName" : "RabbitMQ backend",
+                     "escapedComponentName" : "RabbitMQ%20backend",
+                     "status" : "healthy",
+                     "cause" : null
+                   }, {
+                     "componentName" : "CalendarQueueConsumers",
+                     "escapedComponentName" : "CalendarQueueConsumers",
+                     "status" : "healthy",
+                     "cause" : null
+                   }, {
+                     "componentName" : "RabbitMQDeadLetterQueueEmptiness",
+                     "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
+                     "status" : "healthy",
+                     "cause" : null
+                   } ]
+                }
+                """);
     }
 
     private RequestSpecification webAdminSpec(TwakeCalendarGuiceServer server) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/UserConfigurationsRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/UserConfigurationsRoute.java
@@ -50,6 +50,12 @@ import reactor.core.publisher.Mono;
 import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
 
+/**
+ * @deprecated Use {@link UserConfigurationPatchRoute} instead.
+ *             This PUT endpoint resets all user configurations and does not
+ *             support read-only settings semantics.
+ */
+@Deprecated
 public class UserConfigurationsRoute extends CalendarRoute {
     public static final Logger LOGGER = LoggerFactory.getLogger(UserConfigurationsRoute.class);
 

--- a/docs/apis/twpSettingsConfiguration.md
+++ b/docs/apis/twpSettingsConfiguration.md
@@ -1,0 +1,36 @@
+# Twake Workplace (TWP) Settings Synchronization
+
+This document describes how Calendar side-service synchronizes user settings
+from Twake Workplace (TWP).
+
+## Overview
+
+Calendar can synchronize a subset of user settings from Twake Workplace via
+RabbitMQ. When enabled, TWP becomes the source of truth for these settings.
+
+Currently, the following setting is synchronized from TWP:
+
+- `core.language`
+
+## RabbitMQ Configuration
+
+In `rabbitmq.properties`, Calendar side service uses the following properties to consume
+TWP settings messages.
+
+- `twp.rabbitmq.uri`
+- `twp.rabbitmq.management.uri`
+- `twp.queues.quorum.bypass`
+- `twp.settings.exchange`
+- `twp.settings.routingKey`
+
+For a detailed description of these RabbitMQ properties, please refer to the
+official [TMail documentation](https://github.com/linagora/tmail-backend/blob/master/docs/modules/ROOT/pages/tmail-backend/configure/rabbitmq.adoc#twake-workplace-settings-configuration)
+
+## Enabling TWP Settings Synchronization
+
+To enable synchronization of user settings from Twake Workplace, the following
+property must be set in `configuration.properties`:
+
+```properties
+twp.settings.enabled=true
+```

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -59,6 +59,7 @@ Here is the detail of the configuration entries:
 | basic.auth.enabled | Optional. Defaults to false (basic auth disabled). Alows regular user to use bsic auth mecanism. While implemented by OpenPaaS it shall not be needed by the SPAs.                                                                                                                          | basic.auth.enabled=true |
 | default.calendar.public.visibility.enabled | Optional. Defaults to false. Enable function that set default calendars publicly visible upon creation.                                                                                                                                                                                     | default.calendar.public.visibility.enabled=true |
 | itip.event.messages.prefetch.count | Optional. Defaults to 16. The maximum number of unacknowledged messages the broker will deliver to the event itip consumer.                                                                                                                                                                 | itip.event.messages.prefetch.count=16 |
+| twp.settings.enabled | Optional. Defaults to `false`. Enables synchronization of user settings from Twake Workplace. When enabled, some settings become read-only via REST APIs. | twp.settings.enabled=true |
 
 Please find hereby a [working example](../../app/src/main/conf/configuration.properties).
 

--- a/storage-api/src/main/java/com/linagora/calendar/storage/configuration/ReadOnlyPropertyProvider.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/configuration/ReadOnlyPropertyProvider.java
@@ -18,19 +18,29 @@
 
 package com.linagora.calendar.storage.configuration;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Objects;
+import java.util.Set;
 
-public record ConfigurationEntry(ModuleName moduleName, ConfigurationKey configurationKey, JsonNode node) {
+public interface ReadOnlyPropertyProvider {
 
-    public static ConfigurationEntry of(String moduleName, String configurationKey, JsonNode node) {
-        return new ConfigurationEntry(new ModuleName(moduleName), new ConfigurationKey(configurationKey), node);
+    Set<EntryIdentifier> readOnlySettings();
+
+    static ReadOnlyPropertyProvider of(EntryIdentifier... entries) {
+        Objects.requireNonNull(entries, "entries must not be null");
+        return new ListBasedReadOnlyPropertyProvider(Set.of(entries));
     }
 
-    public static ConfigurationEntry of(EntryIdentifier entryIdentifier, JsonNode node) {
-        return new ConfigurationEntry(entryIdentifier.moduleName(), entryIdentifier.configurationKey(), node);
+    record EmptyReadOnlyPropertyProvider() implements ReadOnlyPropertyProvider {
+        @Override
+        public Set<EntryIdentifier> readOnlySettings() {
+            return Set.of();
+        }
     }
 
-    public EntryIdentifier getEntryIdentifier() {
-        return new EntryIdentifier(moduleName, configurationKey);
+    record ListBasedReadOnlyPropertyProvider(Set<EntryIdentifier> readOnlySettings) implements ReadOnlyPropertyProvider {
+
+        public ListBasedReadOnlyPropertyProvider(Set<EntryIdentifier> readOnlySettings) {
+            this.readOnlySettings = Set.copyOf(readOnlySettings);
+        }
     }
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/configuration/ReadOnlyPropertyProviderModule.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/configuration/ReadOnlyPropertyProviderModule.java
@@ -18,19 +18,26 @@
 
 package com.linagora.calendar.storage.configuration;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.linagora.calendar.storage.configuration.ReadOnlyPropertyProvider.EmptyReadOnlyPropertyProvider;
 
-public record ConfigurationEntry(ModuleName moduleName, ConfigurationKey configurationKey, JsonNode node) {
+public class ReadOnlyPropertyProviderModule {
 
-    public static ConfigurationEntry of(String moduleName, String configurationKey, JsonNode node) {
-        return new ConfigurationEntry(new ModuleName(moduleName), new ConfigurationKey(configurationKey), node);
-    }
+    public static final AbstractModule EMPTY = new AbstractModule() {
+        @Provides
+        @Singleton
+        ReadOnlyPropertyProvider provideReadOnlyPropertyProvider() {
+            return new EmptyReadOnlyPropertyProvider();
+        }
+    };
 
-    public static ConfigurationEntry of(EntryIdentifier entryIdentifier, JsonNode node) {
-        return new ConfigurationEntry(entryIdentifier.moduleName(), entryIdentifier.configurationKey(), node);
-    }
-
-    public EntryIdentifier getEntryIdentifier() {
-        return new EntryIdentifier(moduleName, configurationKey);
-    }
+    public static final AbstractModule WITH_READ_ONLY_LANGUAGE = new AbstractModule() {
+        @Provides
+        @Singleton
+        ReadOnlyPropertyProvider provideReadOnlyPropertyProvider() {
+            return ReadOnlyPropertyProvider.of(EntryIdentifier.LANGUAGE_IDENTIFIER);
+        }
+    };
 }


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional TWP settings synchronization; when enabled, some user settings are read-only via REST APIs and server wiring reflects the chosen mode.

* **Documentation**
  * Added TWP settings synchronization doc and updated configuration docs with the new enabling option.

* **Deprecation**
  * Marked an older user-configuration route as deprecated; use the updated patch route.

* **Tests**
  * Added integration tests for TWP sync behavior and simplified several healthcheck tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->