### PR TITLE
ISSUE-603 [Public agenda] rest api to GET available slots (Public)

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -64,7 +64,6 @@ import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
 import com.linagora.calendar.storage.booking.MemoryBookingLinkDAO;
 
 import io.restassured.RestAssured;
-import io.restassured.authentication.PreemptiveBasicAuthScheme;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
 
@@ -128,10 +127,6 @@ class BookingLinkSlotsRouteTest {
         calendarDataProbe.addDomain(openPaaSUser.username().getDomainPart().get());
         calendarDataProbe.addUserToRepository(openPaaSUser.username(), PASSWORD);
 
-        PreemptiveBasicAuthScheme basicAuthScheme = new PreemptiveBasicAuthScheme();
-        basicAuthScheme.setUserName(openPaaSUser.username().asString());
-        basicAuthScheme.setPassword(PASSWORD);
-
         int restApiPort = server.getProbe(RestApiServerProbe.class).getPort().getValue();
         RestAssured.requestSpecification = new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
@@ -139,7 +134,6 @@ class BookingLinkSlotsRouteTest {
             .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .setPort(restApiPort)
             .setBasePath("")
-            .setAuth(basicAuthScheme)
             .build();
 
         davTestHelper = new DavTestHelper(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
@@ -155,7 +149,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", FROM_20360126)
             .queryParam("to", TO_20360127)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(JSON)
@@ -182,6 +176,23 @@ class BookingLinkSlotsRouteTest {
                   ]
                 }
                 """);
+    }
+
+    @Test
+    void shouldReturnSlotsWithoutAuthentication(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        given()
+            .auth().none()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON);
     }
 
     @Test
@@ -231,7 +242,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", FROM_20360126)
             .queryParam("to", TO_20360127)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(JSON)
@@ -300,7 +311,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", FROM_20360126)
             .queryParam("to", TO_20360127)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(JSON)
@@ -338,7 +349,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", from)
             .queryParam("to", to)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(JSON)
@@ -401,7 +412,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", FROM_20360126)
             .queryParam("to", TO_20360127)
             .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
             .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(JSON)
@@ -431,7 +442,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", "2036-01-01T00:00:00Z")
             .queryParam("to", "2036-03-05T00:00:00Z")
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .contentType(JSON)
@@ -464,7 +475,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", FROM_20360126)
             .queryParam("to", TO_20360127)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(JSON)
@@ -488,7 +499,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", "2036-01-26T00:00:00Z")
             .queryParam("to", "2036-01-26T02:00:00Z")
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(JSON)
@@ -518,7 +529,7 @@ class BookingLinkSlotsRouteTest {
             .pathParam("bookingLinkPublicId", inserted.publicId().value())
             .queryParam("to", TO_20360127)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .contentType(JSON)
@@ -547,7 +558,7 @@ class BookingLinkSlotsRouteTest {
             .pathParam("bookingLinkPublicId", inserted.publicId().value())
             .queryParam("from", FROM_20360126)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .contentType(JSON)
@@ -577,7 +588,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", "invalid")
             .queryParam("to", TO_20360127)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .contentType(JSON)
@@ -607,7 +618,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", FROM_20360126)
             .queryParam("to", "invalid")
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .contentType(JSON)
@@ -637,7 +648,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", FROM_20360126)
             .queryParam("to", FROM_20360126)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .contentType(JSON)
@@ -664,7 +675,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", FROM_20360126)
             .queryParam("to", TO_20360127)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND)
             .contentType(JSON)
@@ -685,37 +696,6 @@ class BookingLinkSlotsRouteTest {
     }
 
     @Test
-    void shouldReturnNotFoundWhenBookingLinkBelongsToAnotherUser(TwakeCalendarGuiceServer server) {
-        OpenPaaSUser otherUser = createTestUser(server, "other");
-        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(otherUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
-        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(otherUser.username(), insertRequest);
-
-        String response = given()
-            .pathParam("bookingLinkPublicId", inserted.publicId().value())
-            .queryParam("from", FROM_20360126)
-            .queryParam("to", TO_20360127)
-        .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
-        .then()
-            .statusCode(HttpStatus.SC_NOT_FOUND)
-            .contentType(JSON)
-            .extract()
-            .body()
-            .asString();
-
-        assertThatJson(response)
-            .describedAs("should return not found when booking link belongs to another user")
-            .isEqualTo("""
-                {
-                    "error": {
-                        "code": 404,
-                        "message": "Not Found",
-                        "details": "Cannot find booking link with publicId %s"
-                    }
-                }""".formatted(inserted.publicId().value()));
-    }
-
-    @Test
     void shouldReturnNotFoundWhenBookingLinkIsInactive(TwakeCalendarGuiceServer server) {
         boolean inactive = false;
         BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, inactive, Optional.of(AVAILABILITY_RULE));
@@ -726,7 +706,7 @@ class BookingLinkSlotsRouteTest {
             .queryParam("from", FROM_20360126)
             .queryParam("to", TO_20360127)
         .when()
-            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND)
             .contentType(JSON)

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -1,0 +1,170 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.app.restapi.routes;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.EncoderConfig.encoderConfig;
+import static io.restassured.config.RestAssuredConfig.newConfig;
+import static io.restassured.http.ContentType.JSON;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.apache.james.backends.rabbitmq.RabbitMQExtension.IsolationPolicy.WEAK;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+
+import org.apache.http.HttpStatus;
+import org.apache.james.backends.rabbitmq.RabbitMQExtension;
+import org.apache.james.core.Username;
+import org.apache.james.utils.GuiceProbe;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
+import com.linagora.calendar.api.booking.AvailabilityRules;
+import com.linagora.calendar.app.AppTestHelper;
+import com.linagora.calendar.app.TwakeCalendarConfiguration;
+import com.linagora.calendar.app.TwakeCalendarExtension;
+import com.linagora.calendar.app.TwakeCalendarGuiceServer;
+import com.linagora.calendar.app.modules.CalendarDataProbe;
+import com.linagora.calendar.restapi.RestApiServerProbe;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.booking.BookingLink;
+import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
+
+import io.restassured.RestAssured;
+import io.restassured.authentication.PreemptiveBasicAuthScheme;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+
+class BookingLinkSlotsRouteTest {
+    private static final String PASSWORD = "secret";
+
+    static class BookingLinkSlotsProbe implements GuiceProbe {
+        private final BookingLinkDAO bookingLinkDAO;
+
+        @Inject
+        BookingLinkSlotsProbe(BookingLinkDAO bookingLinkDAO) {
+            this.bookingLinkDAO = bookingLinkDAO;
+        }
+
+        BookingLink insert(Username username, BookingLinkInsertRequest request) {
+            return bookingLinkDAO.insert(username, request).block();
+        }
+    }
+
+    private OpenPaaSUser openPaaSUser;
+
+    @RegisterExtension
+    @Order(1)
+    private static final RabbitMQExtension rabbitMQExtension = RabbitMQExtension.singletonRabbitMQ()
+        .isolationPolicy(WEAK);
+
+    @RegisterExtension
+    @Order(2)
+    static TwakeCalendarExtension twakeCalendarExtension = new TwakeCalendarExtension(
+        TwakeCalendarConfiguration.builder()
+            .configurationFromClasspath()
+            .userChoice(TwakeCalendarConfiguration.UserChoice.MEMORY)
+            .dbChoice(TwakeCalendarConfiguration.DbChoice.MEMORY),
+        AppTestHelper.BY_PASS_MODULE.apply(rabbitMQExtension),
+        binder -> Multibinder.newSetBinder(binder, GuiceProbe.class)
+            .addBinding()
+            .to(BookingLinkSlotsProbe.class));
+
+    @AfterAll
+    static void afterAll() {
+        RestAssured.reset();
+    }
+
+    @BeforeEach
+    void setUp(TwakeCalendarGuiceServer server) {
+        Username username = Username.of("owner-%s@linagora.com".formatted(UUID.randomUUID()));
+        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
+        calendarDataProbe.addUser(username, PASSWORD);
+        openPaaSUser = calendarDataProbe.getUser(username);
+
+        PreemptiveBasicAuthScheme basicAuthScheme = new PreemptiveBasicAuthScheme();
+        basicAuthScheme.setUserName(openPaaSUser.username().asString());
+        basicAuthScheme.setPassword(PASSWORD);
+
+        int restApiPort = server.getProbe(RestApiServerProbe.class).getPort().getValue();
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+            .setContentType(ContentType.JSON)
+            .setAccept(ContentType.JSON)
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
+            .setPort(restApiPort)
+            .setBasePath("")
+            .setAuth(basicAuthScheme)
+            .build();
+    }
+
+    @Test
+    void getSlotsShouldReturn200ResponseInExpectedJsonFormat(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(
+            new CalendarURL(openPaaSUser.id(), openPaaSUser.id()),
+            Duration.ofMinutes(30),
+            BookingLinkInsertRequest.ACTIVE,
+            Optional.of(AvailabilityRules.of(new FixedAvailabilityRule(
+                ZonedDateTime.parse("2026-01-26T09:00:00Z"),
+                ZonedDateTime.parse("2026-01-26T12:00:00Z")))));
+
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class)
+            .insert(openPaaSUser.username(), insertRequest);
+
+        String response = given().log().all()
+            .when()
+            .get("/calendar/api/booking-links/%s/slots?from=2026-01-26T00:00:00Z&to=2026-01-27T00:00:00Z".formatted(inserted.publicId().value())).prettyPeek()
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                  "durationMinutes": 30,
+                  "range": {
+                    "from": "2026-01-26T00:00:00Z",
+                    "to": "2026-01-27T00:00:00Z"
+                  },
+                  "slots": [
+                    "2026-01-26T09:00:00Z",
+                    "2026-01-26T09:30:00Z",
+                    "2026-01-26T10:00:00Z",
+                    "2026-01-26T10:30:00Z",
+                    "2026-01-26T11:00:00Z",
+                    "2026-01-26T11:30:00Z"
+                  ]
+                }
+                """);
+    }
+}

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -18,12 +18,12 @@
 
 package com.linagora.calendar.app.restapi.routes;
 
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 import static io.restassured.http.ContentType.JSON;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.apache.james.backends.rabbitmq.RabbitMQExtension.IsolationPolicy.WEAK;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -34,7 +34,6 @@ import java.util.UUID;
 import jakarta.inject.Inject;
 
 import org.apache.http.HttpStatus;
