### PR TITLE
fix: Rest API: return JSON Content-Type header for POST /api/configurations

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/UserConfigurationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/UserConfigurationRouteTest.java
@@ -193,6 +193,7 @@ class UserConfigurationRouteTest {
             .post("/api/configurations")
         .then()
             .statusCode(200)
+            .contentType(JSON)
             .extract()
             .body()
             .asString();

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ConfigurationRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ConfigurationRoute.java
@@ -18,6 +18,8 @@
 
 package com.linagora.calendar.restapi.routes;
 
+import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
+
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -97,6 +99,7 @@ public class ConfigurationRoute extends CalendarRoute {
             .map(ConfigurationDocument::asJson)
             .map(Throwing.function(OBJECT_MAPPER::writeValueAsString))
             .flatMap(string -> response.status(HttpResponseStatus.OK)
+                .headers(JSON_HEADER)
                 .sendString(Mono.just(string))
                 .then());
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP response headers to properly indicate JSON content type in API responses, ensuring client applications correctly identify response format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->