### PR TITLE
ISSUE-614 [Public Agenda] Send organizer confirmation email when a guest creates a booking

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -18,32 +18,45 @@
 
 package com.linagora.calendar.app.restapi.routes;
 
+import static com.linagora.calendar.app.restapi.routes.ImportRouteTest.mailSenderConfigurationFunction;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 import static io.restassured.http.ContentType.JSON;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import jakarta.inject.Inject;
 
 import org.apache.http.HttpStatus;
 import org.apache.james.core.Domain;
+import org.apache.james.core.MaybeSender;
 import org.apache.james.core.Username;
 import org.apache.james.utils.GuiceProbe;
 import org.assertj.core.groups.Tuple;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
@@ -66,6 +79,9 @@ import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
+import com.linagora.calendar.smtp.MailSenderConfiguration;
+import com.linagora.calendar.smtp.MockSmtpServerExtension;
+import com.linagora.calendar.smtp.template.MailTemplateConfiguration;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
@@ -79,6 +95,8 @@ import com.linagora.calendar.storage.event.EventParseUtils;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.specification.RequestSpecification;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.Property;
@@ -91,6 +109,10 @@ class BookingLinkReservationRouteTest {
     private static final AvailabilityRules AVAILABILITY_RULE = AvailabilityRules.of(new FixedAvailabilityRule(
         ZonedDateTime.parse("2036-01-26T09:00:00Z"),
         ZonedDateTime.parse("2036-01-26T12:00:00Z")));
+    private static final ConditionFactory CALMLY_AWAIT = Awaitility
+        .with().pollInterval(ONE_HUNDRED_MILLISECONDS)
+        .and().pollDelay(ONE_HUNDRED_MILLISECONDS)
+        .await();
 
     static class BookingLinkReservationProbe implements GuiceProbe {
         private final BookingLinkDAO bookingLinkDAO;
@@ -111,6 +133,10 @@ class BookingLinkReservationRouteTest {
 
     @RegisterExtension
     @Order(2)
+    static final MockSmtpServerExtension mockSmtpExtension = new MockSmtpServerExtension();
+
+    @RegisterExtension
+    @Order(3)
     static TwakeCalendarExtension twakeCalendarExtension = new TwakeCalendarExtension(
         TwakeCalendarConfiguration.builder()
             .configurationFromClasspath()
@@ -118,6 +144,11 @@ class BookingLinkReservationRouteTest {
             .dbChoice(TwakeCalendarConfiguration.DbChoice.MONGODB),
         AppTestHelper.OIDC_BY_PASS_MODULE,
         DavModuleTestHelper.FROM_SABRE_EXTENSION.apply(sabreDavExtension),
+        binder -> binder.bind(MailTemplateConfiguration.class)
+            .toInstance(new MailTemplateConfiguration("classpath://templates/",
+                MaybeSender.getMailSender("no-reply@openpaas.org"))),
+        binder -> binder.bind(MailSenderConfiguration.class)
+            .toInstance(mailSenderConfigurationFunction.apply(mockSmtpExtension)),
         binder -> {
             Multibinder.newSetBinder(binder, GuiceProbe.class)
                 .addBinding()
@@ -135,6 +166,14 @@ class BookingLinkReservationRouteTest {
     private OpenPaaSUser openPaaSUser;
     private CalDavClient calDavClient;
     private DavTestHelper davTestHelper;
+    private int restApiPort;
+
+    static RequestSpecification mockSMTPRequestSpecification() {
+        return new RequestSpecBuilder()
+            .setPort(mockSmtpExtension.getMockSmtp().getRestApiPort())
+            .setBasePath("")
+            .build();
+    }
 
     @BeforeEach
     void setUp(TwakeCalendarGuiceServer server) throws Exception {
@@ -144,7 +183,7 @@ class BookingLinkReservationRouteTest {
         calendarDataProbe.addUser(ownerUsername, PASSWORD, "Owner", "User");
         openPaaSUser = calendarDataProbe.getUser(ownerUsername);
 
-        int restApiPort = server.getProbe(RestApiServerProbe.class).getPort().getValue();
+        restApiPort = server.getProbe(RestApiServerProbe.class).getPort().getValue();
         RestAssured.requestSpecification = new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
             .setAccept(ContentType.JSON)
@@ -155,6 +194,14 @@ class BookingLinkReservationRouteTest {
 
         calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
         davTestHelper = new DavTestHelper(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+
+        given(mockSMTPRequestSpecification())
+            .delete("/smtpMails")
+            .then();
+
+        given(mockSMTPRequestSpecification())
+            .delete("/smtpBehaviors")
+            .then();
     }
 
     @Test
@@ -262,6 +309,139 @@ class BookingLinkReservationRouteTest {
             softly.assertThat(getPropertyValue.apply("X-PUBLICLY-CREATOR"))
                 .isEqualTo("creator@example.com");
         });
+    }
+
+    @Test
+    void shouldSendProposalEmailToOrganizerWhenBookingCreated(TwakeCalendarGuiceServer server) {
+        BookingLink inserted = insertActiveBookingLink(server);
+        String slotStartUtc = getAvailableSlots(inserted.publicId()).getFirst();
+
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body("""
+                {
+                  "startUtc": "%s",
+                  "creator": {
+                    "name": "BOB",
+                    "email": "creator@example.com"
+                  },
+                  "eventTitle": "30-min intro call"
+                }
+                """.formatted(slotStartUtc))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+
+        JsonPath smtpMailsResponse = awaitProposalEmail();
+
+        assertSoftly(softly -> {
+            softly.assertThat(smtpMailsResponse.getString("[0].from")).isEqualTo("no-reply@openpaas.org");
+            softly.assertThat(smtpMailsResponse.getString("[0].recipients[0].address")).isEqualTo(openPaaSUser.username().asString());
+            softly.assertThat(smtpMailsResponse.getString("[0].message")).contains("Subject: New event proposition from BOB: 30-min intro call");
+        });
+    }
+
+    @Test
+    void shouldIncludeThreeParticipationActionLinksInProposalEmail(TwakeCalendarGuiceServer server) {
+        BookingLink inserted = insertActiveBookingLink(server);
+        String slotStartUtc = getAvailableSlots(inserted.publicId()).getFirst();
+
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body("""
+                {
+                  "startUtc": "%s",
+                  "creator": {
+                    "name": "BOB",
+                    "email": "creator@example.com"
+                  },
+                  "eventTitle": "30-min intro call"
+                }
+                """.formatted(slotStartUtc))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+
+        String rawMessage = awaitProposalEmail().getString("[0].message");
+        List<String> actionLinks = extractParticipationActionLinks(getHtml(rawMessage));
+
+        assertSoftly(softly -> {
+            softly.assertThat(actionLinks).hasSize(3).doesNotHaveDuplicates();
+            softly.assertThat(actionLinks).allMatch(link -> link.startsWith("https://excal.linagora.com/excal/?jwt="));
+        });
+
+        String actualResponse = given()
+            .when()
+            .get(toParticipationEndpoint(actionLinks.getFirst()))
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(actualResponse).isEqualTo("""
+            {
+              "eventJSON": "${json-unit.ignore}",
+              "attendeeEmail": "%s",
+              "locale": "en",
+              "links": {
+                "yes": "${json-unit.ignore}",
+                "no": "${json-unit.ignore}",
+                "maybe": "${json-unit.ignore}"
+              }
+            }
+            """.formatted(openPaaSUser.username().asString()));
+    }
+
+    @Test
+    void shouldUpdateOrganizerPartStatWhenProposalActionLinksAreAccessed(TwakeCalendarGuiceServer server) {
+        BookingLink inserted = insertActiveBookingLink(server);
+        String slotStartUtc = getAvailableSlots(inserted.publicId()).getFirst();
+
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body("""
+                {
+                  "startUtc": "%s",
+                  "creator": {
+                    "name": "BOB",
+                    "email": "creator@example.com"
+                  },
+                  "eventTitle": "30-min intro call"
+                }
+                """.formatted(slotStartUtc))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+
+        List<String> actionLinks = extractParticipationActionLinks(getHtml(awaitProposalEmail().getString("[0].message")));
+        Map<String, String> linksByLabel = Map.of(
+            "yes", actionLinks.get(0),
+            "maybe", actionLinks.get(1),
+            "no", actionLinks.get(2));
+        Consumer<String> awaitOrganizerPartStat = expectedPartStat ->
+            CALMLY_AWAIT
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(exportCalendar(openPaaSUser)
+                    .replace("\r\n ", ""))
+                    .contains("ATTENDEE;RSVP=TRUE;ROLE=CHAIR;CUTYPE=INDIVIDUAL;CN=%s;PARTSTAT=%s:mailto:%s"
+                        .formatted(openPaaSUser.fullName(), expectedPartStat, openPaaSUser.username().asString())));
+
+        given().when().get(toParticipationEndpoint(linksByLabel.get("yes")))
+            .then().statusCode(HttpStatus.SC_OK).contentType(JSON);
+        awaitOrganizerPartStat.accept("ACCEPTED");
+
+        given().when().get(toParticipationEndpoint(linksByLabel.get("maybe")))
+            .then().statusCode(HttpStatus.SC_OK).contentType(JSON);
+        awaitOrganizerPartStat.accept("TENTATIVE");
+
+        given().when().get(toParticipationEndpoint(linksByLabel.get("no")))
+            .then().statusCode(HttpStatus.SC_OK).contentType(JSON);
+        awaitOrganizerPartStat.accept("DECLINED");
     }
 
     @Test
@@ -949,6 +1129,51 @@ class BookingLinkReservationRouteTest {
               "notes": ""
             }
             """.formatted(slotStartUtc);
+    }
+
+    private JsonPath awaitProposalEmail() {
+        java.util.function.Supplier<JsonPath> smtpMailsResponseSupplier = () -> given(mockSMTPRequestSpecification())
+            .get("/smtpMails")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .jsonPath();
+
+        CALMLY_AWAIT
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
+
+        return smtpMailsResponseSupplier.get();
+    }
+
+    private String getHtml(String message) {
+        Pattern htmlPattern = Pattern.compile(
+            "Content-Transfer-Encoding: base64\\r?\\nContent-Type: text/html; charset=UTF-8\\r?\\nContent-Language: [^\\r\\n]+\\r?\\n\\r?\\n([A-Za-z0-9+/=\\r\\n]+)\\r?\\n---=Part",
+            Pattern.DOTALL);
+        Matcher matcher = htmlPattern.matcher(message);
+        assertThat(matcher.find()).isTrue();
+        String base64Html = matcher.group(1).replaceAll("\\s+", "");
+        return new String(Base64.getDecoder().decode(base64Html), StandardCharsets.UTF_8);
+    }
+
+    private List<String> extractParticipationActionLinks(String html) {
+        List<String> links = new ArrayList<>();
+        Pattern pattern = Pattern.compile("href\\s*=\\s*['\"]([^'\"]+)['\"]", Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(html);
+
+        while (matcher.find()) {
+            String link = matcher.group(1);
+            if (link.startsWith("https://excal.linagora.com/excal/?jwt=")) {
+                links.add(link);
+            }
+        }
+        return links;
+    }
+
+    private String toParticipationEndpoint(String excalLink) {
+        String jwt = excalLink.substring("https://excal.linagora.com/excal/?jwt=".length());
+        return String.format("http://localhost:%d/calendar/api/calendars/event/participation?jwt=%s",
+            restApiPort, URLEncoder.encode(jwt, StandardCharsets.UTF_8));
     }
 
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -93,6 +93,7 @@ import com.linagora.calendar.restapi.routes.LogoRoute;
 import com.linagora.calendar.restapi.routes.PeopleSearchRoute;
 import com.linagora.calendar.restapi.routes.ProfileAvatarRoute;
 import com.linagora.calendar.restapi.routes.ProfileUpdateRoute;
+import com.linagora.calendar.restapi.routes.PublicAgendaProposalNotifier;
 import com.linagora.calendar.restapi.routes.ResourceIconRoute;
 import com.linagora.calendar.restapi.routes.ResourceParticipationRoute;
 import com.linagora.calendar.restapi.routes.ResourceRoute;
@@ -202,6 +203,7 @@ public class RestApiModule extends AbstractModule {
         bind(ImportWebSocketNotifier.class).in(Scopes.SINGLETON);
         bind(SendMailNotifier.class).in(Scopes.SINGLETON);
         bind(BookingLinkSlotsService.class).in(Scopes.SINGLETON);
+        bind(PublicAgendaProposalNotifier.class).in(Scopes.SINGLETON);
 
         Multibinder<ImportResultNotifier> importResultNotifierMultibinder = Multibinder.newSetBinder(binder(), ImportResultNotifier.class);
         importResultNotifierMultibinder.addBinding().to(ImportWebSocketNotifier.class);

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
@@ -27,6 +27,8 @@ import jakarta.mail.internet.AddressException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.james.core.MailAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
@@ -44,6 +46,7 @@ import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 import reactor.core.publisher.Mono;
 
 public class BookingLinkReservationService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BookingLinkReservationService.class);
 
     private final BookingLinkDAO bookingLinkDAO;
     private final BookingLinkSlotsService bookingLinkSlotsService;
@@ -95,9 +98,18 @@ public class BookingLinkReservationService {
 
                 return calDavClient.importCalendar(bookingLink.calendarUrl(), eventIcsResult.eventIdAsString(), bookingLink.username(), eventIcsResult.icsBytes())
                     .onErrorMap(throwable -> BookingLinkReservationException.createEventFailed(bookingLink.publicId(), eventIcsResult.eventIdAsString(), throwable))
-                    .then(publicAgendaProposalNotifier.notify(new BookingCreated(bookingLink, request, organizer, eventIcsResult)));
+                    .then(notifyBookingCreated(new BookingCreated(bookingLink, request, organizer, eventIcsResult)));
             })
             .then();
+    }
+
+    private Mono<Void> notifyBookingCreated(BookingCreated bookingCreated) {
+        return publicAgendaProposalNotifier.notify(bookingCreated)
+            .onErrorResume(error -> {
+                LOGGER.warn("Failed to send proposal notification for booking {}: {}",
+                    bookingCreated.eventIcsResult().eventIdAsString(), error.getMessage(), error);
+                return Mono.empty();
+            });
     }
 
     public record BookingRequest(Instant slotStartUtc,

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
@@ -32,7 +32,9 @@ import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.restapi.RestApiConfiguration;
+import com.linagora.calendar.restapi.routes.BookingLinkEventIcsBuilder.BuildResult;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest.BookingAttendee;
+import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
@@ -48,6 +50,7 @@ public class BookingLinkReservationService {
     private final BookingLinkEventIcsBuilder bookingLinkEventIcsBuilder;
     private final CalDavClient calDavClient;
     private final OpenPaaSUserDAO openPaaSUserDAO;
+    private final PublicAgendaProposalNotifier publicAgendaProposalNotifier;
 
     @Inject
     public BookingLinkReservationService(BookingLinkDAO bookingLinkDAO,
@@ -55,11 +58,13 @@ public class BookingLinkReservationService {
                                          BookingLinkSlotsService bookingLinkSlotsService,
                                          RestApiConfiguration restApiConfiguration,
                                          CalDavClient calDavClient,
-                                         OpenPaaSUserDAO openPaaSUserDAO) {
+                                         OpenPaaSUserDAO openPaaSUserDAO,
+                                         PublicAgendaProposalNotifier publicAgendaProposalNotifier) {
         this.bookingLinkDAO = bookingLinkDAO;
         this.calDavClient = calDavClient;
         this.bookingLinkSlotsService = bookingLinkSlotsService;
         this.openPaaSUserDAO = openPaaSUserDAO;
+        this.publicAgendaProposalNotifier = publicAgendaProposalNotifier;
         this.bookingLinkEventIcsBuilder = new BookingLinkEventIcsBuilder(clock, new MeetingConferenceLinkResolver.Visio(restApiConfiguration));
 
     }
@@ -84,10 +89,15 @@ public class BookingLinkReservationService {
 
     private Mono<Void> createBooking(BookingLink bookingLink, BookingRequest request) {
         return openPaaSUserDAO.retrieve(bookingLink.username())
-            .map(owner -> BookingAttendee.from(owner.fullName(), owner.username().asString()))
-            .map(organizer -> bookingLinkEventIcsBuilder.build(request, organizer, bookingLink.duration()))
-            .flatMap(eventIcsResult -> calDavClient.importCalendar(bookingLink.calendarUrl(), eventIcsResult.eventIdAsString(), bookingLink.username(), eventIcsResult.icsBytes())
-                .onErrorMap(throwable -> BookingLinkReservationException.createEventFailed(bookingLink.publicId(), eventIcsResult.eventIdAsString(), throwable)).then());
+            .flatMap(organizer -> {
+                BuildResult eventIcsResult = bookingLinkEventIcsBuilder.build(request,
+                    BookingAttendee.from(organizer.fullName(), organizer.username().asString()), bookingLink.duration());
+
+                return calDavClient.importCalendar(bookingLink.calendarUrl(), eventIcsResult.eventIdAsString(), bookingLink.username(), eventIcsResult.icsBytes())
+                    .onErrorMap(throwable -> BookingLinkReservationException.createEventFailed(bookingLink.publicId(), eventIcsResult.eventIdAsString(), throwable))
+                    .then(publicAgendaProposalNotifier.notify(new BookingCreated(bookingLink, request, organizer, eventIcsResult)));
+            })
+            .then();
     }
 
     public record BookingRequest(Instant slotStartUtc,
@@ -113,6 +123,12 @@ public class BookingLinkReservationService {
             Preconditions.checkNotNull(additionalAttendees, "'additionalAttendees' must not be null");
             Preconditions.checkArgument(StringUtils.isNotBlank(title), "'eventTitle' must not be blank");
         }
+    }
+
+    public record BookingCreated(BookingLink bookingLink,
+                                 BookingRequest request,
+                                 OpenPaaSUser organizer,
+                                 BuildResult eventIcsResult) {
     }
 
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/PublicAgendaProposalNotifier.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/PublicAgendaProposalNotifier.java
@@ -19,7 +19,6 @@
 package com.linagora.calendar.restapi.routes;
 
 import static com.linagora.calendar.smtp.template.MimeAttachment.ATTACHMENT_DISPOSITION_TYPE;
-import static reactor.core.scheduler.Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -60,7 +59,6 @@ import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolve
 
 import net.fortuna.ical4j.model.property.immutable.ImmutableMethod;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 public class PublicAgendaProposalNotifier {
@@ -76,7 +74,6 @@ public class PublicAgendaProposalNotifier {
     private final EventInCalendarLinkFactory eventInCalendarLinkFactory;
     private final MailSender.Factory mailSenderFactory;
     private final MailAddress fromMailAddress;
-    private final Scheduler mailScheduler;
 
     @Inject
     @Singleton
@@ -94,7 +91,6 @@ public class PublicAgendaProposalNotifier {
         this.mailSenderFactory = mailSenderFactory;
         this.fromMailAddress = templateConfiguration.sender().asOptional()
             .orElseThrow(() -> new IllegalArgumentException("Sender address must not be empty"));
-        this.mailScheduler = Schedulers.newBoundedElastic(1, DEFAULT_BOUNDED_ELASTIC_QUEUESIZE, "sendMailScheduler");
     }
 
     public Mono<Void> notify(BookingCreated bookingCreated) {
@@ -106,7 +102,7 @@ public class PublicAgendaProposalNotifier {
                         bookingCreated.bookingLink().calendarUrl().base().value())
                     .flatMap(actionLinks -> generateMail(settings, bookingCreated, actionLinks))
                     .flatMap(mail -> mailSenderFactory.create().flatMap(mailSender -> mailSender.send(mail)))))
-            .subscribeOn(mailScheduler)
+            .subscribeOn(Schedulers.boundedElastic())
             .then();
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/PublicAgendaProposalNotifier.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/PublicAgendaProposalNotifier.java
@@ -1,0 +1,214 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import static com.linagora.calendar.smtp.template.MimeAttachment.ATTACHMENT_DISPOSITION_TYPE;
+import static reactor.core.scheduler.Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.james.core.MailAddress;
+import org.apache.james.mailbox.model.ContentType;
+import org.apache.james.mime4j.dom.Message;
+
+import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableMap;
+import com.linagora.calendar.api.EventParticipationActionLinkFactory;
+import com.linagora.calendar.api.EventParticipationActionLinkFactory.ActionLinks;
+import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingCreated;
+import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest.BookingAttendee;
+import com.linagora.calendar.smtp.Mail;
+import com.linagora.calendar.smtp.MailSender;
+import com.linagora.calendar.smtp.template.Language;
+import com.linagora.calendar.smtp.template.MailTemplateConfiguration;
+import com.linagora.calendar.smtp.template.MessageGenerator;
+import com.linagora.calendar.smtp.template.MimeAttachment;
+import com.linagora.calendar.smtp.template.TemplateType;
+import com.linagora.calendar.smtp.template.content.model.EventInCalendarLinkFactory;
+import com.linagora.calendar.smtp.template.content.model.EventTimeModel;
+import com.linagora.calendar.smtp.template.content.model.PersonModel;
+import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
+import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver.ResolvedSettings;
+
+import net.fortuna.ical4j.model.property.immutable.ImmutableMethod;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+public class PublicAgendaProposalNotifier {
+    private static final TemplateType EVENT_PROPOSE_TEMPLATE = new TemplateType("event-propose");
+    private static final String CALENDAR_CONTENT_TYPE_PREFIX = "text/calendar; charset=UTF-8; method=";
+    private static final String ICS_CONTENT_TYPE = "application/ics";
+    private static final String ICS_FILENAME = "meeting.ics";
+
+    private final SettingsBasedResolver settingsResolver;
+    private final EventParticipationActionLinkFactory actionLinkFactory;
+    private final MailTemplateConfiguration templateConfiguration;
+    private final MessageGenerator.Factory messageGeneratorFactory;
+    private final EventInCalendarLinkFactory eventInCalendarLinkFactory;
+    private final MailSender.Factory mailSenderFactory;
+    private final MailAddress fromMailAddress;
+    private final Scheduler mailScheduler;
+
+    @Inject
+    @Singleton
+    public PublicAgendaProposalNotifier(@Named("language_timezone") SettingsBasedResolver settingsResolver,
+                                        EventParticipationActionLinkFactory actionLinkFactory,
+                                        MailTemplateConfiguration templateConfiguration,
+                                        MessageGenerator.Factory messageGeneratorFactory,
+                                        EventInCalendarLinkFactory eventInCalendarLinkFactory,
+                                        MailSender.Factory mailSenderFactory) {
+        this.settingsResolver = settingsResolver;
+        this.actionLinkFactory = actionLinkFactory;
+        this.templateConfiguration = templateConfiguration;
+        this.messageGeneratorFactory = messageGeneratorFactory;
+        this.eventInCalendarLinkFactory = eventInCalendarLinkFactory;
+        this.mailSenderFactory = mailSenderFactory;
+        this.fromMailAddress = templateConfiguration.sender().asOptional()
+            .orElseThrow(() -> new IllegalArgumentException("Sender address must not be empty"));
+        this.mailScheduler = Schedulers.newBoundedElastic(1, DEFAULT_BOUNDED_ELASTIC_QUEUESIZE, "sendMailScheduler");
+    }
+
+    public Mono<Void> notify(BookingCreated bookingCreated) {
+        return settingsResolver.resolveOrDefault(bookingCreated.organizer().username())
+            .flatMap(settings -> Mono.fromCallable(() -> bookingCreated.organizer().username().asMailAddress())
+                .flatMap(organizerMailAddress -> actionLinkFactory.generateLinks(organizerMailAddress,
+                        organizerMailAddress,
+                        bookingCreated.eventIcsResult().eventIdAsString(),
+                        bookingCreated.bookingLink().calendarUrl().base().value())
+                    .flatMap(actionLinks -> generateMail(settings, bookingCreated, actionLinks))
+                    .flatMap(mail -> mailSenderFactory.create().flatMap(mailSender -> mailSender.send(mail)))))
+            .subscribeOn(mailScheduler)
+            .then();
+    }
+
+    private Mono<Mail> generateMail(ResolvedSettings settings, BookingCreated bookingCreated, ActionLinks actionLinks) {
+        return Mono.fromCallable(() -> messageGeneratorFactory.forLocalizedFeature(new Language(settings.locale()), EVENT_PROPOSE_TEMPLATE))
+            .flatMap(messageGenerator -> generateMessage(settings, bookingCreated, actionLinks, messageGenerator))
+            .map(Throwing.function(message -> new Mail(templateConfiguration.sender(), List.of(bookingCreated.organizer().username().asMailAddress()), message)))
+            .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private Mono<Message> generateMessage(ResolvedSettings settings,
+                                          BookingCreated bookingCreated,
+                                          ActionLinks actionLinks,
+                                          MessageGenerator messageGenerator) {
+        List<MimeAttachment> attachments = List.of(
+            MimeAttachment.builder()
+                .contentType(ContentType.of(CALENDAR_CONTENT_TYPE_PREFIX + ImmutableMethod.REQUEST.getValue()))
+                .content(bookingCreated.eventIcsResult().icsBytes())
+                .build(),
+            MimeAttachment.builder()
+                .contentType(ContentType.of(ICS_CONTENT_TYPE))
+                .content(bookingCreated.eventIcsResult().icsBytes())
+                .dispositionType(ATTACHMENT_DISPOSITION_TYPE)
+                .fileName(ICS_FILENAME)
+                .build());
+
+        return messageGenerator.generate(bookingCreated.organizer().username(),
+            fromMailAddress,
+            PugModel.toPugModel(bookingCreated, actionLinks, settings.locale(), settings.zoneId(), eventInCalendarLinkFactory),
+            attachments);
+    }
+
+    interface PugModel {
+        String CONTENT = "content";
+        String EVENT = "event";
+        String PROPOSER = "proposer";
+        String ORGANIZER = "organizer";
+        String ATTENDEES = "attendees";
+        String SUMMARY = "summary";
+        String ALL_DAY = "allDay";
+        String START = "start";
+        String END = "end";
+        String HAS_RESOURCES = "hasResources";
+        String RESOURCES = "resources";
+        String DESCRIPTION = "description";
+        String VIDEO_CONFERENCE_LINK = "videoConferenceLink";
+        String SEE_IN_CALENDAR_LINK = "seeInCalendarLink";
+        String YES_LINK = "yesLink";
+        String MAYBE_LINK = "maybeLink";
+        String NO_LINK = "noLink";
+        String SUBJECT_SUMMARY = "subject.summary";
+        String SUBJECT_PROPOSER = "subject.proposer";
+
+        static Map<String, Object> toPugModel(BookingCreated bookingCreated,
+                                              ActionLinks actionLinks,
+                                              Locale locale,
+                                              ZoneId zoneId,
+                                              EventInCalendarLinkFactory eventInCalendarLinkFactory) {
+            ZonedDateTime start = ZonedDateTime.ofInstant(bookingCreated.request().slotStartUtc(), zoneId);
+            ZonedDateTime end = start.plus(bookingCreated.bookingLink().duration());
+
+            ImmutableMap.Builder<String, Object> eventBuilder = ImmutableMap.builder();
+            eventBuilder.put(PROPOSER, displayName(bookingCreated.request().creator()))
+                .put(ORGANIZER, new PersonModel(bookingCreated.organizer().fullName(), bookingCreated.organizer().username().asString()).toPugModel())
+                .put(ATTENDEES, attendeesAsPugModel(bookingCreated))
+                .put(SUMMARY, bookingCreated.request().title())
+                .put(ALL_DAY, false)
+                .put(START, new EventTimeModel(start).toPugModel(locale, zoneId))
+                .put(END, new EventTimeModel(end).toPugModel(locale, zoneId))
+                .put(HAS_RESOURCES, false)
+                .put(RESOURCES, Map.of());
+
+            Optional.ofNullable(bookingCreated.request().notes())
+                .filter(StringUtils::isNotBlank)
+                .ifPresent(notes -> eventBuilder.put(DESCRIPTION, notes));
+
+            bookingCreated.eventIcsResult().visioLink()
+                .ifPresent(link -> eventBuilder.put(VIDEO_CONFERENCE_LINK, link.toString()));
+
+            return ImmutableMap.of(
+                CONTENT, ImmutableMap.builder()
+                    .put(EVENT, eventBuilder.build())
+                    .put(SEE_IN_CALENDAR_LINK, eventInCalendarLinkFactory.getEventInCalendarLink(start))
+                    .put(YES_LINK, actionLinks.yes())
+                    .put(MAYBE_LINK, actionLinks.maybe())
+                    .put(NO_LINK, actionLinks.no())
+                    .build(),
+                SUBJECT_SUMMARY, bookingCreated.request().title(),
+                SUBJECT_PROPOSER, displayName(bookingCreated.request().creator()));
+        }
+
+        private static Map<String, Object> attendeesAsPugModel(BookingCreated bookingCreated) {
+            return Stream.concat(Stream.of(bookingCreated.request().creator()), bookingCreated.request().additionalAttendees().stream())
+                .collect(Collectors.toMap(attendee -> attendee.email().asString(), PugModel::attendeeToPugModel));
+        }
+
+        private static Map<String, Object> attendeeToPugModel(BookingAttendee attendee) {
+            return new PersonModel(displayName(attendee), attendee.email().asString()).toPugModel();
+        }
+
+        private static String displayName(BookingAttendee attendee) {
+            return StringUtils.defaultIfBlank(attendee.name(), attendee.email().asString());
+        }
+    }
+}


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizers now receive proposal emails with calendar attachments and participation action links when booking link reservations are created.
  * Organizer availability (PARTSTAT) is updated automatically as organizers interact with those email action links.

* **Tests**
  * Integration tests added to cover email delivery, presence and correctness of participation links, and end-to-end participation tracking via those links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->