### PR TITLE
ISSUE-551 [WS] ImportRoute should return importId upon import initiation

### DIFF
--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ImportProcessor.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ImportProcessor.java
@@ -221,6 +221,7 @@ public class ImportProcessor {
     public Mono<Void> process(ImportCommand importCommand, MailboxSession mailboxSession) {
         Username username = mailboxSession.getUser();
 
+        LOGGER.debug("Starting import {} of type {} for user {}", importCommand.importId().value(), importCommand.importType().name(), username);
         ImportToDavHandler importToDavHandler = switch (importCommand.importType()) {
             case ICS -> importICSHandler;
             case VCARD -> importVCardHandler;

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ImportProcessor.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ImportProcessor.java
@@ -50,6 +50,7 @@ import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
 import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver.ResolvedSettings;
 import com.linagora.calendar.storage.event.EventParseUtils;
+import com.linagora.calendar.storage.model.ImportId;
 import com.linagora.calendar.storage.model.UploadedFile;
 
 import ezvcard.Ezvcard;
@@ -99,12 +100,6 @@ public class ImportProcessor {
                 uploadedFile.data(),
                 new OpenPaaSId(baseId),
                 resourceId);
-        }
-    }
-
-    public record ImportId(String value) {
-        public static ImportId generate() {
-            return new ImportId(UUID.randomUUID().toString());
         }
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ImportRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ImportRoute.java
@@ -20,6 +20,8 @@ package com.linagora.calendar.restapi.routes;
 
 import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
 
+import java.util.Map;
+
 import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
@@ -94,7 +97,7 @@ public class ImportRoute extends CalendarRoute {
             .flatMap(importRequest -> handleImport(importRequest, session))
             .flatMap(importId -> response.status(HttpResponseStatus.ACCEPTED)
                 .headers(JSON_HEADER)
-                .sendString(Mono.just(serializeImportResponse(importId)))
+                .sendByteArray(Mono.fromCallable(() -> serializeImportResponse(importId)))
                 .then());
     }
 
@@ -126,8 +129,8 @@ public class ImportRoute extends CalendarRoute {
         };
     }
 
-    private String serializeImportResponse(ImportId importId) {
-        return "{\"" + IMPORT_ID_PROPERTY + "\":\"" + importId.value() + "\"}";
+    private byte[] serializeImportResponse(ImportId importId) throws JsonProcessingException {
+        return OBJECT_MAPPER.writeValueAsBytes(Map.of(IMPORT_ID_PROPERTY, importId.value()));
     }
 
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ImportRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ImportRoute.java
@@ -35,10 +35,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.restapi.routes.ImportProcessor.ImportCommand;
-import com.linagora.calendar.restapi.routes.ImportProcessor.ImportId;
 import com.linagora.calendar.restapi.routes.ImportProcessor.ImportType;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.UploadedFileDAO;
+import com.linagora.calendar.storage.model.ImportId;
 import com.linagora.calendar.storage.model.UploadedMimeType;
 
 import io.netty.handler.codec.http.HttpMethod;

--- a/storage-api/src/main/java/com/linagora/calendar/storage/model/ImportId.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/model/ImportId.java
@@ -1,0 +1,36 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage.model;
+
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Preconditions;
+
+public record ImportId(String value) {
+
+    public ImportId {
+        Preconditions.checkArgument(StringUtils.isNoneEmpty(value), "value must not be null");
+    }
+
+    public static ImportId generate() {
+        return new ImportId(UUID.randomUUID().toString());
+    }
+}

--- a/storage-api/src/main/java/com/linagora/calendar/storage/model/ImportId.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/model/ImportId.java
@@ -27,7 +27,7 @@ import com.google.common.base.Preconditions;
 public record ImportId(String value) {
 
     public ImportId {
-        Preconditions.checkArgument(StringUtils.isNoneEmpty(value), "value must not be null");
+        Preconditions.checkArgument(StringUtils.isNoneEmpty(value), "value must not be null or empty");
     }
 
     public static ImportId generate() {


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import endpoint now returns HTTP 202 with a JSON body containing an importId so users can reference and track imports.

* **Tests**
  * New tests confirm an importId is returned for accepted imports and that each request receives a distinct, non-blank importId.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->