### PR TITLE
feat(docker): switch sabre-dav setup to use FerretDB instead of MongoDB

### DIFF
--- a/app/docker-sample/conf-side-service/configuration.properties
+++ b/app/docker-sample/conf-side-service/configuration.properties
@@ -1,4 +1,4 @@
-mongo.url=mongodb://mongo:27017
+mongo.url=mongodb://username:password@mongo:27017?authMechanism=SCRAM-SHA-256
 mongo.database=esn_docker
 domains=linagora.local
 rest.api.port=80

--- a/app/docker-sample/docker-compose.yml
+++ b/app/docker-sample/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: linagora/twake-calendar-side-service:branch-master
     container_name: tcalendar-side-service.linagora.local
     depends_on:
-      - mongo
+      - ferretdb
       - rabbitmq
       - sabre_dav
       - redis
@@ -89,28 +89,6 @@ services:
     networks:
       - tcalendar
 
-  mongo:
-    image: mongo:6
-    container_name: mongo
-    networks:
-      - tcalendar
-    ports:
-      - "27017:27017"
-    command: [ "mongod", "--bind_ip", "0.0.0.0" ]
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "mongosh",
-          "--quiet",
-          "--eval",
-          "'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'",
-        ]
-      start_period: 40s
-      interval: 10s
-      timeout: 10s
-      retries: 10
-
   rabbitmq:
     image: rabbitmq:3.13.3-management
     container_name: rabbitmq
@@ -135,26 +113,16 @@ services:
     networks:
       - tcalendar
     environment:
-      - SABRE_ENV=dev
-      - SABRE_MONGO_HOST=mongo
-      - SABRE_MONGO_PORT=27017
-      - ESN_MONGO_HOST=mongo
-      - ESN_MONGO_PORT=27017
-      - ESN_MONGO_DBNAME=esn_docker
-      - ESN_HOST=tcalendar-side-service.linagora.local
       - ESN_PORT=80
-      - AMQP_HOST=rabbitmq
-      - AMQP_PORT=5672
-      - AMQP_LOGIN=tcalendar
-      - AMQP_PASSWORD=tcalendar
       - SABRE_ADMIN_LOGIN=admin
       - SABRE_ADMIN_PASSWORD=secret123
       - OPENPASS_BASIC_AUTH=YWRtaW5AbGluYWdvcmEubG9jYWw6c2VjcmV0
     volumes:
       - ./conf-side-service/jwt_publickey:/var/www/config/esn.key.pub
+      - ./sabre/config.json:/var/www/config.json:ro
     depends_on:
-      mongo:
-        condition: service_healthy
+      ferretdb:
+        condition: service_started
       rabbitmq:
         condition: service_healthy
     ports:
@@ -192,14 +160,44 @@ services:
       - tcalendar
 
   provision-data:
-    image: curlimages/curl:latest
+    image: postgres:17-alpine
     depends_on:
-      rabbitmq:
-        condition: service_healthy
+      postgres:
+        condition: service_started
       tcalendar-side-service:
         condition: service_started
     volumes:
-      - ./script:/provision:ro
-    entrypoint: ["sh", "/provision/provision_all.sh"]
+      - ./script:/script:ro
+    entrypoint: ["sh", "/script/provision_entrypoint.sh"]
+    environment:
+      PGPASSWORD: password
+    networks:
+      - tcalendar
+    restart: "no"
+
+  postgres:
+    image: ghcr.io/ferretdb/postgres-documentdb:17-0.107.0-ferretdb-2.7.0
+    restart: on-failure
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=username
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=postgres
+    networks:
+      - tcalendar
+
+  ferretdb:
+    image: ghcr.io/ferretdb/ferretdb:2.7.0
+    restart: on-failure
+    container_name: mongo
+    depends_on:
+      - postgres
+    ports:
+      - "27017:27017"
+    environment:
+      - FERRETDB_LOG_LEVEL=debug
+      - FERRETDB_POSTGRESQL_URL=postgres://username:password@postgres:5432/postgres?sslmode=disable
     networks:
       - tcalendar

--- a/app/docker-sample/sabre/config.json
+++ b/app/docker-sample/sabre/config.json
@@ -1,0 +1,41 @@
+{
+  "webserver": {
+    "baseUri": "/",
+    "allowOrigin": "*",
+    "realm": "ESN"
+  },
+  "amqp": {
+    "host": "rabbitmq",
+    "port": "5672",
+    "login": "tcalendar",
+    "password": "tcalendar",
+    "vhost": "/",
+    "sslEnabled": false,
+    "sslTrustAllCerts": false
+  },
+  "database": {
+    "esn": {
+      "connectionString": "mongodb://username:password@mongo:27017/esn_docker?authMechanism=SCRAM-SHA-256",
+      "connectionOptions": {
+        "w": 1,
+        "fsync": true,
+        "connectTimeoutMS": 10000
+      }
+    },
+    "sabre": {
+      "connectionString": "mongodb://username:password@mongo:27017/sabre?authMechanism=SCRAM-SHA-256",
+      "connectionOptions": {
+        "w": 1,
+        "fsync": true,
+        "connectTimeoutMS": 10000
+      }
+    }
+  },
+  "esn": {
+    "apiRoot": "http://tcalendar-side-service.linagora.local:80",
+    "calendarRoot": "http://tcalendar-side-service.linagora.local:80/calendar/api"
+  },
+  "environment": {
+    "SABRE_ENV": "dev"
+  }
+}

