### PR TITLE
fix(mongodb): detect duplicate key using error code instead of message

### DIFF
--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoConstants.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoConstants.java
@@ -1,0 +1,23 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage.mongodb;
+
+public class MongoConstants {
+    public static final int MONGO_DUPLICATE_KEY_CODE = 11000;
+}


### PR DESCRIPTION
Use MongoDB error code (MONGO_DUPLICATE_KEY_CODE / 11000) instead, which is stable and consistent across MongoDB implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling reliability for MongoDB operations through enhanced error detection and classification mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->