### PR TITLE
ISSUE 438 Email notification for sharee when delegating calendar

### DIFF
--- a/app/src/main/resources/templates/calendar-delegate-created/html.pug
+++ b/app/src/main/resources/templates/calendar-delegate-created/html.pug
@@ -1,0 +1,21 @@
+doctype html
+html
+    head
+        meta(charset='utf-8')
+        meta(name='viewport', content='width=device-width, initial-scale=1')
+    body
+        table(align="center" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:20px;")
+            tr
+                td(align="center")
+                    table(width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:4px;padding:24px;")
+                        tr
+                            td(align="center" style="padding-bottom:24px;")
+                                a(href=content.calendarUrl)
+                                    img(src="cid:logo" alt="Twake Calendar Logo" style="display:block;border:0;outline:none;text-decoration:none;")
+                        tr
+                            td(style="font-family:Arial,sans-serif;color:#222222;")
+                                h2(style="margin:0 0 16px 0;font-weight:normal;")
+                                    | #{content.delegatorName} #{translator.get('mail_body_shared_calendar_title_middle')} “#{content.calendarName}” #{translator.get('mail_body_shared_calendar_title_suffix')}
+                                p(style="margin:0 0 24px 0;color:#555555;")
+                                    | #{translator.get('mail_body_shared_calendar_body_prefix')}
+                                    a(href=content.calendarUrl)= translator.get('mail_body_shared_calendar_body_link')

--- a/app/src/main/resources/templates/calendar-delegate-created/translations/messages_en.properties
+++ b/app/src/main/resources/templates/calendar-delegate-created/translations/messages_en.properties
@@ -1,0 +1,5 @@
+mail_subject=!{delegatorName} shared the “!{calendarName}” calendar with you
+mail_body_shared_calendar_title_middle=shared the calendar
+mail_body_shared_calendar_title_suffix=with you.
+mail_body_shared_calendar_body_prefix=You can now view it in your 
+mail_body_shared_calendar_body_link=calendar list

--- a/app/src/main/resources/templates/calendar-delegate-created/translations/messages_fr.properties
+++ b/app/src/main/resources/templates/calendar-delegate-created/translations/messages_fr.properties
@@ -1,0 +1,5 @@
+mail_subject=!{delegatorName} a partagé le calendrier « !{calendarName} » avec vous
+mail_body_shared_calendar_title_middle=a partagé le calendrier
+mail_body_shared_calendar_title_suffix=avec vous.
+mail_body_shared_calendar_body_prefix=Vous pouvez maintenant le consulter dans votre 
+mail_body_shared_calendar_body_link=liste de calendriers

--- a/app/src/main/resources/templates/calendar-delegate-created/translations/messages_ru.properties
+++ b/app/src/main/resources/templates/calendar-delegate-created/translations/messages_ru.properties
@@ -1,0 +1,5 @@
+mail_subject=!{delegatorName} поделился(лась) с вами календарём « !{calendarName} »
+mail_body_shared_calendar_title_middle=поделился календарем
+mail_body_shared_calendar_title_suffix=с вами.
+mail_body_shared_calendar_body_prefix=Теперь вы можете просмотреть его в 
+mail_body_shared_calendar_body_link=списке календарей

--- a/app/src/main/resources/templates/calendar-delegate-created/translations/messages_vi.properties
+++ b/app/src/main/resources/templates/calendar-delegate-created/translations/messages_vi.properties
@@ -1,0 +1,5 @@
+mail_subject=!{delegatorName} đã chia sẻ lịch “!{calendarName}” với bạn
+mail_body_shared_calendar_title_middle=đã chia sẻ lịch
+mail_body_shared_calendar_title_suffix=với bạn.
+mail_body_shared_calendar_body_prefix=Bây giờ bạn có thể xem lịch này trong 
+mail_body_shared_calendar_body_link=danh sách lịch

--- a/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
@@ -140,6 +140,7 @@ public class ScheduledReconnectionHandlerTest {
                 "tcalendar:event:deleted:notification",
                 "tcalendar:event:cancel:notification",
                 "tcalendar:event:request:notification",
-                "tcalendar:event:reply:notification");
+                "tcalendar:event:reply:notification",
+                "tcalendar:calendar:created");
     }
 }

--- a/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
@@ -141,6 +141,6 @@ public class ScheduledReconnectionHandlerTest {
                 "tcalendar:event:cancel:notification",
                 "tcalendar:event:request:notification",
                 "tcalendar:event:reply:notification",
-                "tcalendar:calendar:created");
+                "tcalendar:calendar:delegated:created");
     }
 }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarAmqpModule.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarAmqpModule.java
@@ -143,6 +143,18 @@ public class CalendarAmqpModule extends AbstractModule {
     }
 
     @ProvidesIntoSet
+    SimpleConnectionPool.ReconnectionHandler provideCalendarDelegatedNotificationReconnectionHandler(CalendarDelegatedNotificationReconnectionHandler reconnectionHandler) {
+        return reconnectionHandler;
+    }
+
+    @ProvidesIntoSet
+    public InitializationOperation initializeCalendarDelegatedNotificationConsumer(CalendarDelegatedNotificationConsumer instance) {
+        return InitilizationOperationBuilder
+            .forClass(CalendarDelegatedNotificationConsumer.class)
+            .init(instance::init);
+    }
+
+    @ProvidesIntoSet
     SimpleConnectionPool.ReconnectionHandler provideEventCalendarReconnectionHandler(EventCalendarReconnectionHandler reconnectionHandler) {
         return reconnectionHandler;
     }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarAmqpModule.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarAmqpModule.java