-import org.apache.james.backends.rabbitmq.RabbitMQExtension;
 import org.apache.james.core.Username;
 import org.apache.james.utils.GuiceProbe;
 import org.junit.jupiter.api.AfterAll;
@@ -43,6 +42,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
 import com.linagora.calendar.api.booking.AvailabilityRules;
@@ -51,12 +51,17 @@ import com.linagora.calendar.app.TwakeCalendarConfiguration;
 import com.linagora.calendar.app.TwakeCalendarExtension;
 import com.linagora.calendar.app.TwakeCalendarGuiceServer;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
+import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.dav.DavTestHelper;
+import com.linagora.calendar.dav.DockerSabreDavSetup;
+import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
+import com.linagora.calendar.storage.booking.MemoryBookingLinkDAO;
 
 import io.restassured.RestAssured;
 import io.restassured.authentication.PreemptiveBasicAuthScheme;
@@ -65,6 +70,13 @@ import io.restassured.http.ContentType;
 
 class BookingLinkSlotsRouteTest {
     private static final String PASSWORD = "secret";
+    private static final long MAX_QUERY_RANGE_DAYS = 60;
+    private static final Duration DURATION_30_MINUTES = Duration.ofMinutes(30);
+    private static final String FROM_20360126 = "2036-01-26T00:00:00Z";
+    private static final String TO_20360127 = "2036-01-27T00:00:00Z";
+    private static final AvailabilityRules AVAILABILITY_RULE = AvailabilityRules.of(new FixedAvailabilityRule(
+        ZonedDateTime.parse("2036-01-26T09:00:00Z"),
+        ZonedDateTime.parse("2036-01-26T12:00:00Z")));
 
     static class BookingLinkSlotsProbe implements GuiceProbe {
         private final BookingLinkDAO bookingLinkDAO;
@@ -79,12 +91,9 @@ class BookingLinkSlotsRouteTest {
         }
     }
 
-    private OpenPaaSUser openPaaSUser;
-
     @RegisterExtension
     @Order(1)
-    private static final RabbitMQExtension rabbitMQExtension = RabbitMQExtension.singletonRabbitMQ()
-        .isolationPolicy(WEAK);
+    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
 
     @RegisterExtension
     @Order(2)
@@ -92,23 +101,32 @@ class BookingLinkSlotsRouteTest {
         TwakeCalendarConfiguration.builder()
             .configurationFromClasspath()
             .userChoice(TwakeCalendarConfiguration.UserChoice.MEMORY)
-            .dbChoice(TwakeCalendarConfiguration.DbChoice.MEMORY),
-        AppTestHelper.BY_PASS_MODULE.apply(rabbitMQExtension),
-        binder -> Multibinder.newSetBinder(binder, GuiceProbe.class)
-            .addBinding()
-            .to(BookingLinkSlotsProbe.class));
+            .dbChoice(TwakeCalendarConfiguration.DbChoice.MONGODB),
+        AppTestHelper.OIDC_BY_PASS_MODULE,
+        DavModuleTestHelper.FROM_SABRE_EXTENSION.apply(sabreDavExtension),
+        binder -> {
+            Multibinder.newSetBinder(binder, GuiceProbe.class)
+                .addBinding()
+                .to(BookingLinkSlotsProbe.class);
+
+            binder.bind(MemoryBookingLinkDAO.class).in(Scopes.SINGLETON);
+            binder.bind(BookingLinkDAO.class).to(MemoryBookingLinkDAO.class);
+        });
 
     @AfterAll
     static void afterAll() {
         RestAssured.reset();
     }
 
