### PR TITLE
[FIX] Handle null timezone in settings

### DIFF
--- a/storage-api/src/main/java/com/linagora/calendar/storage/configuration/resolver/SettingsBasedResolver.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/configuration/resolver/SettingsBasedResolver.java
@@ -89,6 +89,7 @@ public interface SettingsBasedResolver {
         public Optional<ZoneId> parse(JsonNode jsonNode) {
             try {
                 return Optional.ofNullable(jsonNode.get(TIMEZONE_KEY))
+                    .filter(node -> !node.isNull())
                     .map(JsonNode::asText)
                     .map(ZoneId::of);
             } catch (Exception e) {

--- a/storage-api/src/test/java/com/linagora/calendar/storage/configuration/resolver/SettingsBasedResolverTest.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/configuration/resolver/SettingsBasedResolverTest.java
@@ -126,6 +126,15 @@ public class SettingsBasedResolverTest {
     }
 
     @Test
+    void timezoneReaderShouldReturnEmptyWhenTimeZoneIsJsonNull() {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.putNull("timeZone");
+
+        Optional<ZoneId> result = SettingsBasedResolver.TimeZoneSettingReader.INSTANCE.parse(node);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
     void twoUsersShouldFallbackToSecondUserSettingsWhenFirstUserErrors() {
         Username externalUser = Username.of("external@remote.com");
         Username senderUser = Username.of("sender@local.com");


### PR DESCRIPTION
Fixes:

```
timestamp=2026-02-23T14:01:16.628Z, level=ERROR, thread=InnocuousThread-257, logger=com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver, message=Failed to parse time zone setting: {
  "timeZone" : null,
  "use24hourFormat" : false
}, context=default, exception=java.time.zone.ZoneRulesException: Unknown time-zone ID: null
	at java.base/java.time.zone.ZoneRulesProvider.getProvider(Unknown Source)
	at java.base/java.time.zone.ZoneRulesProvider.getRules(Unknown Source)
	at java.base/java.time.ZoneRegion.ofId(Unknown Source)
	at java.base/java.time.ZoneId.of(Unknown Source)
	at java.base/java.time.ZoneId.of(Unknown Source)
	at java.base/java.util.Optional.map(Unknown Source)
	at com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver$TimeZoneSettingReader.parse(SettingsBasedResolver.java:93)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where missing or null timezone configuration values could cause exceptions during calendar storage initialization. The system now gracefully handles these cases by returning an empty result instead of throwing an error.

* **Tests**
  * Added test coverage for null timezone configuration value handling to ensure robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->