### PR TITLE
Handle duplicate attendees/resources when sending calendar event notifications

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventResourceHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventResourceHandler.java
@@ -18,6 +18,8 @@
 
 package com.linagora.calendar.amqp;
 
+import static com.linagora.calendar.storage.event.EventParseUtils.DuplicateAttendeePolicy.KEEP_FIRST;
+
 import java.net.URL;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -82,9 +84,6 @@ public class EventResourceHandler {
         "/" + PLACEHOLDER_EVENT_ID +
         "/participation?status=" + PLACEHOLDER_PART_STAT +
         "&referrer=email&jwt=" + PLACEHOLDER_JWT;
-
-    public static final Function<EventFields.Person, PersonModel> PERSON_TO_MODEL =
-        person -> new PersonModel(person.cn(), person.email().asString());
 
     public static final Function<Calendar, VEvent> GET_FIRST_VEVENT_FUNCTION =
         calendar -> calendar.getComponent(Component.VEVENT)
@@ -299,23 +298,19 @@ public class EventResourceHandler {
     }
 
     private Map<String, Object> toPugModel(VEvent vEvent, Locale locale, ZoneId zoneToDisplay) {
-        PersonModel organizer = PERSON_TO_MODEL.apply(EventParseUtils.getOrganizer(vEvent));
         String summary = EventParseUtils.getSummary(vEvent).orElse(StringUtils.EMPTY);
         ZonedDateTime startDate = EventParseUtils.getStartTime(vEvent);
-        List<EventFields.Person> resourceList = EventParseUtils.getResources(vEvent);
+        List<EventFields.Person> attendees = EventParseUtils.getAttendees(vEvent, KEEP_FIRST);
+        List<EventFields.Person> resourceList = EventParseUtils.getResources(vEvent, KEEP_FIRST);
 
         ImmutableMap.Builder<String, Object> eventBuilder = ImmutableMap.builder();
-        eventBuilder.put("organizer", organizer.toPugModel())
-            .put("attendees", EventParseUtils.getAttendees(vEvent).stream()
-                .collect(ImmutableMap.toImmutableMap(attendee -> attendee.email().asString(),
-                    attendee -> PERSON_TO_MODEL.apply(attendee).toPugModel())))
+        eventBuilder.put("organizer", toPugModel(EventParseUtils.getOrganizer(vEvent)))
+            .put("attendees", toPeoplePugModel(attendees))
             .put("summary", summary)
             .put("allDay", EventParseUtils.isAllDay(vEvent))
             .put("start", new EventTimeModel(startDate).toPugModel(locale, zoneToDisplay))
             .put("hasResources", !resourceList.isEmpty())
-            .put("resources", resourceList.stream()
-                .collect(ImmutableMap.toImmutableMap(resource -> resource.email().asString(),
-                    resource -> PERSON_TO_MODEL.apply(resource).toPugModel())));
+            .put("resources", toPeoplePugModel(resourceList));
         EventParseUtils.getEndTime(vEvent).map(endDate -> new EventTimeModel(endDate).toPugModel(locale, zoneToDisplay))
             .ifPresent(model -> eventBuilder.put("end", model));
         EventParseUtils.getLocation(vEvent).ifPresent(location -> eventBuilder.put("location", new LocationModel(location).toPugModel()));
@@ -324,5 +319,15 @@ public class EventResourceHandler {
             .ifPresent(value -> eventBuilder.put("videoConferenceLink", value));
 
         return eventBuilder.build();
+    }
+
+    private Map<String, Object> toPugModel(EventFields.Person person) {
+        return PersonModel.from(person).toPugModel();
+    }
+
+    private Map<String, Map<String, Object>> toPeoplePugModel(List<EventFields.Person> people) {
+        return people.stream()
+            .collect(ImmutableMap.toImmutableMap(person -> person.email().asString(),
+                this::toPugModel));
     }
 }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventCancelNotificationEmail.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventCancelNotificationEmail.java
@@ -18,8 +18,6 @@
 
 package com.linagora.calendar.amqp.model;
 
-import static com.linagora.calendar.amqp.model.CalendarEventNotificationEmail.PERSON_TO_MODEL;
-
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
@@ -43,7 +41,7 @@ public record CalendarEventCancelNotificationEmail(CalendarEventNotificationEmai
 
     public Map<String, Object> toPugModel(Locale locale, ZoneId zoneToDisplay, EventInCalendarLinkFactory eventInCalendarLinkFactory, boolean isInternalUser) {
         VEvent vEvent = base.getFirstVEvent();
-        PersonModel organizer = PERSON_TO_MODEL.apply(EventParseUtils.getOrganizer(vEvent));
+        PersonModel organizer = PersonModel.from(EventParseUtils.getOrganizer(vEvent));
         String summary = EventParseUtils.getSummary(vEvent).orElse(StringUtils.EMPTY);
         ZonedDateTime startDate = EventParseUtils.getStartTime(vEvent);
 

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventCounterNotificationEmail.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventCounterNotificationEmail.java
@@ -19,7 +19,7 @@
 package com.linagora.calendar.amqp.model;
 
 import static com.linagora.calendar.amqp.model.CalendarEventNotificationEmail.GET_FIRST_VEVENT_FUNCTION;
-import static com.linagora.calendar.amqp.model.CalendarEventReplyNotificationEmail.PERSON_TO_MODEL;
+import static com.linagora.calendar.storage.event.EventParseUtils.DuplicateAttendeePolicy.KEEP_FIRST;
 
 import java.util.List;
 import java.util.function.Function;
@@ -58,14 +58,8 @@ public record CalendarEventCounterNotificationEmail(CalendarEventNotificationEma
             .build();
 
         Function<VEvent, OldEventModel> oldEventModelFunction = vEvent -> {
-            List<PersonModel> attendeeModel = EventParseUtils.getAttendees(vEvent)
-                .stream()
-                .map(PERSON_TO_MODEL)
-                .toList();
-            List<PersonModel> resourceModel = EventParseUtils.getResources(vEvent)
-                .stream()
-                .map(PERSON_TO_MODEL)
-                .toList();
+            List<PersonModel> attendeeModel = PersonModel.fromList(EventParseUtils.getAttendees(vEvent, KEEP_FIRST));
+            List<PersonModel> resourceModel = PersonModel.fromList(EventParseUtils.getResources(vEvent, KEEP_FIRST));
 
             return OldEventModel
                 .builder()
@@ -76,7 +70,7 @@ public record CalendarEventCounterNotificationEmail(CalendarEventNotificationEma
                 .location(EventParseUtils.getLocation(vEvent))
                 .description(EventParseUtils.getDescription(vEvent))
                 .attendee(attendeeModel)
-                .organizer(PERSON_TO_MODEL.apply(EventParseUtils.getOrganizer(vEvent)))
+                .organizer(PersonModel.from(EventParseUtils.getOrganizer(vEvent)))
                 .resources(resourceModel)
                 .build();
         };

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventInviteNotificationEmail.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventInviteNotificationEmail.java
@@ -18,8 +18,6 @@
 
 package com.linagora.calendar.amqp.model;
 
-import static com.linagora.calendar.amqp.model.CalendarEventNotificationEmail.PERSON_TO_MODEL;
-
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
@@ -48,7 +46,7 @@ public record CalendarEventInviteNotificationEmail(CalendarEventNotificationEmai
                                           boolean isInternalUser,
                                           ActionLinks actionLinks) {
         VEvent vEvent = base.getFirstVEvent();
-        PersonModel organizer = PERSON_TO_MODEL.apply(EventParseUtils.getOrganizer(vEvent));
+        PersonModel organizer = PersonModel.from(EventParseUtils.getOrganizer(vEvent));
         String summary = EventParseUtils.getSummary(vEvent).orElse(StringUtils.EMPTY);
         ZonedDateTime startDate = EventParseUtils.getStartTime(vEvent);
 

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventNotificationEmail.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventNotificationEmail.java
@@ -18,6 +18,8 @@
 
 package com.linagora.calendar.amqp.model;
 
+import static com.linagora.calendar.storage.event.EventParseUtils.DuplicateAttendeePolicy.KEEP_FIRST;
+
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -50,9 +52,6 @@ public record CalendarEventNotificationEmail(MailAddress senderEmail,
                                              String calendarURI,
                                              String eventPath) {
 
-    public static final Function<EventFields.Person, PersonModel> PERSON_TO_MODEL =
-        person -> new PersonModel(person.cn(), person.email().asString());
-
     public static final Function<Calendar, VEvent> GET_FIRST_VEVENT_FUNCTION =
         calendar -> calendar.getComponent(Component.VEVENT)
             .map(VEvent.class::cast)
@@ -72,23 +71,19 @@ public record CalendarEventNotificationEmail(MailAddress senderEmail,
 
     public Map<String, Object> toPugModel(Locale locale, ZoneId zoneToDisplay) {
         VEvent vEvent = getFirstVEvent();
-        PersonModel organizer = PERSON_TO_MODEL.apply(EventParseUtils.getOrganizer(vEvent));
         String summary = EventParseUtils.getSummary(vEvent).orElse(StringUtils.EMPTY);
         ZonedDateTime startDate = EventParseUtils.getStartTime(vEvent);
-        List<EventFields.Person> resourceList = EventParseUtils.getResources(vEvent);
+        List<EventFields.Person> attendees = EventParseUtils.getAttendees(vEvent, KEEP_FIRST);
+        List<EventFields.Person> resourceList = EventParseUtils.getResources(vEvent, KEEP_FIRST);
 
         ImmutableMap.Builder<String, Object> eventBuilder = ImmutableMap.builder();
-        eventBuilder.put("organizer", organizer.toPugModel())
-            .put("attendees", EventParseUtils.getAttendees(vEvent).stream()
-                .collect(ImmutableMap.toImmutableMap(attendee -> attendee.email().asString(),
-                    attendee -> PERSON_TO_MODEL.apply(attendee).toPugModel())))
+        eventBuilder.put("organizer", toPugModel(EventParseUtils.getOrganizer(vEvent)))
+            .put("attendees", toPeoplePugModel(attendees))
             .put("summary", summary)
             .put("allDay", EventParseUtils.isAllDay(vEvent))
             .put("start", new EventTimeModel(startDate).toPugModel(locale, zoneToDisplay))
             .put("hasResources", !resourceList.isEmpty())
-            .put("resources", resourceList.stream()
-                .collect(ImmutableMap.toImmutableMap(resource -> resource.email().asString(),
-                    resource -> PERSON_TO_MODEL.apply(resource).toPugModel())));
+            .put("resources", toPeoplePugModel(resourceList));
         EventParseUtils.getEndTime(vEvent).map(endDate -> new EventTimeModel(endDate).toPugModel(locale, zoneToDisplay))
             .ifPresent(model -> eventBuilder.put("end", model));
         EventParseUtils.getLocation(vEvent).ifPresent(location -> eventBuilder.put("location", new LocationModel(location).toPugModel()));
@@ -97,6 +92,16 @@ public record CalendarEventNotificationEmail(MailAddress senderEmail,
             .ifPresent(value -> eventBuilder.put("videoConferenceLink", value));
 
         return eventBuilder.build();
+    }
+
+    private Map<String, Object> toPugModel(EventFields.Person person) {
+        return PersonModel.from(person).toPugModel();
+    }
+
+    private Map<String, Map<String, Object>> toPeoplePugModel(List<EventFields.Person> people) {
+        return people.stream()
+            .collect(ImmutableMap.toImmutableMap(person -> person.email().asString(),
+                this::toPugModel));
     }
 
     public byte[] eventAsBytes() {

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventReplyNotificationEmail.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventReplyNotificationEmail.java
@@ -18,8 +18,9 @@
 
 package com.linagora.calendar.amqp.model;
 
+import static com.linagora.calendar.storage.event.EventParseUtils.DuplicateAttendeePolicy.KEEP_FIRST;
+
 import java.util.List;
-import java.util.function.Function;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -34,9 +35,6 @@ import net.fortuna.ical4j.model.parameter.PartStat;
 
 public record CalendarEventReplyNotificationEmail(CalendarEventNotificationEmail base) {
 
-    public static final Function<Person, PersonModel> PERSON_TO_MODEL =
-        person -> new PersonModel(person.cn(), person.email().asString());
-
     public static CalendarEventReplyNotificationEmail from(CalendarEventNotificationEmailDTO dto) {
         return new CalendarEventReplyNotificationEmail(CalendarEventNotificationEmail.from(dto));
     }
@@ -45,14 +43,11 @@ public record CalendarEventReplyNotificationEmail(CalendarEventNotificationEmail
         VEvent vEvent = base.getFirstVEvent();
 
         Person attendee = EventParseUtils.getAttendees(vEvent).getFirst();
-        PersonModel attendeeModel = PERSON_TO_MODEL.apply(attendee);
+        PersonModel attendeeModel = PersonModel.from(attendee);
         PartStat attendeePartStat = attendee.partStat()
             .orElseThrow(() -> new IllegalStateException("Attendee partStat is missing"));
 
-        List<PersonModel> resourceModel = EventParseUtils.getResources(vEvent)
-            .stream()
-            .map(PERSON_TO_MODEL)
-            .toList();
+        List<PersonModel> resourceModel = PersonModel.fromList(EventParseUtils.getResources(vEvent, KEEP_FIRST));
 
         return ReplyContentModelBuilder.builder()
             .eventSummary(EventParseUtils.getSummary(vEvent).orElse(StringUtils.EMPTY))
@@ -61,7 +56,7 @@ public record CalendarEventReplyNotificationEmail(CalendarEventNotificationEmail
             .eventEnd(EventParseUtils.getEndTime(vEvent))
             .eventLocation(EventParseUtils.getLocation(vEvent))
             .eventAttendee(attendeeModel, attendeePartStat)
-            .eventOrganizer(PERSON_TO_MODEL.apply(EventParseUtils.getOrganizer(vEvent)))
+            .eventOrganizer(PersonModel.from(EventParseUtils.getOrganizer(vEvent)))
             .eventResources(resourceModel)
             .eventDescription(EventParseUtils.getDescription(vEvent));
     }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventUpdateNotificationEmail.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventUpdateNotificationEmail.java
@@ -18,8 +18,6 @@
 
 package com.linagora.calendar.amqp.model;
 
-import static com.linagora.calendar.amqp.model.CalendarEventNotificationEmail.PERSON_TO_MODEL;
-
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -58,7 +56,7 @@ public record CalendarEventUpdateNotificationEmail(CalendarEventNotificationEmai
                                           boolean isInternalUser,
                                           ActionLinks actionLinks) {
         VEvent vEvent = base.getFirstVEvent();
-        PersonModel organizer = PERSON_TO_MODEL.apply(EventParseUtils.getOrganizer(vEvent));
+        PersonModel organizer = PersonModel.from(EventParseUtils.getOrganizer(vEvent));
         String summary = EventParseUtils.getSummary(vEvent).orElse(StringUtils.EMPTY);
         ZonedDateTime startDate = EventParseUtils.getStartTime(vEvent);
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventInviteEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventInviteEmailConsumerTest.java
@@ -160,6 +160,7 @@ public class EventInviteEmailConsumerTest {
     private OpenPaaSUser attendee;
     private Sender sender;
     private UsersRepository usersRepository;
+    private EventEmailConsumer consumer;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -177,6 +178,10 @@ public class EventInviteEmailConsumerTest {
 
     @AfterEach
     void afterEach() {
+        if (consumer != null) {
+            consumer.close();
+        }
+
         Arrays.stream(EventIndexerConsumer.Queue
                 .values())
             .map(EventIndexerConsumer.Queue::queueName)
@@ -236,7 +241,7 @@ public class EventInviteEmailConsumerTest {
             usersRepository,  resourceDAO, domainDAO,
             settingsResolver, actionLinkFactory);
 
-        EventEmailConsumer consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
+        consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
             eventEmailFilter, new RecordingMetricFactory());
         consumer.init();
 
@@ -364,6 +369,59 @@ public class EventInviteEmailConsumerTest {
         }));
     }
 
+    @Test
+    void shouldSendInviteEmailWhenCalendarEventContainsDuplicatedAttendee() {
+        String eventUid = UUID.randomUUID().toString();
+        String initialCalendarData = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.2.2//EN
+            CALSCALE:GREGORIAN
+            BEGIN:VTIMEZONE
+            TZID:Asia/Ho_Chi_Minh
+            BEGIN:STANDARD
+            TZOFFSETFROM:+0700
+            TZOFFSETTO:+0700
+            TZNAME:ICT
+            DTSTART:19700101T000000
+            END:STANDARD
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:30250411T022032Z
+            SEQUENCE:1
+            DTSTART;TZID=Asia/Ho_Chi_Minh:30250411T100000
+            DTEND;TZID=Asia/Ho_Chi_Minh:30250411T110000
+            SUMMARY:Twake Calendar - Sprint planning #04
+            LOCATION:Twake Meeting Room
+            DESCRIPTION:This is a meeting to discuss the sprint planning for the next week.
+            ORGANIZER;CN=Van Tung TRAN:mailto:%s
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Benoît TELLIER:mailto:%s
+            ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=Benoît TELLIER:mailto:%s
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(eventUid,
+            organizer.username().asString(),
+            attendee.username().asString(),
+            attendee.username().asString());
+        davTestHelper.upsertCalendar(organizer, initialCalendarData, eventUid);
+
+        awaitAtMost.atMost(Duration.ofSeconds(20))
+            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
+
+        JsonPath smtpMailsResponse = smtpMailsResponseSupplier.get();
+
+        assertSoftly(Throwing.consumer(softly -> {
+            softly.assertThat(smtpMailsResponse.getString("[0].from")).isEqualTo(organizer.username().asString());
+            softly.assertThat(smtpMailsResponse.getString("[0].recipients[0].address")).isEqualTo(attendee.username().asString());
+
+            String html = getHtml(smtpMailsResponse);
+            softly.assertThat(html)
+                .contains("Van Tung TRAN")
+                .contains(attendee.username().asString());
+        }));
+    }
+
     private String getHtml(JsonPath smtpMailsResponse) {
         String rawMessage = smtpMailsResponse.getString("[0].message");
         Pattern htmlPattern = Pattern.compile(
@@ -414,4 +472,3 @@ public class EventInviteEmailConsumerTest {
             .replace("{partStat}", partStat.getValue());
     }
 }
-

--- a/calendar-scheduling/src/main/java/com/linagora/calendar/scheduling/AlarmTriggerService.java
+++ b/calendar-scheduling/src/main/java/com/linagora/calendar/scheduling/AlarmTriggerService.java
@@ -20,6 +20,7 @@ package com.linagora.calendar.scheduling;
 
 import static com.linagora.calendar.storage.configuration.resolver.AlarmSettingReader.ALARM_SETTING_IDENTIFIER;
 import static com.linagora.calendar.storage.configuration.resolver.AlarmSettingReader.ENABLE_ALARM;
+import static com.linagora.calendar.storage.event.EventParseUtils.DuplicateAttendeePolicy.KEEP_FIRST;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -60,7 +61,6 @@ import com.linagora.calendar.storage.UsernameRegistrationKey;
 import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
 import com.linagora.calendar.storage.event.AlarmAction;
 import com.linagora.calendar.storage.event.AlarmInstantFactory;
-import com.linagora.calendar.storage.event.EventFields;
 import com.linagora.calendar.storage.event.EventParseUtils;
 
 import net.fortuna.ical4j.model.Calendar;
@@ -71,9 +71,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 public class AlarmTriggerService {
-
-    public static final Function<EventFields.Person, PersonModel> PERSON_TO_MODEL =
-        person -> new PersonModel(person.cn(), person.email().asString());
 
     public static final Function<Calendar, VEvent> GET_FIRST_VEVENT_FUNCTION =
         calendar -> calendar.getComponent(Component.VEVENT)
@@ -200,14 +197,9 @@ public class AlarmTriggerService {
     }
 
     private Map<String, Object> toPugModel(VEvent vEvent, Duration duration, Locale locale) {
-        PersonModel organizer = PERSON_TO_MODEL.apply(EventParseUtils.getOrganizer(vEvent));
         String summary = EventParseUtils.getSummary(vEvent).orElse(StringUtils.EMPTY);
-        List<PersonModel> attendees = EventParseUtils.getAttendees(vEvent).stream()
-            .map(PERSON_TO_MODEL)
-            .toList();
-        List<PersonModel> resources = EventParseUtils.getResources(vEvent).stream()
-            .map(PERSON_TO_MODEL)
-            .toList();
+        List<PersonModel> attendees = PersonModel.fromList(EventParseUtils.getAttendees(vEvent, KEEP_FIRST));
+        List<PersonModel> resources = PersonModel.fromList(EventParseUtils.getResources(vEvent, KEEP_FIRST));
         Optional<String> location = EventParseUtils.getLocation(vEvent);
         Optional<String> description = EventParseUtils.getDescription(vEvent);
         Optional<String> videoConf = EventParseUtils.getPropertyValueIgnoreCase(vEvent, "X-OPENPAAS-VIDEOCONFERENCE");
@@ -216,7 +208,7 @@ public class AlarmTriggerService {
             .duration(duration)
             .summary(summary)
             .location(location)
-            .organizer(organizer)
+            .organizer(PersonModel.from(EventParseUtils.getOrganizer(vEvent)))
             .attendees(attendees)
             .resources(resources)
             .description(description)

--- a/calendar-smtp/src/main/java/com/linagora/calendar/smtp/template/content/model/PersonModel.java
+++ b/calendar-smtp/src/main/java/com/linagora/calendar/smtp/template/content/model/PersonModel.java
@@ -19,12 +19,25 @@
 package com.linagora.calendar.smtp.template.content.model;
 
 
+import java.util.List;
 import java.util.Map;
+
+import com.linagora.calendar.storage.event.EventFields.Person;
 
 public record PersonModel(String cn, String email) {
 
     public Map<String, Object> toPugModel() {
         return Map.of("cn", cn,
             "email", email);
+    }
+
+    public static PersonModel from(Person person) {
+        return new PersonModel(person.cn(), person.email().asString());
+    }
+
+    public static List<PersonModel> fromList(List<Person> people) {
+        return people.stream()
+            .map(PersonModel::from)
+            .toList();
     }
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/EventParseUtils.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/EventParseUtils.java
@@ -34,9 +34,11 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -66,6 +68,11 @@ import net.fortuna.ical4j.model.property.Summary;
 import net.fortuna.ical4j.model.property.Uid;
 
 public class EventParseUtils {
+    public enum DuplicateAttendeePolicy {
+        KEEP_ALL,
+        KEEP_FIRST
+    }
+
     public static final Logger LOGGER = LoggerFactory.getLogger(EventParseUtils.class);
 
     public static final DateTimeFormatter UTC_DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
@@ -125,11 +132,39 @@ public class EventParseUtils {
     }
 
     public static List<EventFields.Person> getAttendees(VEvent vEvent) {
-        return getPeople(vEvent, GET_ATTENDEE);
+        return getAttendees(vEvent, DuplicateAttendeePolicy.KEEP_ALL);
+    }
+
+    public static List<EventFields.Person> getAttendees(VEvent vEvent, DuplicateAttendeePolicy duplicateAttendeePolicy) {
+        List<EventFields.Person> attendees = getPeople(vEvent, GET_ATTENDEE);
+        if (duplicateAttendeePolicy == DuplicateAttendeePolicy.KEEP_FIRST) {
+            return deduplicatePeopleByEmail(attendees);
+        }
+
+        return attendees;
+    }
+
+    private static List<EventFields.Person> deduplicatePeopleByEmail(List<EventFields.Person> people) {
+        return people.stream()
+            .collect(Collectors.collectingAndThen(
+                Collectors.toMap(EventFields.Person::email,
+                    Function.identity(),
+                    (first, ignored) -> first,
+                    LinkedHashMap::new),
+                map -> List.copyOf(map.values())));
     }
 
     public static List<EventFields.Person> getResources(VEvent vEvent) {
-        return getPeople(vEvent, GET_RESOURCE);
+        return getResources(vEvent, DuplicateAttendeePolicy.KEEP_ALL);
+    }
+
+    public static List<EventFields.Person> getResources(VEvent vEvent, DuplicateAttendeePolicy duplicateAttendeePolicy) {
+        List<EventFields.Person> resources = getPeople(vEvent, GET_RESOURCE);
+        if (duplicateAttendeePolicy == DuplicateAttendeePolicy.KEEP_FIRST) {
+            return deduplicatePeopleByEmail(resources);
+        }
+
+        return resources;
     }
 
     public static EventFields.Person getOrganizer(VEvent vEvent) {


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling duplicate attendees in calendar events with configurable deduplication policies.

* **Tests**
  * Added test coverage for calendar events with duplicate attendees.

* **Refactor**
  * Improved internal architecture for processing attendee, resource, and organizer information in calendar notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->