+    private OpenPaaSUser openPaaSUser;
+    private DavTestHelper davTestHelper;
+
     @BeforeEach
-    void setUp(TwakeCalendarGuiceServer server) {
-        Username username = Username.of("owner-%s@linagora.com".formatted(UUID.randomUUID()));
+    void setUp(TwakeCalendarGuiceServer server) throws Exception {
+        openPaaSUser = sabreDavExtension.newTestUser(Optional.of("owner"));
         CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
-        calendarDataProbe.addUser(username, PASSWORD);
-        openPaaSUser = calendarDataProbe.getUser(username);
+        calendarDataProbe.addDomain(openPaaSUser.username().getDomainPart().get());
+        calendarDataProbe.addUserToRepository(openPaaSUser.username(), PASSWORD);
 
         PreemptiveBasicAuthScheme basicAuthScheme = new PreemptiveBasicAuthScheme();
         basicAuthScheme.setUserName(openPaaSUser.username().asString());
@@ -123,24 +141,21 @@ class BookingLinkSlotsRouteTest {
             .setBasePath("")
             .setAuth(basicAuthScheme)
             .build();
+
+        davTestHelper = new DavTestHelper(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
     }
 
     @Test
-    void getSlotsShouldReturn200ResponseInExpectedJsonFormat(TwakeCalendarGuiceServer server) {
-        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(
-            new CalendarURL(openPaaSUser.id(), openPaaSUser.id()),
-            Duration.ofMinutes(30),
-            BookingLinkInsertRequest.ACTIVE,
-            Optional.of(AvailabilityRules.of(new FixedAvailabilityRule(
-                ZonedDateTime.parse("2026-01-26T09:00:00Z"),
-                ZonedDateTime.parse("2026-01-26T12:00:00Z")))));
+    void shouldReturnSlotsWhenRequestIsValid(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
 
-        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class)
-            .insert(openPaaSUser.username(), insertRequest);
-
-        String response = given().log().all()
-            .when()
-            .get("/calendar/api/booking-links/%s/slots?from=2026-01-26T00:00:00Z&to=2026-01-27T00:00:00Z".formatted(inserted.publicId().value())).prettyPeek()
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(JSON)
@@ -149,22 +164,593 @@ class BookingLinkSlotsRouteTest {
             .asString();
 
         assertThatJson(response)
+            .describedAs("should return full slots payload for a valid request")
             .isEqualTo("""
                 {
                   "durationMinutes": 30,
                   "range": {
-                    "from": "2026-01-26T00:00:00Z",
-                    "to": "2026-01-27T00:00:00Z"
+                    "from": "2036-01-26T00:00:00Z",
+                    "to": "2036-01-27T00:00:00Z"
                   },
                   "slots": [
-                    "2026-01-26T09:00:00Z",
-                    "2026-01-26T09:30:00Z",
-                    "2026-01-26T10:00:00Z",
-                    "2026-01-26T10:30:00Z",
-                    "2026-01-26T11:00:00Z",
-                    "2026-01-26T11:30:00Z"
+                    { "start": "2036-01-26T09:00:00Z" },
+                    { "start": "2036-01-26T09:30:00Z" },
+                    { "start": "2036-01-26T10:00:00Z" },
+                    { "start": "2036-01-26T10:30:00Z" },
+                    { "start": "2036-01-26T11:00:00Z" },
+                    { "start": "2036-01-26T11:30:00Z" }
                   ]
                 }
                 """);
+    }
+
+    @Test
+    void shouldExcludeBusyIntervalsFromReturnedSlots(TwakeCalendarGuiceServer server) {
+        // Given: an active booking link with a 09:00-12:00 availability window
+        // and two opaque busy events that overlap expected 30-minute slots.
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        // Given busy interval [09:30, 10:00): this should exclude slot starting at 09:30.
+        String firstUid = UUID.randomUUID().toString();
+        davTestHelper.upsertCalendar(openPaaSUser, """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Twake//BookingSlotsTest//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20360101T000000Z
+            DTSTART:20360126T093000Z
+            DTEND:20360126T100000Z
+            SUMMARY:busy-1x
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(firstUid), firstUid);
+
+        // Given busy interval [11:00, 11:30): this should exclude slot starting at 11:00.
+        String secondUid = UUID.randomUUID().toString();
+        davTestHelper.upsertCalendar(openPaaSUser, """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Twake//BookingSlotsTest//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20360101T000000Z
+            DTSTART:20360126T110000Z
+            DTEND:20360126T113000Z
+            SUMMARY:busy-2
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(secondUid), secondUid);
+
+        // When: requesting available slots for that date range via the booking slots endpoint.
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should exclude slots that overlap owner's busy intervals")
+            .inPath("$.slots")
+            .isEqualTo("""
+                [
+                  { "start": "2036-01-26T09:00:00Z" },
+                  { "start": "2036-01-26T10:00:00Z" },
+                  { "start": "2036-01-26T10:30:00Z" },
+                  { "start": "2036-01-26T11:30:00Z" }
+                ]
+                """);
+    }
+
+    @Test
+    void shouldExcludeOnlyCurrentUserBusyIntervalsFromReturnedSlots(TwakeCalendarGuiceServer server) {
+        // Given: two users, where both have busy events at the same period,
+        // but only user A owns the booking link being queried.
+        OpenPaaSUser otherUser = createTestUser(server, "other");
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        // Given owner busy interval [09:30, 10:00): this should exclude owner slot starting at 09:30.
+        String ownerBusyUid = UUID.randomUUID().toString();
+        davTestHelper.upsertCalendar(openPaaSUser, """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Twake//BookingSlotsTest//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20360101T000000Z
+            DTSTART:20360126T093000Z
+            DTEND:20360126T100000Z
+            SUMMARY:owner-busy
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(ownerBusyUid), ownerBusyUid);
+
+        // Given other-user busy interval [09:00, 12:00): this must not affect owner's returned slots.
+        String otherBusyUid = UUID.randomUUID().toString();
+        davTestHelper.upsertCalendar(otherUser, """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Twake//BookingSlotsTest//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20360101T000000Z
+            DTSTART:20360126T090000Z
+            DTEND:20360126T120000Z
+            SUMMARY:other-user-busy
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(otherBusyUid), otherBusyUid);
+
+        // When: user A requests slots for user A's booking link.
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should only apply owner's busy intervals and ignore another user's busy intervals")
+            .inPath("$.slots")
+            .isEqualTo("""
+                [
+                  { "start": "2036-01-26T09:00:00Z" },
+                  { "start": "2036-01-26T10:00:00Z" },
+                  { "start": "2036-01-26T10:30:00Z" },
+                  { "start": "2036-01-26T11:00:00Z" },
+                  { "start": "2036-01-26T11:30:00Z" }
+                ]
+                """);
+    }
+
+    @Test
+    void shouldComputeSlotsWhenQueryRangeContainsHourMinute(TwakeCalendarGuiceServer server) {
+        // Given a booking link with fixed availability 09:00-12:00 and 30-minute duration.
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        // Given query range containing HH:mm precision instead of full-day boundaries.
+        String from = "2036-01-26T09:00:00Z";
+        String to = "2036-01-26T10:45:00Z";
+
+        // When querying slots with hour-minute range.
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", from)
+            .queryParam("to", to)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        // Then computed slots respect the hour-minute request boundaries.
+        assertThatJson(response)
+            .describedAs("should compute slots correctly when query range has hour-minute precision")
+            .inPath("$.slots")
+            .isEqualTo("""
+                [
+                  { "start": "2036-01-26T09:00:00Z" },
+                  { "start": "2036-01-26T09:30:00Z" },
+                  { "start": "2036-01-26T10:00:00Z" }
+                ]
+                """);
+    }
+
+    @Test
+    void shouldExcludeSlotsOverlappingNonRoundedBusyIntervals(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String firstUid = UUID.randomUUID().toString();
+        davTestHelper.upsertCalendar(openPaaSUser, """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Twake//BookingSlotsTest//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20360101T000000Z
+            DTSTART:20360126T094000Z
+            DTEND:20360126T101000Z
+            SUMMARY:owner-busy-non-aligned-1
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(firstUid), firstUid);
+
+        String secondUid = UUID.randomUUID().toString();
+        davTestHelper.upsertCalendar(openPaaSUser, """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Twake//BookingSlotsTest//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20360101T000000Z
+            DTSTART:20360126T110500Z
+            DTEND:20360126T112000Z
+            SUMMARY:owner-busy-non-aligned-2
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(secondUid), secondUid);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+            .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should exclude slots overlapping busy intervals with non-rounded boundaries")
+            .inPath("$.slots")
+            .isEqualTo("""
+                [
+                  { "start": "2036-01-26T09:00:00Z" },
+                  { "start": "2036-01-26T10:10:00Z" },
+                  { "start": "2036-01-26T11:20:00Z" }
+                ]
+                """);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenRangeExceedsMaximumAllowedDays(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", "2036-01-01T00:00:00Z")
+            .queryParam("to", "2036-03-05T00:00:00Z")
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return bad request when requested range exceeds maximum allowed days")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 400,
+                        "message": "Bad Request",
+                        "details": "Requested range is too large, max is %s days"
+                    }
+                }""".formatted(MAX_QUERY_RANGE_DAYS));
+    }
+
+    @Test
+    void shouldReturnEmptySlotsWhenNoAvailabilityInRequestedRange(TwakeCalendarGuiceServer server) {
+        AvailabilityRules anotherDayRule = AvailabilityRules.of(new FixedAvailabilityRule(
+            ZonedDateTime.parse("2036-01-25T09:00:00Z"),
+            ZonedDateTime.parse("2036-01-25T12:00:00Z")));
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, anotherDayRule);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return empty slots when no availability matches requested range")
+            .inPath("$.slots")
+            .isEqualTo("[]");
+    }
+
+    @Test
+    void shouldUseFixedRuleFromQueryRangeWhenAvailabilityRulesIsAbsent(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, BookingLinkInsertRequest.ACTIVE, Optional.empty());
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", "2036-01-26T00:00:00Z")
+            .queryParam("to", "2036-01-26T02:00:00Z")
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should compute slots from query range when availability rules are absent")
+            .inPath("$.slots")
+            .isEqualTo("""
+                [
+                  { "start": "2036-01-26T00:00:00Z" },
+                  { "start": "2036-01-26T00:30:00Z" },
+                  { "start": "2036-01-26T01:00:00Z" },
+                  { "start": "2036-01-26T01:30:00Z" }
+                ]
+                """);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenFromQueryParamIsMissing(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return bad request when 'from' query parameter is missing")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 400,
+                        "message": "Bad Request",
+                        "details": "Missing or invalid query parameter 'from'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
+                    }
+                }""");
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenToQueryParamIsMissing(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return bad request when 'to' query parameter is missing")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 400,
+                        "message": "Bad Request",
+                        "details": "Missing or invalid query parameter 'to'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
+                    }
+                }""");
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenFromIsInvalidInstant(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", "invalid")
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return bad request when 'from' is not a valid instant")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 400,
+                        "message": "Bad Request",
+                        "details": "Missing or invalid query parameter 'from'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
+                    }
+                }""");
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenToIsInvalidInstant(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", "invalid")
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return bad request when 'to' is not a valid instant")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 400,
+                        "message": "Bad Request",
+                        "details": "Missing or invalid query parameter 'to'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
+                    }
+                }""");
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenToIsNotAfterFrom(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", FROM_20360126)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return bad request when 'to' is not after 'from'")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 400,
+                        "message": "Bad Request",
+                        "details": "'to' must be after 'from'"
+                    }
+                }""");
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenBookingLinkPublicIdDoesNotExist() {
+        String response = given()
+            .pathParam("bookingLinkPublicId", "missing-public-id")
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return not found when booking link public id does not exist")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 404,
+                        "message": "Not Found",
+                        "details": "Cannot find booking link with publicId missing-public-id"
+                    }
+                }""");
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenBookingLinkBelongsToAnotherUser(TwakeCalendarGuiceServer server) {
+        OpenPaaSUser otherUser = createTestUser(server, "other");
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(otherUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(otherUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return not found when booking link belongs to another user")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 404,
+                        "message": "Not Found",
+                        "details": "Cannot find booking link with publicId %s"
+                    }
+                }""".formatted(inserted.publicId().value()));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenBookingLinkIsInactive(TwakeCalendarGuiceServer server) {
+        boolean inactive = false;
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, inactive, Optional.of(AVAILABILITY_RULE));
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/calendar/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return not found when booking link is inactive")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 404,
+                        "message": "Not Found",
+                        "details": "Cannot find booking link with publicId %s"
+                    }
+                }""".formatted(inserted.publicId().value()));
+    }
+
+    private OpenPaaSUser createTestUser(TwakeCalendarGuiceServer server, String prefix) {
+        OpenPaaSUser user = sabreDavExtension.newTestUser(Optional.of(prefix + "-"));
+
+        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
+        calendarDataProbe.addUserToRepository(user.username(), PASSWORD);
+        return user;
     }
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -69,6 +69,7 @@ import com.linagora.calendar.restapi.auth.OidcAuthenticationStrategy;
 import com.linagora.calendar.restapi.auth.OidcEndpointsInfoResolver;
 import com.linagora.calendar.restapi.auth.OidcFallbackCookieAuthenticationStrategy;
 import com.linagora.calendar.restapi.routes.AvatarRoute;
+import com.linagora.calendar.restapi.routes.BookingLinkSlotsRoute;
 import com.linagora.calendar.restapi.routes.CalendarSearchRoute;
 import com.linagora.calendar.restapi.routes.CalendarTicketRoutes;
 import com.linagora.calendar.restapi.routes.CheckTechnicalUserTokenRoute;
@@ -138,6 +139,7 @@ public class RestApiModule extends AbstractModule {
 
         Multibinder<JMAPRoutes> routes = Multibinder.newSetBinder(binder(), JMAPRoutes.class);
         routes.addBinding().to(AvatarRoute.class);
+        routes.addBinding().to(BookingLinkSlotsRoute.class);
         routes.addBinding().to(DomainRoute.class);
         routes.addBinding().to(ThemeRoute.class);
         routes.addBinding().to(LogoRoute.class);

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
@@ -75,13 +75,13 @@ public class BookingLinkSlotsRoute extends CalendarRoute {
     Mono<Void> handleRequest(HttpServerRequest request, HttpServerResponse response, MailboxSession session) {
         return Mono.fromCallable(() -> new QueryStringDecoder(request.uri()))
             .flatMap(queryStringDecoder -> {
-                Instant from = parseRequiredInstant(queryStringDecoder, FROM_QUERY_PARAM);
-                Instant to = parseRequiredInstant(queryStringDecoder, TO_QUERY_PARAM);
-                validateRange(from, to);
+                Instant queryStart = parseRequiredInstant(queryStringDecoder, FROM_QUERY_PARAM);
+                Instant queryEnd = parseRequiredInstant(queryStringDecoder, TO_QUERY_PARAM);
+                validateRange(queryStart, queryEnd);
                 BookingLinkPublicId bookingLinkPublicId = new BookingLinkPublicId(request.param(BOOKING_LINK_PUBLIC_ID_PARAM));
 
-                return bookingLinkSlotsService.computeSlots(session.getUser(), bookingLinkPublicId, from, to)
-                    .flatMap(result -> doResponse(response, from, to, result.getLeft(), result.getRight()));
+                return bookingLinkSlotsService.computeSlots(session.getUser(), bookingLinkPublicId, queryStart, queryEnd)
+                    .flatMap(result -> doResponse(response, queryStart, queryEnd, result.getLeft(), result.getRight()));
             })
             .onErrorResume(Exception.class, exception -> switch (exception) {
                 case BookingLinkNotFoundException notFound -> {
@@ -116,16 +116,17 @@ public class BookingLinkSlotsRoute extends CalendarRoute {
                 .map(Instant::parse)
                 .orElseThrow();
         } catch (RuntimeException e) {
-            throw new IllegalArgumentException("Missing or invalid query parameter: " + parameterName, e);
+            throw new IllegalArgumentException("Missing or invalid query parameter '%s'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
+                    .formatted(parameterName), e);
         }
     }
 
     private Mono<Void> doResponse(HttpServerResponse response,
-                                  Instant from,
-                                  Instant to,
+                                  Instant queryStart,
+                                  Instant queryEnd,
                                   BookingLink bookingLink,
                                   Set<AvailabilitySlot> slots) {
-        return Mono.fromCallable(() -> BookingLinkSlotsResponse.of(bookingLink, from, to, slots).jsonAsBytes())
+        return Mono.fromCallable(() -> BookingLinkSlotsResponse.of(bookingLink, queryStart, queryEnd, slots).jsonAsBytes())
             .flatMap(bytes -> response.status(HttpResponseStatus.OK)
                 .headers(JSON_HEADER)
                 .sendByteArray(Mono.just(bytes))

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
@@ -24,12 +24,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
 import org.apache.james.jmap.Endpoint;
-import org.apache.james.jmap.http.Authenticator;
-import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.jmap.JMAPRoute;
+import org.apache.james.jmap.JMAPRoutes;
 import org.apache.james.metrics.api.MetricFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +48,7 @@ import reactor.core.publisher.Mono;
 import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
 
-public class BookingLinkSlotsRoute extends CalendarRoute {
+public class BookingLinkSlotsRoute implements JMAPRoutes {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BookingLinkSlotsRoute.class);
 
@@ -56,23 +57,29 @@ public class BookingLinkSlotsRoute extends CalendarRoute {
     private static final String TO_QUERY_PARAM = "to";
     private static final Duration MAX_QUERY_RANGE = Duration.ofDays(60);
 
+    private final MetricFactory metricFactory;
     private final BookingLinkSlotsService bookingLinkSlotsService;
 
     @Inject
-    public BookingLinkSlotsRoute(Authenticator authenticator,
-                                 MetricFactory metricFactory,
+    public BookingLinkSlotsRoute(MetricFactory metricFactory,
                                  BookingLinkSlotsService bookingLinkSlotsService) {
-        super(authenticator, metricFactory);
+        this.metricFactory = metricFactory;
         this.bookingLinkSlotsService = bookingLinkSlotsService;
     }
 
-    @Override
     Endpoint endpoint() {
-        return new Endpoint(HttpMethod.GET, "/calendar/api/booking-links/{%s}/slots".formatted(BOOKING_LINK_PUBLIC_ID_PARAM));
+        return new Endpoint(HttpMethod.GET, "/api/booking-links/{%s}/slots".formatted(BOOKING_LINK_PUBLIC_ID_PARAM));
     }
 
     @Override
-    Mono<Void> handleRequest(HttpServerRequest request, HttpServerResponse response, MailboxSession session) {
+    public Stream<JMAPRoute> routes() {
+        return Stream.of(JMAPRoute.builder()
+            .endpoint(endpoint())
+            .action((req, res) -> Mono.from(metricFactory.decoratePublisherWithTimerMetric(this.getClass().getSimpleName(), handleRequest(req, res))))
+            .corsHeaders());
+    }
+
+    Mono<Void> handleRequest(HttpServerRequest request, HttpServerResponse response) {
         return Mono.fromCallable(() -> new QueryStringDecoder(request.uri()))
             .flatMap(queryStringDecoder -> {
                 Instant queryStart = parseRequiredInstant(queryStringDecoder, FROM_QUERY_PARAM);
@@ -80,7 +87,7 @@ public class BookingLinkSlotsRoute extends CalendarRoute {
                 validateRange(queryStart, queryEnd);
                 BookingLinkPublicId bookingLinkPublicId = new BookingLinkPublicId(request.param(BOOKING_LINK_PUBLIC_ID_PARAM));
 
-                return bookingLinkSlotsService.computeSlots(session.getUser(), bookingLinkPublicId, queryStart, queryEnd)
+                return bookingLinkSlotsService.computeSlots(bookingLinkPublicId, queryStart, queryEnd)
                     .flatMap(result -> doResponse(response, queryStart, queryEnd, result.getLeft(), result.getRight()));
             })
             .onErrorResume(Exception.class, exception -> switch (exception) {
@@ -117,7 +124,7 @@ public class BookingLinkSlotsRoute extends CalendarRoute {
                 .orElseThrow();
         } catch (RuntimeException e) {
             throw new IllegalArgumentException("Missing or invalid query parameter '%s'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
-                    .formatted(parameterName), e);
+                .formatted(parameterName), e);
         }
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
@@ -1,0 +1,134 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.jmap.Endpoint;
+import org.apache.james.jmap.http.Authenticator;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.metrics.api.MetricFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
+import com.linagora.calendar.restapi.routes.response.BookingLinkSlotsResponse;
+import com.linagora.calendar.storage.booking.BookingLink;
+import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.server.HttpServerRequest;
+import reactor.netty.http.server.HttpServerResponse;
+
+public class BookingLinkSlotsRoute extends CalendarRoute {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BookingLinkSlotsRoute.class);
+
+    private static final String BOOKING_LINK_PUBLIC_ID_PARAM = "bookingLinkPublicId";
+    private static final String FROM_QUERY_PARAM = "from";
+    private static final String TO_QUERY_PARAM = "to";
+    private static final Duration MAX_QUERY_RANGE = Duration.ofDays(60);
+
+    private final BookingLinkSlotsService bookingLinkSlotsService;
+
+    @Inject
+    public BookingLinkSlotsRoute(Authenticator authenticator,
+                                 MetricFactory metricFactory,
+                                 BookingLinkSlotsService bookingLinkSlotsService) {
+        super(authenticator, metricFactory);
+        this.bookingLinkSlotsService = bookingLinkSlotsService;
+    }
+
+    @Override
+    Endpoint endpoint() {
+        return new Endpoint(HttpMethod.GET, "/calendar/api/booking-links/{%s}/slots".formatted(BOOKING_LINK_PUBLIC_ID_PARAM));
+    }
+
+    @Override
+    Mono<Void> handleRequest(HttpServerRequest request, HttpServerResponse response, MailboxSession session) {
+        return Mono.fromCallable(() -> new QueryStringDecoder(request.uri()))
+            .flatMap(queryStringDecoder -> {
+                Instant from = parseRequiredInstant(queryStringDecoder, FROM_QUERY_PARAM);
+                Instant to = parseRequiredInstant(queryStringDecoder, TO_QUERY_PARAM);
+                validateRange(from, to);
+                BookingLinkPublicId bookingLinkPublicId = new BookingLinkPublicId(request.param(BOOKING_LINK_PUBLIC_ID_PARAM));
+
+                return bookingLinkSlotsService.computeSlots(session.getUser(), bookingLinkPublicId, from, to)
+                    .flatMap(result -> doResponse(response, from, to, result.getLeft(), result.getRight()));
+            })
+            .onErrorResume(Exception.class, exception -> switch (exception) {
+                case BookingLinkNotFoundException notFound -> {
+                    LOGGER.warn("Booking link not found for [{}]: {}", request.uri(), notFound.getMessage());
+                    yield ErrorResponseHandler.handle(response, HttpResponseStatus.NOT_FOUND, notFound);
+                }
+                case IllegalArgumentException illegalArgumentException -> {
+                    LOGGER.warn("Bad request for [{}]: {}", request.uri(), illegalArgumentException.getMessage());
+                    yield ErrorResponseHandler.handle(response, HttpResponseStatus.BAD_REQUEST, illegalArgumentException);
+                }
+                default -> {
+                    LOGGER.error("Unexpected error for [{}]", request.uri(), exception);
+                    yield ErrorResponseHandler.handle(response, HttpResponseStatus.INTERNAL_SERVER_ERROR, exception);
+                }
+            });
+    }
+
+    private void validateRange(Instant from, Instant to) {
+        if (!to.isAfter(from)) {
+            throw new IllegalArgumentException("'to' must be after 'from'");
+        }
+        if (Duration.between(from, to).compareTo(MAX_QUERY_RANGE) > 0) {
+            throw new IllegalArgumentException("Requested range is too large, max is " + MAX_QUERY_RANGE.toDays() + " days");
+        }
+    }
+
+    private Instant parseRequiredInstant(QueryStringDecoder queryStringDecoder, String parameterName) {
+        try {
+            return queryStringDecoder.parameters().getOrDefault(parameterName, List.of())
+                .stream()
+                .findFirst()
+                .map(Instant::parse)
+                .orElseThrow();
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("Missing or invalid query parameter: " + parameterName, e);
+        }
+    }
+
+    private Mono<Void> doResponse(HttpServerResponse response,
+                                  Instant from,
+                                  Instant to,
+                                  BookingLink bookingLink,
+                                  Set<AvailabilitySlot> slots) {
+        return Mono.fromCallable(() -> BookingLinkSlotsResponse.of(bookingLink, from, to, slots).jsonAsBytes())
+            .flatMap(bytes -> response.status(HttpResponseStatus.OK)
+                .headers(JSON_HEADER)
+                .sendByteArray(Mono.just(bytes))
+                .then());
+    }
+}

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
@@ -1,0 +1,92 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.james.core.Username;
+
+import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
+import com.linagora.calendar.api.booking.AvailabilityRules;
+import com.linagora.calendar.api.booking.AvailableSlotsCalculator;
+import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
+import com.linagora.calendar.api.booking.AvailableSlotsCalculator.ComputeSlotsRequest;
+import com.linagora.calendar.api.booking.AvailableSlotsCalculator.UnavailableTimeRanges;
+import com.linagora.calendar.api.booking.AvailableSlotsCalculator.UnavailableTimeRanges.TimeRange;
+import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.storage.booking.BookingLink;
+import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+
+import reactor.core.publisher.Mono;
+
+public class BookingLinkSlotsService {
+    private final BookingLinkDAO bookingLinkDAO;
+    private final CalDavClient calDavClient;
+    private final AvailableSlotsCalculator availableSlotsCalculator;
+
+    @Inject
+    public BookingLinkSlotsService(BookingLinkDAO bookingLinkDAO, CalDavClient calDavClient) {
+        this.bookingLinkDAO = bookingLinkDAO;
+        this.calDavClient = calDavClient;
+        this.availableSlotsCalculator = new AvailableSlotsCalculator.Default();
+    }
+
+    public Mono<Pair<BookingLink, Set<AvailabilitySlot>>> computeSlots(Username username, BookingLinkPublicId publicId, Instant from, Instant to) {
+        return findActiveBookingLink(username, publicId)
+            .flatMap(bookingLink -> computeSlots(bookingLink, from, to)
+                .map(set -> Pair.of(bookingLink, set)));
+    }
+
+    private Mono<Set<AvailabilitySlot>> computeSlots(BookingLink bookingLink, Instant from, Instant to) {
+        return retrieveUnavailableTimeRanges(bookingLink, from, to)
+            .map(unavailableTimeRanges -> new ComputeSlotsRequest(
+                bookingLink.duration(), from, to,
+                resolveAvailabilityRules(bookingLink.availabilityRules(), from, to),
+                unavailableTimeRanges))
+            .map(availableSlotsCalculator::computeSlots);
+    }
+
+    private Mono<UnavailableTimeRanges> retrieveUnavailableTimeRanges(BookingLink bookingLink, Instant from, Instant to) {
+        return calDavClient.findBusyIntervals(bookingLink.username(), bookingLink.calendarUrl(), from, to)
+            .map(busyInterval -> new TimeRange(busyInterval.start(), busyInterval.end()))
+            .collectList()
+            .map(UnavailableTimeRanges::new);
+    }
+
+    private Mono<BookingLink> findActiveBookingLink(Username username, BookingLinkPublicId publicId) {
+        return bookingLinkDAO.findByPublicId(username, publicId)
+            .filter(BookingLink::active)
+            .switchIfEmpty(Mono.error(() -> new BookingLinkNotFoundException(publicId)));
+    }
+
+    private AvailabilityRules resolveAvailabilityRules(Optional<AvailabilityRules> availabilityRules, Instant fromRequest, Instant toRequest) {
+        return availabilityRules.orElseGet(() -> AvailabilityRules.of(
+            new FixedAvailabilityRule(ZonedDateTime.ofInstant(fromRequest, ZoneOffset.UTC),
+                ZonedDateTime.ofInstant(toRequest, ZoneOffset.UTC))));
+    }
+}

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
@@ -21,7 +21,6 @@ package com.linagora.calendar.restapi.routes;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.Optional;
 import java.util.Set;
 
 import jakarta.inject.Inject;
@@ -64,11 +63,20 @@ public class BookingLinkSlotsService {
 
     private Mono<Set<AvailabilitySlot>> computeSlots(BookingLink bookingLink, Instant from, Instant to) {
         return retrieveUnavailableTimeRanges(bookingLink, from, to)
-            .map(unavailableTimeRanges -> new ComputeSlotsRequest(
-                bookingLink.duration(), from, to,
-                resolveAvailabilityRules(bookingLink.availabilityRules(), from, to),
-                unavailableTimeRanges))
+            .map(unavailableTimeRanges -> toComputeSlotsRequest(bookingLink, from, to, unavailableTimeRanges))
             .map(availableSlotsCalculator::computeSlots);
+    }
+
+    private ComputeSlotsRequest toComputeSlotsRequest(BookingLink bookingLink,
+                                                      Instant from,
+                                                      Instant to,
+                                                      UnavailableTimeRanges unavailableTimeRanges) {
+        AvailabilityRules availabilityRules = bookingLink.availabilityRules()
+            .orElseGet(() -> AvailabilityRules.of(
+                new FixedAvailabilityRule(ZonedDateTime.ofInstant(from, ZoneOffset.UTC),
+                    ZonedDateTime.ofInstant(to, ZoneOffset.UTC))));
+
+        return new ComputeSlotsRequest(bookingLink.duration(), from, to, availabilityRules, unavailableTimeRanges);
     }
 
     private Mono<UnavailableTimeRanges> retrieveUnavailableTimeRanges(BookingLink bookingLink, Instant from, Instant to) {
@@ -84,9 +92,4 @@ public class BookingLinkSlotsService {
             .switchIfEmpty(Mono.error(() -> new BookingLinkNotFoundException(publicId)));
     }
 
-    private AvailabilityRules resolveAvailabilityRules(Optional<AvailabilityRules> availabilityRules, Instant fromRequest, Instant toRequest) {
-        return availabilityRules.orElseGet(() -> AvailabilityRules.of(
-            new FixedAvailabilityRule(ZonedDateTime.ofInstant(fromRequest, ZoneOffset.UTC),
-                ZonedDateTime.ofInstant(toRequest, ZoneOffset.UTC))));
-    }
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.james.core.Username;
 
 import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
 import com.linagora.calendar.api.booking.AvailabilityRules;
@@ -55,8 +54,8 @@ public class BookingLinkSlotsService {
         this.availableSlotsCalculator = new AvailableSlotsCalculator.Default();
     }
 
-    public Mono<Pair<BookingLink, Set<AvailabilitySlot>>> computeSlots(Username username, BookingLinkPublicId publicId, Instant from, Instant to) {
-        return findActiveBookingLink(username, publicId)
+    public Mono<Pair<BookingLink, Set<AvailabilitySlot>>> computeSlots(BookingLinkPublicId publicId, Instant from, Instant to) {
+        return findActiveBookingLink(publicId)
             .flatMap(bookingLink -> computeSlots(bookingLink, from, to)
                 .map(set -> Pair.of(bookingLink, set)));
     }
@@ -86,8 +85,8 @@ public class BookingLinkSlotsService {
             .map(UnavailableTimeRanges::new);
     }
 
-    private Mono<BookingLink> findActiveBookingLink(Username username, BookingLinkPublicId publicId) {
-        return bookingLinkDAO.findByPublicId(username, publicId)
+    private Mono<BookingLink> findActiveBookingLink(BookingLinkPublicId publicId) {
+        return bookingLinkDAO.findByPublicId(publicId)
             .filter(BookingLink::active)
             .switchIfEmpty(Mono.error(() -> new BookingLinkNotFoundException(publicId)));
     }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
@@ -22,22 +22,18 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
 import com.linagora.calendar.storage.booking.BookingLink;
 
 public record BookingLinkSlotsResponse(long durationMinutes,
                                        RangeDTO range,
-                                       @JsonFormat(shape = JsonFormat.Shape.ARRAY)
-                                       @JsonSerialize(contentUsing = InstantSerializer.class)
-                                       List<Instant> slots) {
+                                       List<SlotDTO> slots) {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
         .registerModule(new JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
@@ -47,6 +43,7 @@ public record BookingLinkSlotsResponse(long durationMinutes,
             slots.stream()
                 .map(AvailabilitySlot::start)
                 .sorted()
+                .map(SlotDTO::new)
                 .toList());
     }
 
@@ -54,6 +51,10 @@ public record BookingLinkSlotsResponse(long durationMinutes,
                            @JsonFormat(shape = JsonFormat.Shape.STRING) Instant from,
                            @JsonProperty("to")
                            @JsonFormat(shape = JsonFormat.Shape.STRING) Instant to) {
+    }
+
+    public record SlotDTO(@JsonProperty("start")
+                          @JsonFormat(shape = JsonFormat.Shape.STRING) Instant start) {
     }
 
     public byte[] jsonAsBytes() throws JsonProcessingException {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
@@ -1,0 +1,62 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes.response;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
+import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
+import com.linagora.calendar.storage.booking.BookingLink;
+
+public record BookingLinkSlotsResponse(long durationMinutes,
+                                       RangeDTO range,
+                                       @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+                                       @JsonSerialize(contentUsing = InstantSerializer.class)
+                                       List<Instant> slots) {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    public static BookingLinkSlotsResponse of(BookingLink bookingLink, Instant from, Instant to, Set<AvailabilitySlot> slots) {
+        return new BookingLinkSlotsResponse(bookingLink.duration().toMinutes(), new RangeDTO(from, to),
+            slots.stream()
+                .map(AvailabilitySlot::start)
+                .sorted()
+                .toList());
+    }
+
+    public record RangeDTO(@JsonProperty("from")
+                           @JsonFormat(shape = JsonFormat.Shape.STRING) Instant from,
+                           @JsonProperty("to")
+                           @JsonFormat(shape = JsonFormat.Shape.STRING) Instant to) {
+    }
+
+    public byte[] jsonAsBytes() throws JsonProcessingException {
+        return OBJECT_MAPPER.writeValueAsBytes(this);
+    }
+}

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkDAO.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkDAO.java
@@ -26,6 +26,8 @@ import reactor.core.publisher.Mono;
 public interface BookingLinkDAO {
     Mono<BookingLink> insert(Username username, BookingLinkInsertRequest request);
 
+    Mono<BookingLink> findByPublicId(BookingLinkPublicId publicId);
+
     Mono<BookingLink> findByPublicId(Username username, BookingLinkPublicId publicId);
 
     Flux<BookingLink> findByUsername(Username username);

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
@@ -37,4 +37,11 @@ public record BookingLinkInsertRequest(CalendarURL calendarUrl,
         Preconditions.checkArgument(!eventDuration.isNegative() && !eventDuration.isZero(), "'eventDuration' must be positive");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
     }
+
+    public BookingLinkInsertRequest(CalendarURL calendarUrl,
+                                    Duration eventDuration,
+                                    AvailabilityRules availabilityRules) {
+        this(calendarUrl, eventDuration, ACTIVE, Optional.of(availabilityRules));
+    }
+
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkNotFoundException.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkNotFoundException.java
@@ -20,6 +20,6 @@ package com.linagora.calendar.storage.booking;
 
 public class BookingLinkNotFoundException extends RuntimeException {
     public BookingLinkNotFoundException(BookingLinkPublicId publicId) {
-        super("Cannot find booking link with publicId " + publicId);
+        super("Cannot find booking link with publicId " + publicId.value());
     }
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
@@ -70,6 +70,11 @@ public class MemoryBookingLinkDAO implements BookingLinkDAO {
     }
 
     @Override
+    public Mono<BookingLink> findByPublicId(BookingLinkPublicId publicId) {
+        return Mono.justOrEmpty(store.column(publicId).values().stream().findFirst());
+    }
+
+    @Override
     public Flux<BookingLink> findByUsername(Username username) {
         return Flux.fromIterable(store.row(username).values());
     }

--- a/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
@@ -117,6 +117,24 @@ public interface BookingLinkDAOContract {
     }
 
     @Test
+    default void findByPublicIdShouldReturnInsertedBookingLink() {
+        BookingLink inserted = testee().insert(USER_1, INSERT_REQUEST).block();
+
+        BookingLink found = testee().findByPublicId(inserted.publicId()).block();
+
+        assertThat(found)
+            .isEqualTo(inserted);
+    }
+
+    @Test
+    default void findByPublicIdWithoutUsernameShouldReturnEmptyWhenPublicIdDoesNotExist() {
+        BookingLinkPublicId missingPublicId = new BookingLinkPublicId("missing-public-id");
+
+        assertThat(testee().findByPublicId(missingPublicId).blockOptional())
+            .isEmpty();
+    }
+
+    @Test
     default void findByUsernameShouldReturnEmptyByDefault() {
         assertThat(testee().findByUsername(USER_1).collectList().block())
             .isEmpty();

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBStorageModule.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBStorageModule.java
@@ -44,6 +44,8 @@ import com.linagora.calendar.storage.OpenPaaSDomainList;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.ResourceDAO;
 import com.linagora.calendar.storage.UploadedFileDAO;
+import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.MemoryBookingLinkDAO;
 import com.linagora.calendar.storage.configuration.UserConfigurationDAO;
 import com.linagora.calendar.storage.secretlink.SecretLinkStore;
 import com.linagora.tmail.james.jmap.ticket.TicketStore;
@@ -80,6 +82,10 @@ public class MongoDBStorageModule extends AbstractModule {
 
         bind(MongoDBTicketDAO.class).in(Scopes.SINGLETON);
         bind(TicketStore.class).to(MongoDBTicketDAO.class);
+
+        // TODO: https://github.com/linagora/twake-calendar-side-service/issues/600
+        bind(MemoryBookingLinkDAO.class).in(Scopes.SINGLETON);
+        bind(BookingLinkDAO.class).to(MemoryBookingLinkDAO.class);
 
         Multibinder.newSetBinder(binder(), HealthCheck.class)
             .addBinding()


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GET endpoint to fetch available slots for booking links (ISO-8601 range, max 60 days), returning JSON slots that exclude the link owner's busy times and provide detailed errors for invalid requests.

* **Tests**
  * New integration tests cover slot computation, edge cases, auth-free access, and error responses; DAO contract tests for public-id lookup.

* **Chores**
  * Registered the new route and an in-memory booking-link DAO for runtime/testing.
* **API**
  * Added public lookup by booking-link ID and a convenience constructor; improved not-found error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->