### PR TITLE
ISSUE-575 [WS calendarList] Handle delegated / subscribed events in WS layer

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarListNotificationHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarListNotificationHandler.java
@@ -65,12 +65,9 @@ public class CalendarListNotificationHandler {
     private ChangeType resolveChangeType(CalendarListExchange exchange, CalendarListChangesMessage message) {
         return switch (exchange) {
             case CALENDAR_CREATED -> resolveCalendarCreatedChangeType(message);
-            case CALENDAR_UPDATED -> ChangeType.UPDATED;
-            case CALENDAR_DELETED -> ChangeType.DELETED;
+            case CALENDAR_UPDATED, SUBSCRIPTION_UPDATED -> ChangeType.UPDATED;
+            case CALENDAR_DELETED, SUBSCRIPTION_DELETED -> ChangeType.DELETED;
             case SUBSCRIPTION_CREATED -> ChangeType.SUBSCRIBED;
-            // TODO https://github.com/linagora/esn-sabre/issues/261
-            case SUBSCRIPTION_UPDATED -> ChangeType.UPDATED;
-            case SUBSCRIPTION_DELETED -> ChangeType.RIGHTS_REVOKED;
         };
     }
 

--- a/storage-api/src/main/java/com/linagora/calendar/storage/CalendarListChangedEvent.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/CalendarListChangedEvent.java
@@ -40,8 +40,7 @@ public record CalendarListChangedEvent(Event.EventId eventId,
         UPDATED,
         DELETED,
         DELEGATED,
-        SUBSCRIBED,
-        RIGHTS_REVOKED;
+        SUBSCRIBED;
 
         public static ChangeType parse(String rawString) {
             Preconditions.checkArgument(StringUtils.isNotBlank(rawString), "ChangeType must not be blank");


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar event notifications for subscriptions, delegations, and multi-client scenarios to ensure proper event delivery and state synchronization across clients.
  * Fixed notification delivery for calendar visibility changes and delegation updates.

* **Tests**
  * Added comprehensive test coverage for WebSocket calendar operations and notification handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->