### PR TITLE
[FIX] Set date header on outgoing mails

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventMailHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventMailHandler.java
@@ -22,6 +22,7 @@ import static com.linagora.calendar.amqp.EventFieldConverter.extractCalendarURL;
 import static com.linagora.calendar.smtp.template.MimeAttachment.ATTACHMENT_DISPOSITION_TYPE;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -341,6 +342,7 @@ public class EventMailHandler {
                 MailAddress fromAsMailAddress = event.senderEmail();
                 return Message.Builder.of()
                     .setMessageId("<" + UUID.randomUUID() + "@" + Optional.of(fromAsMailAddress).map(MailAddress::getDomain).map(Domain::asString).orElse("") + ">")
+                    .setDate(new Date())
                     .setSubject(subject)
                     .setBody(multipartBuilder.build())
                     .setFrom(event.senderEmail().asString())

--- a/calendar-smtp/src/main/java/com/linagora/calendar/smtp/template/MessageGenerator.java
+++ b/calendar-smtp/src/main/java/com/linagora/calendar/smtp/template/MessageGenerator.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -184,6 +185,7 @@ public class MessageGenerator {
 
             return Message.Builder.of()
                 .setMessageId("<" + UUID.randomUUID() + "@" + Optional.of(fromAsMailAddress).map(MailAddress::getDomain).map(Domain::asString).orElse("") + ">")
+                .setDate(new Date())
                 .setSubject(subject(scopedVariableFinal))
                 .setBody(multipartBuilder.build())
                 .setFrom(fromAddress.toString())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification emails from the calendar system now properly include date headers, ensuring accurate timestamp display across all email clients and mail servers. This prevents issues with message filtering and sorting, improves email standards compliance, and enhances delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->