--- a/app/docker-sample/script/patch_postgres_auth.sh
+++ b/app/docker-sample/script/patch_postgres_auth.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+# NOTE:
+# mongo-c-driver SCRAM-SHA-256 uses a 28-byte salt, while PostgreSQL uses a 16-byte salt.
+# To keep compatibility with MongoDB clients in esn-sabre,
+# we manually patch `pg_authid.rolpassword` with a precomputed SCRAM-SHA-256 hash
+PG_HOST="postgres"
+PG_PORT="5432"
+PG_USER="username"
+PG_PASSWORD="password"
+PG_DATABASE="postgres"
+NEW_ROL_PASSWORD="SCRAM-SHA-256\$4096:dm4MIMl6+sUG6p/eeOGsYEYFs1y7UcbrLnbBOg==\$cRTjw3T3qpNaLceUY9UVoUC87LJhcIf/mLaNS0sI/qo=:8Fc3Chlq4vXgDzG2xnBA4ds0gnAt6KLBKd8yFeHRLBE="
+
+export PGPASSWORD="${PG_PASSWORD}"
+
+echo "[pg-authid-patch] Waiting for postgres..."
+until pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USER}"; do
+  sleep 2
+done
+
+echo "[pg-authid-patch] Running SQL patch..."
+
+psql -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USER}" -d "${PG_DATABASE}" <<EOF
+UPDATE pg_authid
+SET rolpassword = '${NEW_ROL_PASSWORD}'
+WHERE rolname = 'username';
+EOF
+
+echo "[pg-authid-patch] Done."

--- a/app/docker-sample/script/provision_entrypoint.sh
+++ b/app/docker-sample/script/provision_entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+echo "[provision] Installing curl..."
+apk add --no-cache curl
+
+echo "[provision] Patching PostgreSQL authentication..."
+sh /script/patch_postgres_auth.sh
+
 # Wait for Twake Calendar service to be up
 echo "Waiting for twake-calendar-side-service to be available..."
 
@@ -15,6 +21,6 @@ done
 
 # Run user provisioning
 echo "Provisioning users..."
-sh /provision/provision_users.sh
+sh /script/provision_users.sh
 echo "Provisioning resources..."
-sh /provision/provision_resources.sh
+sh /script/provision_resources.sh

--- a/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
+++ b/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
@@ -22,25 +22,6 @@ services:
       RABBITMQ_DEFAULT_USER: calendar
       RABBITMQ_DEFAULT_PASS: calendar
 
-  mongo:
-    image: mongo
-    networks:
-      - tcalendar
-    command: ["mongod", "--bind_ip", "0.0.0.0"]
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "mongosh",
-          "--quiet",
-          "--eval",
-          "'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'",
-        ]
-      start_period: 40s
-      interval: 10s
-      timeout: 10s
-      retries: 10
-
   sabre_dav:
     hostname: esn_sabre
     image: linagora/esn-sabre:sabre-4_7_0-09-12-2025
@@ -67,3 +48,25 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+
+  postgres:
+    image: ghcr.io/ferretdb/postgres-documentdb:17-0.107.0-ferretdb-2.7.0
+    hostname: postgres
+    environment:
+      - POSTGRES_USER=username
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=postgres
+    networks:
+      - tcalendar
+
+  mongo:
+    image: ghcr.io/ferretdb/ferretdb:2.7.0
+    hostname: mongo
+    depends_on:
+      - postgres
+    environment:
+      - FERRETDB_AUTH=false
+      - FERRETDB_LOG_LEVEL=debug
+      - FERRETDB_POSTGRESQL_URL=postgres://username:password@postgres:5432/postgres?sslmode=disable
+    networks:
+      - tcalendar

--- a/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
+++ b/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
@@ -29,9 +29,13 @@ services:
       - SABRE_ENV=dev
       - SABRE_MONGO_HOST=mongo
       - SABRE_MONGO_PORT=27017
+      - SABRE_MONGO_USER=username
+      - SABRE_MONGO_PASSWORD=password
       - ESN_MONGO_HOST=mongo
       - ESN_MONGO_PORT=27017
       - ESN_MONGO_DBNAME=esn_docker
+      - ESN_MONGO_USER=username
+      - ESN_MONGO_PASSWORD=password
       - MONGO_TIMEOUT=100000
       - ESN_HOST=esn
       - ESN_PORT=1080
@@ -65,7 +69,6 @@ services:
     depends_on:
       - postgres
     environment:
-      - FERRETDB_AUTH=false
       - FERRETDB_LOG_LEVEL=debug
       - FERRETDB_POSTGRESQL_URL=postgres://username:password@postgres:5432/postgres?sslmode=disable
     networks:


### PR DESCRIPTION
Authentication is disabled on FerretDB due to known incompatibilities driver (https://github.com/linagora/twake-calendar-side-service/issues/158#issuecomment-3664650547)

The goal of this pr is to evaluate FerretDB compatibility with MongoDB CRUD features (indexes, queries, updates) by pass integration test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test database infrastructure by replacing standard MongoDB with FerretDB, a PostgreSQL-backed alternative for improved testing reliability.

* **Bug Fixes**
  * Enhanced duplicate key error detection and handling across data storage operations to provide clearer error reporting when duplicate entries are encountered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->