@@ -56,6 +56,7 @@ public class CalendarAmqpModule extends AbstractModule {
         bind(EventResourceConsumer.class).in(Scopes.SINGLETON);
         bind(EventCalendarConsumer.class).in(Scopes.SINGLETON);
         bind(EventCalendarNotificationConsumer.class).in(Scopes.SINGLETON);
+        bind(CalendarDelegatedNotificationConsumer.class).in(Scopes.SINGLETON);
 
         Multibinder<HealthCheck> healthCheckMultibinder = Multibinder.newSetBinder(binder(), HealthCheck.class);
         healthCheckMultibinder.addBinding().to(RabbitMQCalendarQueueConsumerHealthCheck.class);

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
@@ -1,0 +1,181 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import static com.linagora.calendar.amqp.CalendarAmqpModule.INJECT_KEY_DAV;
+import static org.apache.james.backends.rabbitmq.Constants.DURABLE;
+import static org.apache.james.backends.rabbitmq.Constants.EMPTY_ROUTING_KEY;
+import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
+
+import java.io.Closeable;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.apache.james.backends.rabbitmq.QueueArguments;
+import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
+import org.apache.james.backends.rabbitmq.ReceiverProvider;
+import org.apache.james.lifecycle.api.Startable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.lambdas.Throwing;
+import com.google.inject.name.Named;
+import com.linagora.calendar.storage.CalendarURL;
+import com.rabbitmq.client.BuiltinExchangeType;
+
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.rabbitmq.AcknowledgableDelivery;
+import reactor.rabbitmq.BindingSpecification;
+import reactor.rabbitmq.ConsumeOptions;
+import reactor.rabbitmq.ExchangeSpecification;
+import reactor.rabbitmq.QueueSpecification;
+import reactor.rabbitmq.Receiver;
+import reactor.rabbitmq.Sender;
+
+public class CalendarDelegatedNotificationConsumer implements Closeable, Startable {
+
+    public static final String QUEUE = "tcalendar:calendar:created";
+    private static final String EXCHANGE = "calendar:calendar:created";
+    private static final String DEAD_LETTER = "tcalendar:calendar:created:dead-letter";
+    private static final boolean REQUEUE_ON_NACK = true;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Logger LOGGER = LoggerFactory.getLogger(CalendarDelegatedNotificationConsumer.class);
+
+    private final ReceiverProvider receiverProvider;
+    private Disposable consumeDisposable;
+
+    private final ReactorRabbitMQChannelPool channelPool;
+    private final Supplier<QueueArguments.Builder> queueArgumentSupplier;
+    private final DelegatedCalendarNotificationHandler notificationHandler;
+
+    @Inject
+    @Singleton
+    public CalendarDelegatedNotificationConsumer(ReactorRabbitMQChannelPool channelPool,
+                                                 @Named(INJECT_KEY_DAV) Supplier<QueueArguments.Builder> queueArgumentSupplier,
+                                                 DelegatedCalendarNotificationHandler notificationHandler) {
+        this.receiverProvider = channelPool::createReceiver;
+        this.channelPool = channelPool;
+        this.queueArgumentSupplier = queueArgumentSupplier;
+        this.notificationHandler = notificationHandler;
+    }
+
+    public void init() {
+        declareExchangeAndQueue(channelPool.getSender(), queueArgumentSupplier);
+    }
+
+    public void start() {
+        this.consumeDisposable = doConsume();
+    }
+
+    @Override
+    public void close() {
+        if (consumeDisposable != null && !consumeDisposable.isDisposed()) {
+            consumeDisposable.dispose();
+        }
+    }
+
+    public void restart() {
+        close();
+        start();
+    }
+
+    private void declareExchangeAndQueue(Sender sender, Supplier<QueueArguments.Builder> queueArguments) {
+        Flux.concat(sender.declareExchange(ExchangeSpecification.exchange(EXCHANGE)
+                    .durable(DURABLE)
+                    .type(BuiltinExchangeType.FANOUT.getType())),
+                sender.declareQueue(QueueSpecification.queue(DEAD_LETTER)
+                    .durable(DURABLE)
+                    .arguments(queueArguments.get().build())),
+                sender.declareQueue(QueueSpecification.queue(QUEUE)
+                    .durable(DURABLE)
+                    .arguments(queueArguments.get()
+                        .deadLetter(DEAD_LETTER)
+                        .build())),
+                sender.bind(BindingSpecification.binding()
+                    .exchange(EXCHANGE)
+                    .queue(QUEUE)
+                    .routingKey(EMPTY_ROUTING_KEY)))
+            .then()
+            .block();
+    }
+
+    private Disposable doConsume() {
+        return consumeFromQueue(QUEUE)
+            .flatMap(this::handleMessage, DEFAULT_CONCURRENCY)
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe();
+    }
+
+    private Flux<AcknowledgableDelivery> consumeFromQueue(String queue) {
+        return Flux.using(receiverProvider::createReceiver,
+            receiver -> receiver.consumeManualAck(queue, new ConsumeOptions().qos(DEFAULT_CONCURRENCY)),
+            Receiver::close);
+    }
+
+    private Mono<Void> handleMessage(AcknowledgableDelivery acknowledgableDelivery) {
+        return Mono.fromSupplier(Throwing.supplier(() -> CalendarDelegatedCreatedMessage.deserialize(acknowledgableDelivery.getBody())))
+            .filter(hasDelegationRightKey())
+            .flatMap(notificationHandler::handle)
+            .doOnSuccess(any -> acknowledgableDelivery.ack())
+            .onErrorResume(error -> {
+                LOGGER.error("Error when consuming calendar delegated notification event", error);
+                acknowledgableDelivery.nack(!REQUEUE_ON_NACK);
+                return Mono.empty();
+            });
+    }
+
+    private Predicate<CalendarDelegatedCreatedMessage> hasDelegationRightKey() {
+        return message -> message.rightKey().isPresent();
+    }
+
+    public record CalendarDelegatedCreatedMessage(@JsonProperty("calendarPath") String calendarPath,
+                                                  @JsonProperty("calendarProps") Map<String, JsonNode> calendarProps) {
+        static final String RIGHT_KEY = "access";
+
+        public static CalendarDelegatedCreatedMessage deserialize(byte[] payload) {
+            try {
+                return OBJECT_MAPPER.readValue(payload, CalendarDelegatedCreatedMessage.class);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to deserialize calendar calendar created message: " + new String(payload, StandardCharsets.UTF_8), e);
+            }
+        }
+
+        public CalendarURL calendarURL() {
+            return CalendarURL.parse(calendarPath);
+        }
+
+        public Optional<String> rightKey() {
+            return Optional.ofNullable(calendarProps.get(RIGHT_KEY))
+                .filter(JsonNode::isTextual)
+                .map(JsonNode::asText);
+        }
+    }
+}

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.lambdas.Throwing;
@@ -66,7 +67,9 @@ public class CalendarDelegatedNotificationConsumer implements Closeable, Startab
     private static final String EXCHANGE = "calendar:calendar:created";
     private static final String DEAD_LETTER = QUEUE + ":dead-letter";
     private static final boolean REQUEUE_ON_NACK = true;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CalendarDelegatedNotificationConsumer.class);
 
     private final ReceiverProvider receiverProvider;

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
@@ -64,8 +64,8 @@ import reactor.rabbitmq.Sender;
 public class CalendarDelegatedNotificationConsumer implements Closeable, Startable {
 
     public static final String QUEUE = "tcalendar:calendar:delegated:created";
+    public static final String DEAD_LETTER_QUEUE = QUEUE + ":dead-letter";
     private static final String EXCHANGE = "calendar:calendar:created";
-    private static final String DEAD_LETTER = QUEUE + ":dead-letter";
     private static final boolean REQUEUE_ON_NACK = true;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -115,13 +115,13 @@ public class CalendarDelegatedNotificationConsumer implements Closeable, Startab
         Flux.concat(sender.declareExchange(ExchangeSpecification.exchange(EXCHANGE)
                     .durable(DURABLE)
                     .type(BuiltinExchangeType.FANOUT.getType())),
-                sender.declareQueue(QueueSpecification.queue(DEAD_LETTER)
+                sender.declareQueue(QueueSpecification.queue(DEAD_LETTER_QUEUE)
                     .durable(DURABLE)
                     .arguments(queueArguments.get().build())),
                 sender.declareQueue(QueueSpecification.queue(QUEUE)
                     .durable(DURABLE)
                     .arguments(queueArguments.get()
-                        .deadLetter(DEAD_LETTER)
+                        .deadLetter(DEAD_LETTER_QUEUE)
                         .build())),
                 sender.bind(BindingSpecification.binding()
                     .exchange(EXCHANGE)

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
@@ -145,7 +145,7 @@ public class CalendarDelegatedNotificationConsumer implements Closeable, Startab
         return Mono.fromSupplier(Throwing.supplier(() -> CalendarDelegatedCreatedMessage.deserialize(acknowledgableDelivery.getBody())))
             .filter(hasDelegationRightKey())
             .flatMap(notificationHandler::handle)
-            .doOnTerminate(acknowledgableDelivery::ack)
+            .doOnSuccess(any -> acknowledgableDelivery.ack())
             .onErrorResume(error -> {
                 LOGGER.error("Error when consuming calendar delegated notification event", error);
                 acknowledgableDelivery.nack(!REQUEUE_ON_NACK);

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationReconnectionHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationReconnectionHandler.java
@@ -1,0 +1,49 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rabbitmq.client.Connection;
+
+import reactor.core.publisher.Mono;
+
+public class CalendarDelegatedNotificationReconnectionHandler implements SimpleConnectionPool.ReconnectionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CalendarDelegatedNotificationReconnectionHandler.class);
+
+    private final CalendarDelegatedNotificationConsumer calendarDelegatedNotificationConsumer;
+
+    @Inject
+    public CalendarDelegatedNotificationReconnectionHandler(CalendarDelegatedNotificationConsumer calendarDelegatedNotificationConsumer) {
+        this.calendarDelegatedNotificationConsumer = calendarDelegatedNotificationConsumer;
+    }
+
+    @Override
+    public Publisher<Void> handleReconnection(Connection connection) {
+        return Mono.fromRunnable(calendarDelegatedNotificationConsumer::restart)
+            .doOnError(error -> LOGGER.error("Error while handling reconnection for CalendarDelegatedNotificationConsumer", error))
+            .then();
+    }
+}

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarQueueUtil.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarQueueUtil.java
@@ -66,6 +66,7 @@ public class CalendarQueueUtil {
                 .collect(ImmutableList.toImmutableList()))
             .add(EventEmailConsumer.DEAD_LETTER_QUEUE)
             .add(EventITIPConsumer.DEAD_LETTER_QUEUE)
+            .add(CalendarDelegatedNotificationConsumer.DEAD_LETTER_QUEUE)
             .build();
     }
 }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarQueueUtil.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarQueueUtil.java
@@ -43,6 +43,7 @@ public class CalendarQueueUtil {
                 .collect(ImmutableList.toImmutableList()))
             .add(EventEmailConsumer.QUEUE_NAME)
             .add(EventITIPConsumer.QUEUE_NAME)
+            .add(CalendarDelegatedNotificationConsumer.QUEUE)
             .build();
     }
 

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/DelegatedCalendarNotificationHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/DelegatedCalendarNotificationHandler.java
@@ -1,0 +1,194 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.inject.Named;
+
+import org.apache.james.core.MailAddress;
+import org.apache.james.core.MaybeSender;
+import org.apache.james.core.Username;
+import org.apache.james.mailbox.model.Cid;
+import org.apache.james.mailbox.model.ContentType;
+import org.apache.james.mime4j.dom.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.linagora.calendar.amqp.CalendarDelegatedNotificationConsumer.CalendarDelegatedCreatedMessage;
+import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.smtp.EventEmailFilter;
+import com.linagora.calendar.smtp.Mail;
+import com.linagora.calendar.smtp.MailSender;
+import com.linagora.calendar.smtp.template.Language;
+import com.linagora.calendar.smtp.template.MailTemplateConfiguration;
+import com.linagora.calendar.smtp.template.MessageGenerator;
+import com.linagora.calendar.smtp.template.MimeAttachment;
+import com.linagora.calendar.smtp.template.TemplateType;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
+import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver.ResolvedSettings;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+public class DelegatedCalendarNotificationHandler {
+    static class CalendarDelegatedNotificationHandlerException extends RuntimeException {
+        public CalendarDelegatedNotificationHandlerException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelegatedCalendarNotificationHandler.class);
+    private static final TemplateType MAIL_TEMPLATE = new TemplateType("calendar-delegate-created");
+    private static final String DELEGATED_SOURCE_PROPERTY = "calendarserver:delegatedsource";
+    private static final String CALENDAR_NAME_PROPERTY = "dav:name";
+
+    private final OpenPaaSUserDAO openPaaSUserDAO;
+    private final CalDavClient calDavClient;
+    private final SettingsBasedResolver settingsResolver;
+    private final MailSender.Factory mailSenderFactory;
+    private final MaybeSender maybeSender;
+    private final MailAddress senderAddress;
+    private final MessageGenerator.Factory messageGeneratorFactory;
+    private final EventEmailFilter eventEmailFilter;
+    private final URI spaCalendarBaseUrl;
+    private final MimeAttachment logoAttachment;
+
+    @Inject
+    public DelegatedCalendarNotificationHandler(OpenPaaSUserDAO openPaaSUserDAO,
+                                                CalDavClient calDavClient,
+                                                @Named("language") SettingsBasedResolver settingsResolver,
+                                                MailSender.Factory mailSenderFactory,
+                                                MailTemplateConfiguration mailTemplateConfiguration,
+                                                MessageGenerator.Factory messageGeneratorFactory,
+                                                EventEmailFilter eventEmailFilter,
+                                                @Named("spaCalendarUrl") URL calendarBaseUrl,
+                                                @Named("calendar-logo") byte[] calendarLogo) throws URISyntaxException {
+        this.openPaaSUserDAO = openPaaSUserDAO;
+        this.calDavClient = calDavClient;
+        this.settingsResolver = settingsResolver;
+        this.mailSenderFactory = mailSenderFactory;
+        this.maybeSender = mailTemplateConfiguration.sender();
+        this.messageGeneratorFactory = messageGeneratorFactory;
+        this.eventEmailFilter = eventEmailFilter;
+        this.spaCalendarBaseUrl = calendarBaseUrl.toURI();
+        this.senderAddress = maybeSender.asOptional()
+            .orElseThrow(() -> new IllegalArgumentException("Sender address must not be empty"));
+        this.logoAttachment = MimeAttachment.builder()
+            .contentType(ContentType.of("image/png"))
+            .cid(Cid.from("<logo>"))
+            .content(calendarLogo)
+            .fileName("logo.png")
+            .build();
+    }
+
+    public record DelegatedCalendarNotificationData(OpenPaaSUser delegatorUser,
+                                                    CalendarURL originalCalendarURL,
+                                                    String originalCalendarName,
+                                                    OpenPaaSUser delegatedUser,
+                                                    CalendarURL delegatedCalendarURL,
+                                                    String rightKey) {
+
+        public Map<String, Object> toPugModel(URI spaCalendarBaseUrl) {
+            return ImmutableMap.of(
+                "content", ImmutableMap.of(
+                    "delegatorName", delegatorUser.fullName(),
+                    "calendarName", originalCalendarName,
+                    "calendarUrl", spaCalendarBaseUrl.toASCIIString(),
+                    "rightKey", rightKey),
+                "delegatorName", delegatorUser.fullName(),
+                "calendarName", originalCalendarName);
+        }
+    }
+
+    private record CalendarMetadata(OpenPaaSUser owner, JsonNode metadata) {
+    }
+
+    public Mono<Void> handle(CalendarDelegatedCreatedMessage createdMessage) {
+        return buildNotificationData(createdMessage)
+            .filter(Throwing.predicate(notificationData -> eventEmailFilter.shouldProcess(notificationData.delegatedUser().username().asMailAddress())))
+            .flatMap(this::processNotification);
+    }
+
+    public Mono<Void> processNotification(DelegatedCalendarNotificationData notificationData) {
+        Username recipientUser = notificationData.delegatedUser().username();
+
+        return settingsResolver.resolveOrDefault(recipientUser)
+            .flatMap(resolvedSettings -> generateMessage(notificationData, resolvedSettings))
+            .flatMap(mailMessage -> mailSenderFactory.create()
+                .flatMap(mailSender -> mailSender.send(new Mail(maybeSender, ImmutableList.of(Throwing.supplier(recipientUser::asMailAddress).get()), mailMessage)))
+                .onErrorMap(error -> new CalendarDelegatedNotificationHandlerException("Failed to send delegated calendar notification email", error)))
+            .doOnSuccess(any -> LOGGER.debug("Consumed delegated calendar notification for user {} on calendar {}", notificationData.delegatedUser().username(), notificationData.originalCalendarURL()));
+    }
+
+    private Mono<Message> generateMessage(DelegatedCalendarNotificationData notificationData, ResolvedSettings resolvedSettings) {
+        return Mono.fromCallable(() -> messageGeneratorFactory.forLocalizedFeature(new Language(resolvedSettings.locale()), MAIL_TEMPLATE))
+            .subscribeOn(Schedulers.boundedElastic())
+            .flatMap(messageGenerator -> {
+                Username recipientUser = notificationData.delegatedUser().username();
+                return messageGenerator.generate(recipientUser, senderAddress, notificationData.toPugModel(spaCalendarBaseUrl),
+                    List.of(logoAttachment));
+            })
+            .onErrorResume(error -> Mono.error(new CalendarDelegatedNotificationHandlerException("Failed to generate delegated calendar notification email", error)));
+    }
+
+    public Mono<DelegatedCalendarNotificationData> buildNotificationData(CalendarDelegatedCreatedMessage message) {
+        LOGGER.debug("Enriching delegated calendar notification for message: {}", message);
+        CalendarURL delegatedCalendarURL = message.calendarURL();
+
+        return fetchCalendarWithOwner(delegatedCalendarURL)
+            .filter(result -> result.metadata().has(DELEGATED_SOURCE_PROPERTY))
+            .flatMap(delegated -> {
+                LOGGER.debug("Delegated calendar detected for calendar {}, delegated user={}", delegatedCalendarURL.serialize(), delegated.owner().username());
+                CalendarURL originalCalendarURL = CalendarURL.parse(delegated.metadata().get(DELEGATED_SOURCE_PROPERTY).asText());
+                OpenPaaSUser delegatedUser = delegated.owner();
+
+                return fetchCalendarWithOwner(originalCalendarURL)
+                    .map(original -> {
+                        String originalCalendarName = original.metadata().path(CALENDAR_NAME_PROPERTY).asText();
+                        return new DelegatedCalendarNotificationData(
+                            original.owner(),
+                            originalCalendarURL,
+                            originalCalendarName,
+                            delegatedUser,
+                            delegatedCalendarURL,
+                            message.rightKey().orElse(null));
+                    });
+            });
+    }
+
+    private Mono<CalendarMetadata> fetchCalendarWithOwner(CalendarURL calendarURL) {
+        return openPaaSUserDAO.retrieve(calendarURL.base())
+            .flatMap(user -> calDavClient.fetchCalendarMetadata(user.username(), calendarURL)
+                .map(metadata -> new CalendarMetadata(user, metadata)))
+            .doOnError(e -> LOGGER.error("Failed to resolve owner or metadata for calendar {}", calendarURL.serialize(), e));
+    }
+}

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/DelegatedCalendarNotificationHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/DelegatedCalendarNotificationHandler.java
@@ -122,8 +122,7 @@ public class DelegatedCalendarNotificationHandler {
                 "content", ImmutableMap.of(
                     "delegatorName", delegatorUser.fullName(),
                     "calendarName", originalCalendarName,
-                    "calendarUrl", spaCalendarBaseUrl.toASCIIString(),
-                    "rightKey", rightKey),
+                    "calendarUrl", spaCalendarBaseUrl.toASCIIString()),
                 "delegatorName", delegatorUser.fullName(),
                 "calendarName", originalCalendarName);
         }

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedCreatedMessageTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedCreatedMessageTest.java
@@ -1,0 +1,69 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.calendar.amqp.CalendarDelegatedNotificationConsumer.CalendarDelegatedCreatedMessage;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
+
+public class CalendarDelegatedCreatedMessageTest {
+
+    @Test
+    void deserializeShouldSucceedWhenDoesDelegatedMessage() {
+        String json = """
+            {
+                "calendarPath": "\\/calendars\\/67e26ebbecd9f300255a9f80\\/dafa1cb9-17c6-40fa-bd0c-4da06f2faf17",
+                "calendarProps": {
+                    "access": "dav:read-write"
+                }
+            }
+            """;
+        CalendarDelegatedCreatedMessage message = CalendarDelegatedCreatedMessage.deserialize(json.getBytes(StandardCharsets.UTF_8));
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(message.calendarURL()).isEqualTo(new CalendarURL(new OpenPaaSId("67e26ebbecd9f300255a9f80"), new OpenPaaSId("dafa1cb9-17c6-40fa-bd0c-4da06f2faf17")));
+            softly.assertThat(message.rightKey().get()).isEqualTo("dav:read-write");
+        });
+    }
+
+    @Test
+    void deserializeShouldSucceedWhenDoesNotDelegatedMessage() {
+        String json = """
+            {
+              "calendarPath": "/calendars/69704ec60dbc345e7d54b997/69704ec60dbc345e7d54b997",
+              "calendarProps": {
+                "{http://calendarserver.org/ns/}getctag": "http://sabre.io/ns/sync/1",
+                "{http://sabredav.org/ns}sync-token": 1,
+                "{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set": {},
+                "{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp": {},
+                "{DAV:}displayname": "#default"
+              }
+            }
+            """;
+        CalendarDelegatedCreatedMessage message = CalendarDelegatedCreatedMessage.deserialize(json.getBytes(StandardCharsets.UTF_8));
+        assertThat(message.rightKey()).isEmpty();
+    }
+}

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
@@ -1,0 +1,349 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import static com.linagora.calendar.amqp.TestFixture.awaitAtMost;
+import static com.linagora.calendar.amqp.TestFixture.extractSubject;
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+import static com.linagora.calendar.storage.configuration.EntryIdentifier.LANGUAGE_IDENTIFIER;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.james.backends.rabbitmq.QueueArguments;
+import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
+import org.apache.james.backends.rabbitmq.RabbitMQConnectionFactory;
+import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
+import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
+import org.apache.james.core.MaybeSender;
+import org.apache.james.core.Username;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.apache.james.server.core.filesystem.FileSystemImpl;
+import org.apache.james.util.Port;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import com.github.fge.lambdas.Throwing;
+import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.CalDavClient.NewCalendar;
+import com.linagora.calendar.dav.DavTestHelper;
+import com.linagora.calendar.dav.DockerSabreDavSetup;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.dav.dto.SubscribedCalendarRequest;
+import com.linagora.calendar.smtp.EventEmailFilter;
+import com.linagora.calendar.smtp.MailSender;
+import com.linagora.calendar.smtp.MailSenderConfiguration;
+import com.linagora.calendar.smtp.MockSmtpServerExtension;
+import com.linagora.calendar.smtp.template.MailTemplateConfiguration;
+import com.linagora.calendar.smtp.template.MessageGenerator;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSDomain;
+import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+import com.rabbitmq.client.Channel;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.path.json.JsonPath;
+import io.restassured.specification.RequestSpecification;
+import reactor.core.publisher.Mono;
+
+public class CalendarDelegatedNotificationConsumerTest {
+
+    @RegisterExtension
+    @Order(1)
+    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+
+    @RegisterExtension
+    @Order(2)
+    static final MockSmtpServerExtension mockSmtpExtension = new MockSmtpServerExtension();
+
+    private static final SettingsBasedResolver settingsResolver = mock(SettingsBasedResolver.class);
+    private static final EventEmailFilter eventEmailFilter = spy(EventEmailFilter.acceptAll());
+    private static ReactorRabbitMQChannelPool channelPool;
+    private static SimpleConnectionPool connectionPool;
+    private static DavTestHelper davTestHelper;
+    private static Channel channel;
+
+    private CalDavClient calDavClient;
+    private CalendarDelegatedNotificationConsumer consumer;
+
+    private OpenPaaSUser bob;
+    private OpenPaaSUser alice;
+    private OpenPaaSDomain domain;
+
+    @BeforeAll
+    static void beforeAll(DockerSabreDavSetup dockerSabreDavSetup) throws Exception {
+        RabbitMQConfiguration rabbitMQConfiguration = dockerSabreDavSetup.rabbitMQConfiguration();
+
+        RabbitMQConnectionFactory connectionFactory = new RabbitMQConnectionFactory(rabbitMQConfiguration);
+        connectionPool = new SimpleConnectionPool(connectionFactory,
+            SimpleConnectionPool.Configuration.builder()
+                .retries(2)
+                .initialDelay(Duration.ofMillis(5)));
+        channelPool = new ReactorRabbitMQChannelPool(connectionPool.getResilientConnection(),
+            ReactorRabbitMQChannelPool.Configuration.builder()
+                .retries(2)
+                .maxBorrowDelay(Duration.ofMillis(250))
+                .maxChannel(10),
+            new RecordingMetricFactory(),
+            new NoopGaugeRegistry());
+        channelPool.start();
+
+        davTestHelper = new DavTestHelper(dockerSabreDavSetup.davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        channel = connectionPool.getResilientConnection().block().createChannel();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        channelPool.close();
+        connectionPool.close();
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        bob = sabreDavExtension.newTestUser(Optional.of("Bob"));
+        alice = sabreDavExtension.newTestUser(Optional.of("Alice"));
+        domain = new MongoDBOpenPaaSDomainDAO(sabreDavExtension.dockerSabreDavSetup().getMongoDB())
+            .retrieve(bob.username().getDomainPart().get()).block();
+
+        when(settingsResolver.resolveOrDefault(any(Username.class)))
+            .thenReturn(Mono.just(new SettingsBasedResolver.ResolvedSettings(
+                Map.of(LANGUAGE_IDENTIFIER, Locale.ENGLISH))));
+        setupConsumer();
+        clearSmtpMock();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (consumer != null) {
+            consumer.close();
+        }
+
+        Mockito.reset(settingsResolver);
+        Mockito.reset(eventEmailFilter);
+    }
+
+
+    private void setupConsumer() throws Exception {
+        MailSenderConfiguration mailSenderConfiguration = new MailSenderConfiguration(
+            "localhost", Port.of(mockSmtpExtension.getMockSmtp().getSmtpPort()),
+            "localhost", Optional.empty(), Optional.empty(),
+            false, false, false);
+
+        MailSender.Factory mailSenderFactory = new MailSender.Factory.Default(mailSenderConfiguration, EventEmailFilter.acceptAll());
+        FileSystemImpl fileSystem = FileSystemImpl.forTesting();
+        Path templateDirectory = Paths.get(Paths.get("").toAbsolutePath().getParent().toString(),
+            "app", "src", "main", "resources", "templates");
+
+        MailTemplateConfiguration mailTemplateConfig = new MailTemplateConfiguration("file://" + templateDirectory.toAbsolutePath(),
+            MaybeSender.getMailSender("no-reply@openpaas.org"));
+
+        MongoDatabase mongoDB = sabreDavExtension.dockerSabreDavSetup().getMongoDB();
+        MongoDBOpenPaaSDomainDAO domainDAO = new MongoDBOpenPaaSDomainDAO(mongoDB);
+        OpenPaaSUserDAO openPaaSUserDAO = new MongoDBOpenPaaSUserDAO(mongoDB, domainDAO);
+        MessageGenerator.Factory messageFactory = MessageGenerator.factory(mailTemplateConfig, fileSystem, openPaaSUserDAO);
+
+        URL spaCalendarURL = URI.create("https://localhost/").toURL();
+        Path logoPath = Paths.get("/Users/tungtv/workplace/twake-calendar-side-service/calendar-rest-api/src/main/resources/assets/calendar/logo.png");
+        byte[] calendarLogo;
+        try (InputStream is = Files.newInputStream(logoPath)) {
+            calendarLogo = IOUtils.toByteArray(is);
+        }
+
+        DelegatedCalendarNotificationHandler notificationHandler = new DelegatedCalendarNotificationHandler(
+            openPaaSUserDAO, calDavClient, settingsResolver, mailSenderFactory, mailTemplateConfig, messageFactory,
+            eventEmailFilter, spaCalendarURL, calendarLogo);
+
+        consumer = new CalendarDelegatedNotificationConsumer(channelPool, QueueArguments.Builder::new, notificationHandler);
+        consumer.init();
+    }
+
+    private final Supplier<JsonPath> smtpMailsResponseSupplier = () -> given(mockSMTPRequestSpecification())
+        .get("/smtpMails")
+        .jsonPath();
+
+    private void clearSmtpMock() {
+        given(mockSMTPRequestSpecification()).delete("/smtpMails").then();
+        given(mockSMTPRequestSpecification()).delete("/smtpBehaviors").then();
+    }
+
+    static RequestSpecification mockSMTPRequestSpecification() {
+        return new RequestSpecBuilder()
+            .setPort(mockSmtpExtension.getMockSmtp().getRestApiPort())
+            .setBasePath("")
+            .build();
+    }
+
+    @Test
+    void shouldSendMailWhenCalendarIsDelegated() {
+        String calendarName = "Bob Private1";
+        NewCalendar bobCalendar = new NewCalendar(UUID.randomUUID().toString(),
+            calendarName, "#123456", "Calendar for testing");
+        calDavClient.createNewCalendar(bob.username(), bob.id(), bobCalendar).block();
+
+        calDavClient.patchReadWriteDelegations(domain.id(), new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
+                List.of(alice.username()), List.of())
+            .block();
+
+        // Wait for the mail to be received via mock SMTP
+        awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
+        JsonPath smtpMailsResponse = smtpMailsResponseSupplier.get();
+
+        assertSoftly(Throwing.consumer(softly -> {
+            softly.assertThat(smtpMailsResponse.getString("[0].from")).isEqualTo("no-reply@openpaas.org");
+            softly.assertThat(smtpMailsResponse.getString("[0].recipients[0].address")).isEqualTo(alice.username().asString());
+            String subject = extractSubject(smtpMailsResponse.getString("[0].message"));
+            softly.assertThat(subject)
+                .isEqualTo("%s shared the “%s” calendar with you".formatted(bob.fullName(), calendarName));
+        }));
+    }
+
+    @Test
+    void shouldGenerateMailUsingRecipientLocale() {
+        String calendarName = "Bob Private1";
+        // Override settingsResolver to return Locale.FRENCH for Alice
+        when(settingsResolver.resolveOrDefault(any(Username.class)))
+            .thenReturn(Mono.just(new SettingsBasedResolver.ResolvedSettings(
+                Map.of(LANGUAGE_IDENTIFIER, Locale.FRENCH))));
+
+        NewCalendar bobCalendar = new NewCalendar(UUID.randomUUID().toString(),
+            calendarName, "#123456", "Calendar for testing");
+        calDavClient.createNewCalendar(bob.username(), bob.id(), bobCalendar).block();
+
+        calDavClient.patchReadWriteDelegations(domain.id(), new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
+                List.of(alice.username()), List.of())
+            .block();
+
+        // Wait for the mail to be received via mock SMTP
+        awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
+        JsonPath smtpMailsResponse = smtpMailsResponseSupplier.get();
+
+        assertSoftly(Throwing.consumer(softly -> {
+            softly.assertThat(smtpMailsResponse.getString("[0].from")).isEqualTo("no-reply@openpaas.org");
+            softly.assertThat(smtpMailsResponse.getString("[0].recipients[0].address")).isEqualTo(alice.username().asString());
+            String subject = extractSubject(smtpMailsResponse.getString("[0].message"));
+            // Expected French subject: "<Bob full name> a partagé le calendrier « <calendar name> » avec vous"
+            String expectedSubject = "%s a partagé le calendrier « %s » avec vous".formatted(bob.fullName(), calendarName);
+            softly.assertThat(subject)
+                .isEqualTo(expectedSubject);
+        }));
+    }
+
+
+    @Test
+    void shouldNotCrashWhenReceivingInvalidAMQPMessage() throws Exception {
+        // Step 1: Publish an invalid AMQP message payload directly to the queue
+        String queueName = "tcalendar:calendar:created";
+        byte[] invalidBody = "not a json".getBytes();
+        channel.basicPublish("", queueName, null, invalidBody);
+
+        // Step 2: Publish a valid delegated calendar creation flow: Bob creates a calendar and delegates to Alice
+        String calendarName = "Bob Private InvalidTest";
+        NewCalendar bobCalendar = new NewCalendar(UUID.randomUUID().toString(),
+            calendarName, "#654321", "Calendar for invalid message test");
+        calDavClient.createNewCalendar(bob.username(), bob.id(), bobCalendar).block();
+
+        calDavClient.patchReadWriteDelegations(domain.id(), new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
+                List.of(alice.username()), List.of())
+            .block();
+
+        // Step 3: Await until exactly ONE mail is received
+        awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
+        JsonPath smtpMailsResponse = smtpMailsResponseSupplier.get();
+
+        // Step 4: Assert: One mail exists, recipient is Alice
+        assertThat(smtpMailsResponse.getList("")).hasSize(1);
+        assertThat(smtpMailsResponse.getString("[0].recipients[0].address")).isEqualTo(alice.username().asString());
+    }
+
+    @Test
+    void shouldNotSendMailWhenEventEmailFilterRejects() throws InterruptedException {
+        when(eventEmailFilter.shouldProcess(any())).thenReturn(false);
+
+        String calendarName = "Bob Private FilterTest";
+        NewCalendar bobCalendar = new NewCalendar(UUID.randomUUID().toString(), calendarName,
+            "#abcdef", "Calendar for event email filter test");
+
+        // Bob creates a calendar
+        calDavClient.createNewCalendar(bob.username(), bob.id(), bobCalendar).block();
+
+        // Bob delegates the calendar to Alice
+        calDavClient.patchReadWriteDelegations(domain.id(), new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
+            List.of(alice.username()), List.of()).block();
+
+        Thread.sleep(1000);
+        // Then: no mail should be sent
+        awaitAtMost.untilAsserted(() ->
+            assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
+    }
+
+    @Test
+    void shouldNotSendMailWhenSelfSubscribedToSharedCalendar() throws InterruptedException {
+        // Given: Bob shares calendar with read access
+        davTestHelper.updateCalendarAcl(bob, CalendarURL.from(bob.id()).asUri(), "{DAV:}read");
+
+        SubscribedCalendarRequest subscribedCalendarRequest = SubscribedCalendarRequest.builder()
+            .id(UUID.randomUUID().toString())
+            .sourceUserId(bob.id().value())
+            .name("Bob readonly shared")
+            .color("#00FF00")
+            .readOnly(true)
+            .build();
+
+        // When: Alice subscribes to the shared calendar herself
+        davTestHelper.subscribeToSharedCalendar(alice, subscribedCalendarRequest);
+
+        Thread.sleep(1000);
+        // Then: No notification email is sent
+        awaitAtMost.untilAsserted(() ->
+            assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
+    }
+}

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
@@ -30,10 +30,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -44,7 +42,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.james.backends.rabbitmq.QueueArguments;
 import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.backends.rabbitmq.RabbitMQConnectionFactory;
@@ -192,12 +189,7 @@ public class CalendarDelegatedNotificationConsumerTest {
         MessageGenerator.Factory messageFactory = MessageGenerator.factory(mailTemplateConfig, fileSystem, openPaaSUserDAO);
 
         URL spaCalendarURL = URI.create("https://localhost/").toURL();
-        Path logoPath = Paths.get("/Users/tungtv/workplace/twake-calendar-side-service/calendar-rest-api/src/main/resources/assets/calendar/logo.png");
-        byte[] calendarLogo;
-        try (InputStream is = Files.newInputStream(logoPath)) {
-            calendarLogo = IOUtils.toByteArray(is);
-        }
-
+        byte[] calendarLogo = new byte[0];
         DelegatedCalendarNotificationHandler notificationHandler = new DelegatedCalendarNotificationHandler(
             openPaaSUserDAO, calDavClient, settingsResolver, mailSenderFactory, mailTemplateConfig, messageFactory,
             eventEmailFilter, spaCalendarURL, calendarLogo);
@@ -277,11 +269,10 @@ public class CalendarDelegatedNotificationConsumerTest {
         }));
     }
 
-
     @Test
     void shouldNotCrashWhenReceivingInvalidAMQPMessage() throws Exception {
         // Step 1: Publish an invalid AMQP message payload directly to the queue
-        String queueName = "tcalendar:calendar:created";
+        String queueName = "tcalendar:calendar:delegated:created";
         byte[] invalidBody = "not a json".getBytes();
         channel.basicPublish("", queueName, null, invalidBody);
 


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email notifications when a calendar is delegated: localized subject/body, logo, delegator & calendar details, and link.
  * New background consumer and reconnection handler to process delegated-calendar events with automatic restart on reconnect.
  * Queue registration for delegated-created events.

* **Localization**
  * Added English, French, Russian, and Vietnamese translations for delegation emails.

* **Tests**
  * New unit and integration tests for payload deserialization, delivery, localization, invalid payloads, and no-mail edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->