### PR TITLE
ISSUE-601 [Public agenda] rest api to get booking links and reset public id

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/BookingLinkDataProbe.java
+++ b/app/src/test/java/com/linagora/calendar/app/BookingLinkDataProbe.java
@@ -27,6 +27,7 @@ import org.apache.james.utils.GuiceProbe;
 
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 
 public class BookingLinkDataProbe implements GuiceProbe {
@@ -43,5 +44,9 @@ public class BookingLinkDataProbe implements GuiceProbe {
 
     public List<BookingLink> listBookingLinks(Username username) {
         return bookingLinkDAO.findByUsername(username).collectList().block();
+    }
+
+    public BookingLink insertBookingLink(Username username, BookingLinkInsertRequest request) {
+        return bookingLinkDAO.insert(username, request).block();
     }
 }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
@@ -1,0 +1,292 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.app.restapi.routes;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.with;
+import static io.restassured.config.EncoderConfig.encoderConfig;
+import static io.restassured.config.RestAssuredConfig.newConfig;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+import java.nio.charset.StandardCharsets;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.http.HttpStatus;
+import org.apache.james.utils.GuiceProbe;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
+import com.linagora.calendar.api.booking.AvailabilityRule.WeeklyAvailabilityRule;
+import com.linagora.calendar.api.booking.AvailabilityRules;
+import com.linagora.calendar.app.AppTestHelper;
+import com.linagora.calendar.app.BookingLinkDataProbe;
+import com.linagora.calendar.app.TwakeCalendarConfiguration;
+import com.linagora.calendar.app.TwakeCalendarExtension;
+import com.linagora.calendar.app.TwakeCalendarGuiceServer;
+import com.linagora.calendar.app.modules.CalendarDataProbe;
+import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.dav.DockerSabreDavSetup;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.restapi.RestApiServerProbe;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.booking.BookingLink;
+import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
+
+import io.restassured.RestAssured;
+import io.restassured.authentication.PreemptiveBasicAuthScheme;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+
+class BookingLinkGetRouteTest {
+
+    private static final boolean ACTIVE = true;
+    private static final boolean NOT_ACTIVE = false;
+    private static final String PASSWORD = "secret";
+    private static final ZoneId ZONE_HO_CHI_MINH = ZoneId.of("Asia/Ho_Chi_Minh");
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    @RegisterExtension
+    @Order(1)
+    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+
+    @RegisterExtension
+    @Order(2)
+    static TwakeCalendarExtension twakeCalendarExtension = new TwakeCalendarExtension(
+        TwakeCalendarConfiguration.builder()
+            .configurationFromClasspath()
+            .userChoice(TwakeCalendarConfiguration.UserChoice.MEMORY)
+            .dbChoice(TwakeCalendarConfiguration.DbChoice.MONGODB),
+        AppTestHelper.OIDC_BY_PASS_MODULE,
+        DavModuleTestHelper.FROM_SABRE_EXTENSION.apply(sabreDavExtension),
+        binder -> {
+            Multibinder.newSetBinder(binder, GuiceProbe.class)
+                .addBinding()
+                .to(BookingLinkDataProbe.class);
+        });
+
+    @AfterAll
+    static void afterAll() {
+        RestAssured.reset();
+    }
+
+    private BookingLinkDataProbe dataProbe;
+    private OpenPaaSUser openPaaSUser;
+
+    @BeforeEach
+    void setUp(TwakeCalendarGuiceServer server) {
+        openPaaSUser = sabreDavExtension.newTestUser();
+        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
+        calendarDataProbe.addDomain(openPaaSUser.username().getDomainPart().get());
+        calendarDataProbe.addUserToRepository(openPaaSUser.username(), PASSWORD);
+
+        dataProbe = server.getProbe(BookingLinkDataProbe.class);
+
+        PreemptiveBasicAuthScheme basicAuthScheme = new PreemptiveBasicAuthScheme();
+        basicAuthScheme.setUserName(openPaaSUser.username().asString());
+        basicAuthScheme.setPassword(PASSWORD);
+
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+            .setContentType(ContentType.JSON)
+            .setAccept(ContentType.JSON)
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
+            .setPort(server.getProbe(RestApiServerProbe.class).getPort().getValue())
+            .setBasePath("")
+            .setAuth(basicAuthScheme)
+            .build();
+    }
+
+    @Test
+    void shouldReturn200WithExpectedBodyWhenNoAvailabilityRules() {
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        String response = given()
+        .when()
+            .get("/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                    "publicId": "%s",
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true
+                }
+                """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));
+    }
+
+    @Test
+    void shouldReturn200WithWeeklyAvailabilityRules() {
+        AvailabilityRules rules = AvailabilityRules.of(
+            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(12, 0), ZONE_HO_CHI_MINH),
+            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(17, 0), ZONE_HO_CHI_MINH));
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.of(rules)));
+
+        String response = given()
+        .when()
+            .get("/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                    "publicId": "%s",
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "timeZone": "Asia/Ho_Chi_Minh",
+                    "availabilityRules": [
+                        { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00" },
+                        { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00" }
+                    ]
+                }
+                """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));
+    }
+
+    @Test
+    void shouldReturn200WithFixedAvailabilityRule() {
+        AvailabilityRules rules = AvailabilityRules.of(
+            new FixedAvailabilityRule(
+                LocalDateTime.parse("2026-01-26T02:00:00").atZone(UTC),
+                LocalDateTime.parse("2026-01-30T02:00:00").atZone(UTC)));
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(60), NOT_ACTIVE, Optional.of(rules)));
+
+        String response = given()
+        .when()
+            .get("/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                    "publicId": "%s",
+                    "calendarUrl": "%s",
+                    "durationMinutes": 60,
+                    "active": false,
+                    "timeZone": "UTC",
+                    "availabilityRules": [
+                        { "type": "fixed", "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00" }
+                    ]
+                }
+                """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));
+    }
+
+    @Test
+    void shouldReturn200WithMixedAvailabilityRules() {
+        AvailabilityRules rules = AvailabilityRules.of(
+            new WeeklyAvailabilityRule(DayOfWeek.TUESDAY, LocalTime.of(9, 0), LocalTime.of(17, 0), ZONE_HO_CHI_MINH),
+            new FixedAvailabilityRule(
+                LocalDateTime.parse("2026-01-26T00:00:00").atZone(ZONE_HO_CHI_MINH),
+                LocalDateTime.parse("2026-01-30T00:00:00").atZone(ZONE_HO_CHI_MINH)));
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.of(rules)));
+
+        String response = given()
+        .when()
+            .get("/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                    "publicId": "%s",
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "timeZone": "Asia/Ho_Chi_Minh",
+                    "availabilityRules": [
+                        { "type": "weekly", "dayOfWeek": "TUE", "start": "09:00", "end": "17:00" },
+                        { "type": "fixed", "start": "2026-01-26T00:00:00", "end": "2026-01-30T00:00:00" }
+                    ]
+                }
+                """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));
+    }
+
+    @Test
+    void shouldReturn404WhenBookingLinkDoesNotExist() {
+        given()
+        .when()
+            .get("/booking-links/" + UUID.randomUUID())
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    void shouldReturn404WhenBookingLinkBelongsToAnotherUser() {
+        OpenPaaSUser otherUser = sabreDavExtension.newTestUser();
+        BookingLink inserted = dataProbe.insertBookingLink(otherUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(otherUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        given()
+        .when()
+            .get("/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    void shouldReturn401WhenUnauthenticated() {
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        with()
+            .auth().none()
+            .contentType(ContentType.JSON)
+        .when()
+            .get("/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldReturn400WhenPublicIdIsNotAValidUUID() {
+        given()
+        .when()
+            .get("/booking-links/invalid-uuid")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+}

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkResetPublicIdRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkResetPublicIdRouteTest.java
@@ -1,0 +1,225 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.app.restapi.routes;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.with;
+import static io.restassured.config.EncoderConfig.encoderConfig;
+import static io.restassured.config.RestAssuredConfig.newConfig;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.http.HttpStatus;
+import org.apache.james.utils.GuiceProbe;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.calendar.app.AppTestHelper;
+import com.linagora.calendar.app.BookingLinkDataProbe;
+import com.linagora.calendar.app.TwakeCalendarConfiguration;
+import com.linagora.calendar.app.TwakeCalendarExtension;
+import com.linagora.calendar.app.TwakeCalendarGuiceServer;
+import com.linagora.calendar.app.modules.CalendarDataProbe;
+import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.dav.DockerSabreDavSetup;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.restapi.RestApiServerProbe;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.booking.BookingLink;
+import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+
+import io.restassured.RestAssured;
+import io.restassured.authentication.PreemptiveBasicAuthScheme;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+
+class BookingLinkResetPublicIdRouteTest {
+
+    private static final boolean ACTIVE = true;
+    private static final String PASSWORD = "secret";
+
+    @RegisterExtension
+    @Order(1)
+    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+
+    @RegisterExtension
+    @Order(2)
+    static TwakeCalendarExtension twakeCalendarExtension = new TwakeCalendarExtension(
+        TwakeCalendarConfiguration.builder()
+            .configurationFromClasspath()
+            .userChoice(TwakeCalendarConfiguration.UserChoice.MEMORY)
+            .dbChoice(TwakeCalendarConfiguration.DbChoice.MONGODB),
+        AppTestHelper.OIDC_BY_PASS_MODULE,
+        DavModuleTestHelper.FROM_SABRE_EXTENSION.apply(sabreDavExtension),
+        binder -> {
+            Multibinder.newSetBinder(binder, GuiceProbe.class)
+                .addBinding()
+                .to(BookingLinkDataProbe.class);
+        });
+
+    @AfterAll
+    static void afterAll() {
+        RestAssured.reset();
+    }
+
+    private BookingLinkDataProbe dataProbe;
+    private OpenPaaSUser openPaaSUser;
+
+    @BeforeEach
+    void setUp(TwakeCalendarGuiceServer server) {
+        openPaaSUser = sabreDavExtension.newTestUser();
+        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
+        calendarDataProbe.addDomain(openPaaSUser.username().getDomainPart().get());
+        calendarDataProbe.addUserToRepository(openPaaSUser.username(), PASSWORD);
+
+        dataProbe = server.getProbe(BookingLinkDataProbe.class);
+
+        PreemptiveBasicAuthScheme basicAuthScheme = new PreemptiveBasicAuthScheme();
+        basicAuthScheme.setUserName(openPaaSUser.username().asString());
+        basicAuthScheme.setPassword(PASSWORD);
+
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+            .setContentType(ContentType.JSON)
+            .setAccept(ContentType.JSON)
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
+            .setPort(server.getProbe(RestApiServerProbe.class).getPort().getValue())
+            .setBasePath("")
+            .setAuth(basicAuthScheme)
+            .build();
+    }
+
+    @Test
+    void shouldReturn200WithNewBookingLinkPublicId() {
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        String response = given()
+        .when()
+            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                { "bookingLinkPublicId": "${json-unit.ignore}" }""");
+    }
+
+    @Test
+    void shouldReturnAPublicIdDifferentFromTheOldOne() {
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        String newPublicId = given()
+        .when()
+            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract().jsonPath().getString("bookingLinkPublicId");
+
+        assertThat(newPublicId).isNotEqualTo(inserted.publicId().value());
+    }
+
+    @Test
+    void shouldInvalidateOldPublicId() {
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        given()
+        .when()
+            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+        .then()
+            .statusCode(HttpStatus.SC_OK);
+
+        assertThat(dataProbe.findBookingLink(openPaaSUser.username(), inserted.publicId())).isNull();
+    }
+
+    @Test
+    void shouldMakeNewPublicIdRetrievable() {
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        String newPublicId = given()
+        .when()
+            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract().jsonPath().getString("bookingLinkPublicId");
+
+        assertThat(dataProbe.findBookingLink(openPaaSUser.username(), new BookingLinkPublicId(UUID.fromString(newPublicId)))).isNotNull();
+    }
+
+    @Test
+    void shouldReturn404WhenBookingLinkDoesNotExist() {
+        given()
+        .when()
+            .post("/booking-links/" + UUID.randomUUID() + "/reset")
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    void shouldReturn404WhenBookingLinkBelongsToAnotherUser() {
+        OpenPaaSUser otherUser = sabreDavExtension.newTestUser();
+        BookingLink inserted = dataProbe.insertBookingLink(otherUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        given()
+        .when()
+            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    void shouldReturn401WhenUnauthenticated() {
+        BookingLink inserted = dataProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        with()
+            .auth().none()
+            .contentType(ContentType.JSON)
+        .when()
+            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+        .then()
+            .statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldReturn400WhenPublicIdIsNotAValidUUID() {
+        with()
+            .contentType(ContentType.JSON)
+        .when()
+            .post("/booking-links/invalid-uuid/reset")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+}

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -70,6 +70,8 @@ import com.linagora.calendar.restapi.auth.OidcEndpointsInfoResolver;
 import com.linagora.calendar.restapi.auth.OidcFallbackCookieAuthenticationStrategy;
 import com.linagora.calendar.restapi.routes.AvatarRoute;
 import com.linagora.calendar.restapi.routes.BookingLinkCreateRoute;
+import com.linagora.calendar.restapi.routes.BookingLinkGetRoute;
+import com.linagora.calendar.restapi.routes.BookingLinkResetPublicIdRoute;
 import com.linagora.calendar.restapi.routes.BookingLinkSlotsRoute;
 import com.linagora.calendar.restapi.routes.CalendarSearchRoute;
 import com.linagora.calendar.restapi.routes.CalendarTicketRoutes;
@@ -141,6 +143,8 @@ public class RestApiModule extends AbstractModule {
         Multibinder<JMAPRoutes> routes = Multibinder.newSetBinder(binder(), JMAPRoutes.class);
         routes.addBinding().to(AvatarRoute.class);
         routes.addBinding().to(BookingLinkCreateRoute.class);
+        routes.addBinding().to(BookingLinkGetRoute.class);
+        routes.addBinding().to(BookingLinkResetPublicIdRoute.class);
         routes.addBinding().to(BookingLinkSlotsRoute.class);
         routes.addBinding().to(DomainRoute.class);
         routes.addBinding().to(ThemeRoute.class);

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkGetRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkGetRoute.java
@@ -1,0 +1,156 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
+import static com.linagora.calendar.restapi.RestApiConstants.OBJECT_MAPPER_DEFAULT;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.jmap.Endpoint;
+import org.apache.james.jmap.http.Authenticator;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.metrics.api.MetricFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.calendar.api.booking.AvailabilityRule;
+import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
+import com.linagora.calendar.api.booking.AvailabilityRule.WeeklyAvailabilityRule;
+import com.linagora.calendar.restapi.DayOfWeekUtil;
+import com.linagora.calendar.storage.booking.BookingLink;
+import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.server.HttpServerRequest;
+import reactor.netty.http.server.HttpServerResponse;
+
+public class BookingLinkGetRoute extends CalendarRoute {
+
+    public static final String WEEKLY_RULE_TYPE = "weekly";
+    public static final String FIXED_RULE_TYPE = "fixed";
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public record AvailabilityRuleDTO(@JsonProperty("type") String type,
+                                      @JsonProperty("dayOfWeek") Optional<String> dayOfWeek,
+                                      @JsonProperty("start") String start,
+                                      @JsonProperty("end") String end) {
+
+        private static final DateTimeFormatter LOCAL_DATE_TIME_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        public static final Optional<String> NO_DAY_OF_WEEK = Optional.empty();
+
+        private static AvailabilityRuleDTO from(AvailabilityRule rule) {
+            return switch (rule) {
+                case WeeklyAvailabilityRule weekly -> AvailabilityRuleDTO.fromWeekly(weekly);
+                case FixedAvailabilityRule fixed -> AvailabilityRuleDTO.fromFixed(fixed);
+            };
+        }
+
+        public static AvailabilityRuleDTO fromWeekly(WeeklyAvailabilityRule rule) {
+            return new AvailabilityRuleDTO(WEEKLY_RULE_TYPE, Optional.of(DayOfWeekUtil.toAbbreviation(rule.dayOfWeek())),
+                rule.start().toString(), rule.end().toString());
+        }
+
+        public static AvailabilityRuleDTO fromFixed(FixedAvailabilityRule rule) {
+            return new AvailabilityRuleDTO(FIXED_RULE_TYPE, NO_DAY_OF_WEEK,
+                rule.start().toLocalDateTime().format(LOCAL_DATE_TIME_FORMAT),
+                rule.end().toLocalDateTime().format(LOCAL_DATE_TIME_FORMAT));
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
+                                 @JsonProperty("calendarUrl") String calendarUrl,
+                                 @JsonProperty("durationMinutes") long durationMinutes,
+                                 @JsonProperty("active") boolean active,
+                                 @JsonProperty("timeZone") Optional<String> timeZone,
+                                 @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules) {
+
+        public static final String UTC = "UTC";
+
+        public static BookingLinkDTO from(BookingLink bookingLink) {
+            Optional<List<AvailabilityRuleDTO>> ruleDTOs = bookingLink.availabilityRules()
+                .map(rules -> rules.values().stream()
+                    .map(AvailabilityRuleDTO::from)
+                    .toList());
+
+            Optional<String> timeZone = bookingLink.availabilityRules()
+                .flatMap(rules -> rules.values().stream().findFirst())
+                .map(BookingLinkDTO::extractTimeZone);
+
+            return new BookingLinkDTO(
+                bookingLink.publicId().value().toString(),
+                bookingLink.calendarUrl().asUri().toString(),
+                bookingLink.duration().toMinutes(),
+                bookingLink.active(),
+                timeZone,
+                ruleDTOs);
+        }
+
+        private static String extractTimeZone(AvailabilityRule rule) {
+            return switch (rule) {
+                case WeeklyAvailabilityRule weekly -> weekly.timeZone().map(ZoneId::getId).orElse(UTC);
+                case FixedAvailabilityRule fixed -> fixed.start().getZone().getId();
+            };
+        }
+    }
+
+    private static final String PUBLIC_ID_PARAM = "bookingLinkPublicId";
+
+    private final BookingLinkDAO bookingLinkDAO;
+
+    @Inject
+    public BookingLinkGetRoute(Authenticator authenticator,
+                               MetricFactory metricFactory,
+                               BookingLinkDAO bookingLinkDAO) {
+        super(authenticator, metricFactory);
+        this.bookingLinkDAO = bookingLinkDAO;
+    }
+
+    @Override
+    Endpoint endpoint() {
+        return new Endpoint(HttpMethod.GET, "/booking-links/{" + PUBLIC_ID_PARAM + "}");
+    }
+
+    @Override
+    Mono<Void> handleRequest(HttpServerRequest request, HttpServerResponse response, MailboxSession session) {
+        BookingLinkPublicId publicId = new BookingLinkPublicId(UUID.fromString(request.param(PUBLIC_ID_PARAM)));
+
+        return bookingLinkDAO.findByPublicId(session.getUser(), publicId)
+            .switchIfEmpty(Mono.error(new BookingLinkNotFoundException(publicId)))
+            .flatMap(bookingLink -> response.status(HttpResponseStatus.OK)
+                .headers(JSON_HEADER)
+                .sendByteArray(Mono.fromCallable(() ->
+                    OBJECT_MAPPER_DEFAULT.writeValueAsBytes(BookingLinkDTO.from(bookingLink))))
+                .then())
+            .onErrorResume(BookingLinkNotFoundException.class, e ->
+                response.status(HttpResponseStatus.NOT_FOUND).send().then());
+    }
+}

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkResetPublicIdRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkResetPublicIdRoute.java
@@ -1,0 +1,77 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
+import static com.linagora.calendar.restapi.RestApiConstants.OBJECT_MAPPER_DEFAULT;
+
+import java.util.Map;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.jmap.Endpoint;
+import org.apache.james.jmap.http.Authenticator;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.metrics.api.MetricFactory;
+
+import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.server.HttpServerRequest;
+import reactor.netty.http.server.HttpServerResponse;
+
+public class BookingLinkResetPublicIdRoute extends CalendarRoute {
+
+    private static final String PUBLIC_ID_PARAM = "bookingLinkPublicId";
+    private static final String BOOKING_LINK_PUBLIC_ID_FIELD = "bookingLinkPublicId";
+
+    private final BookingLinkDAO bookingLinkDAO;
+
+    @Inject
+    public BookingLinkResetPublicIdRoute(Authenticator authenticator,
+                                         MetricFactory metricFactory,
+                                         BookingLinkDAO bookingLinkDAO) {
+        super(authenticator, metricFactory);
+        this.bookingLinkDAO = bookingLinkDAO;
+    }
+
+    @Override
+    Endpoint endpoint() {
+        return new Endpoint(HttpMethod.POST, "/booking-links/{" + PUBLIC_ID_PARAM + "}/reset");
+    }
+
+    @Override
+    Mono<Void> handleRequest(HttpServerRequest request, HttpServerResponse response, MailboxSession session) {
+        BookingLinkPublicId publicId = new BookingLinkPublicId(UUID.fromString(request.param(PUBLIC_ID_PARAM)));
+
+        return bookingLinkDAO.resetPublicId(session.getUser(), publicId)
+            .flatMap(newPublicId -> response.status(HttpResponseStatus.OK)
+                .headers(JSON_HEADER)
+                .sendByteArray(Mono.fromCallable(() -> OBJECT_MAPPER_DEFAULT.writeValueAsBytes(
+                    Map.of(BOOKING_LINK_PUBLIC_ID_FIELD, newPublicId.value()))))
+                .then())
+            .onErrorResume(BookingLinkNotFoundException.class, e ->
+                response.status(HttpResponseStatus.NOT_FOUND).send().then());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GET endpoint to retrieve booking link details, including calendar URL, duration, availability rules with time zones, and active status.
  * Added POST endpoint to reset a booking link's public ID, generating a new secure identifier while invalidating the old one.
  * Comprehensive error handling for unauthorized access, missing links, and invalid identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->