### PR TITLE
ISSUE-578 [WS calendarList] Document

### DIFF
--- a/docs/apis/websocket.md
+++ b/docs/apis/websocket.md
@@ -96,6 +96,16 @@ Disable:
 
 ### Server → Client
 
+#### Calendar list default subscription
+When a WebSocket connection is established, the server automatically subscribes the user to `calendarList` notifications.
+
+Ack message:
+```json
+{
+  "calendarListRegistered": true
+}
+```
+
 #### Register / Unregister response
 ```json
 {
@@ -121,6 +131,38 @@ Possible error values:
 | Forbidden     | The user has no access rights to the resource |
 | NotFound      | The resource does not exist |
 | InternalError | An unexpected server-side error |
+
+#### Calendar list push
+`calendarList` events notify clients about changes in the user-visible calendar list.
+
+Payload shape:
+```json
+{
+  "calendarList": {
+    "updated": ["/calendars/userA/12345"]
+  }
+}
+```
+
+Supported change keys:
+- `created`: a calendar is created by owner
+- `updated`: calendar metadata/rights changed
+- `deleted`: calendar is deleted/removed from the list
+- `delegated`: delegated calendar appears for delegate user
+- `subscribed`: subscribed calendar appears for subscriber user
+
+Delegation behavior:
+- Owner grants delegation (`dav:read-write`, `dav:read`, `dav:administration`) → owner receives `updated`
+- Owner revokes delegation → owner receives `updated`
+- Owner changes delegation right (example: `dav:read-write` to `dav:read`) → owner receives `updated`
+- Delegate receives `delegated` when delegated calendar is added
+- Delegate receives `deleted` when delegation is revoked
+
+Subscription behavior:
+- Subscriber subscribes to a shared/public calendar → subscriber receives `subscribed`
+- Subscriber renames subscribed calendar metadata (for example display name) → subscriber receives `updated`
+- Subscriber deletes subscribed calendar from their list → subscriber receives `deleted`
+- Owner hides/restricts source shared calendar so subscriber loses visibility → subscriber receives `deleted`
 
 #### Calendar Event push
 

--- a/docs/apis/websocket.md
+++ b/docs/apis/websocket.md
@@ -145,11 +145,11 @@ Payload shape:
 ```
 
 Supported change keys:
-- `created`: a calendar is created by owner
+- `created`: a calendar is created by the owner
 - `updated`: calendar metadata/rights changed
 - `deleted`: calendar is deleted/removed from the list
-- `delegated`: delegated calendar appears for delegate user
-- `subscribed`: subscribed calendar appears for subscriber user
+- `delegated`: delegated calendar appears for the delegate user
+- `subscribed`: subscribed calendar appears for the subscriber user
 
 Delegation behavior:
 - Owner grants delegation (`dav:read-write`, `dav:read`, `dav:administration`) → owner receives `updated`


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added WebSocket calendar list subscription docs, including default server acknowledgment indicating calendarList registration
  * Added calendar list push payload specification and supported change keys: created, updated, deleted, delegated, subscribed
  * Documented delegation and subscription behavior outcomes for calendar list changes
  * Clarified calendar event push wording (removes ambiguous qualifier)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->