### PR TITLE
ISSUE-611 [Public agenda] Fix AvailableSlotsCalculator: merge by type, intersect across types

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -26,7 +26,10 @@ import static io.restassured.http.ContentType.JSON;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import java.nio.charset.StandardCharsets;
+import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
@@ -45,6 +48,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
+import com.linagora.calendar.api.booking.AvailabilityRule.WeeklyAvailabilityRule;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.app.AppTestHelper;
 import com.linagora.calendar.app.TwakeCalendarConfiguration;
@@ -487,6 +491,40 @@ class BookingLinkSlotsRouteTest {
             .describedAs("should return empty slots when no availability matches requested range")
             .inPath("$.slots")
             .isEqualTo("[]");
+    }
+
+    @Test
+    void shouldIntersectWeeklyAndFixedRulesWhenComputingSlots(TwakeCalendarGuiceServer server) {
+        // 2036-01-26 is Saturday; weekly and fixed rules overlap on that same day.
+        AvailabilityRules mixedRules = AvailabilityRules.of(
+            new WeeklyAvailabilityRule(DayOfWeek.SATURDAY, LocalTime.parse("09:00"), LocalTime.parse("10:00"), ZoneId.of("UTC")),
+            new FixedAvailabilityRule(
+                ZonedDateTime.parse("2036-01-26T09:30:00Z"),
+                ZonedDateTime.parse("2036-01-26T10:30:00Z")));
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, mixedRules);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return slots from the overlapping part of weekly and fixed rules")
+            .inPath("$.slots")
+            .isEqualTo("""
+                [
+                  { "start": "2036-01-26T09:30:00Z" }
+                ]
+                """);
     }
 
     @Test

--- a/calendar-api/src/main/java/com/linagora/calendar/api/booking/AvailabilityRules.java
+++ b/calendar-api/src/main/java/com/linagora/calendar/api/booking/AvailabilityRules.java
@@ -22,6 +22,8 @@ import static com.linagora.calendar.api.booking.AvailableSlotsCalculator.validat
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Range;
@@ -38,14 +40,35 @@ public record AvailabilityRules(List<AvailabilityRule> values) {
         Preconditions.checkArgument(values != null && !values.isEmpty(), "'values' must not be null or empty");
     }
 
-    // Expands rules into ranges, merges overlaps, and clips the result to [start, end).
+    // Build availability as: intersection(union(rules by type)), clipped to [start, end).
     public RangeSet<Instant> toRangeSet(Instant start, Instant end) {
         validateTimeRange(start, end);
 
-        RangeSet<Instant> availabilityRanges = TreeRangeSet.create(values.stream()
-            .flatMap(rule -> rule.availabilityRanges(start, end).stream())
-            .toList());
+        Map<Class<? extends AvailabilityRule>, List<AvailabilityRule>> rulesByType = values.stream()
+            .collect(Collectors.groupingBy(AvailabilityRule::getClass));
+
+        List<RangeSet<Instant>> mergedByType = rulesByType.values().stream()
+            .map(rulesOfSameType -> mergeAvailabilityRanges(start, end, rulesOfSameType))
+            .toList();
+
+        RangeSet<Instant> availabilityRanges = intersectAvailabilityRanges(mergedByType);
 
         return availabilityRanges.subRangeSet(Range.closedOpen(start, end));
+    }
+
+    private RangeSet<Instant> mergeAvailabilityRanges(Instant start, Instant end, List<AvailabilityRule> rulesOfSameType) {
+        return TreeRangeSet.create(rulesOfSameType.stream()
+            .flatMap(rule -> rule.availabilityRanges(start, end).stream())
+            .toList());
+    }
+
+    private RangeSet<Instant> intersectAvailabilityRanges(List<RangeSet<Instant>> mergedByType) {
+        return mergedByType.stream()
+            .map(TreeRangeSet::create)
+            .reduce((left, right) -> {
+                left.removeAll(right.complement());
+                return left;
+            })
+            .orElseGet(TreeRangeSet::create);
     }
 }

--- a/calendar-api/src/test/java/com/linagora/calendar/api/booking/AvailabilityRulesTest.java
+++ b/calendar-api/src/test/java/com/linagora/calendar/api/booking/AvailabilityRulesTest.java
@@ -130,7 +130,7 @@ class AvailabilityRulesTest {
     }
 
     @Test
-    void toRangeSetShouldMergeFixedAndWeeklyRules() {
+    void toRangeSetShouldIntersectFixedAndWeeklyRules() {
         AvailabilityRules rules = AvailabilityRules.of(
             new FixedAvailabilityRule(ZonedDateTime.parse("2026-02-23T09:00:00Z[UTC]"), ZonedDateTime.parse("2026-02-23T10:00:00Z[UTC]")),
             new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.parse("09:30"), LocalTime.parse("11:00")));
@@ -138,7 +138,20 @@ class AvailabilityRulesTest {
         RangeSet<Instant> actual = rules.toRangeSet(Instant.parse("2026-02-23T00:00:00Z"), Instant.parse("2026-02-24T00:00:00Z"));
 
         assertThat(actual.asRanges())
-            .containsExactly(Range.closedOpen(Instant.parse("2026-02-23T09:00:00Z"), Instant.parse("2026-02-23T11:00:00Z")));
+            .containsExactly(Range.closedOpen(Instant.parse("2026-02-23T09:30:00Z"), Instant.parse("2026-02-23T10:00:00Z")));
+    }
+
+    @Test
+    void toRangeSetShouldReturnEmptyWhenMixedRulesAndOneTypeHasNoRangeInWindow() {
+        AvailabilityRules rules = AvailabilityRules.of(
+            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.parse("09:00"), LocalTime.parse("10:00"), ZoneId.of("UTC")),
+            new FixedAvailabilityRule(ZonedDateTime.parse("2026-02-24T09:00:00Z[UTC]"), ZonedDateTime.parse("2026-02-24T10:00:00Z[UTC]")));
+
+        RangeSet<Instant> actual = rules.toRangeSet(
+            Instant.parse("2026-02-23T00:00:00Z"),
+            Instant.parse("2026-02-24T00:00:00Z"));
+
+        assertThat(actual.asRanges()).isEmpty();
     }
 
     @Test

--- a/calendar-api/src/test/java/com/linagora/calendar/api/booking/AvailableSlotsCalculatorTest.java
+++ b/calendar-api/src/test/java/com/linagora/calendar/api/booking/AvailableSlotsCalculatorTest.java
@@ -91,7 +91,7 @@ class AvailableSlotsCalculatorTest {
     }
 
     @Test
-    void shouldMergeWeeklyAndFixedAvailabilityRules() {
+    void shouldIntersectWeeklyAndFixedAvailabilityRules() {
         Duration eventDuration = Duration.ofHours(2);
         AvailabilityRules availabilityRules = AvailabilityRules.of(
             new WeeklyAvailabilityRule(DayOfWeek.TUESDAY,
@@ -106,9 +106,8 @@ class AvailableSlotsCalculatorTest {
             availabilityRules,
             EMPTY_UNAVAILABLE_TIME_RANGES);
 
-        // Weekly [09:00-10:00] and fixed [09:30-11:00] merge into one 2-hour slot at 09:00.
-        assertThat(testee.computeSlots(request))
-            .containsExactlyInAnyOrder(new AvailabilitySlot(Instant.parse("2026-02-24T09:00:00Z"), eventDuration));
+        // Weekly [09:00-10:00] intersect fixed [09:30-11:00] => [09:30-10:00], too short for a 2-hour slot.
+        assertThat(testee.computeSlots(request)).isEmpty();
     }
 
     @Test
@@ -132,16 +131,38 @@ class AvailableSlotsCalculatorTest {
             unavailableTimeRanges);
 
         assertThat(testee.computeSlots(request)).containsExactlyInAnyOrder(
-            // Tuesday slots
-            new AvailabilitySlot(Instant.parse("2026-02-24T09:00:00Z"), eventDuration),
-            new AvailabilitySlot(Instant.parse("2026-02-24T10:00:00Z"), eventDuration),
-            new AvailabilitySlot(Instant.parse("2026-02-24T10:30:00Z"), eventDuration),
-            new AvailabilitySlot(Instant.parse("2026-02-24T11:00:00Z"), eventDuration),
-            new AvailabilitySlot(Instant.parse("2026-02-24T11:30:00Z"), eventDuration),
-            // Wednesday slots
-            new AvailabilitySlot(Instant.parse("2026-02-25T13:00:00Z"), eventDuration),
-            new AvailabilitySlot(Instant.parse("2026-02-25T13:30:00Z"), eventDuration),
-            new AvailabilitySlot(Instant.parse("2026-02-25T15:30:00Z"), eventDuration));
+            // Tuesday intersection is [10:30-11:00], Wednesday intersection is removed by unavailable range.
+            new AvailabilitySlot(Instant.parse("2026-02-24T10:30:00Z"), eventDuration));
+    }
+
+    @Test
+    void shouldComputeSlotsFromIntersectionWhenWeeklyAndFixedRulesUseTimezone() {
+        Duration eventDuration = Duration.ofMinutes(20);
+        ZoneId hoChiMinh = ZoneId.of("Asia/Ho_Chi_Minh");
+
+        AvailabilityRules availabilityRules = AvailabilityRules.of(
+            // Weekly working window is Monday 09:00-10:00 in Asia/Ho_Chi_Minh.
+            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.parse("09:00"), LocalTime.parse("10:00"), hoChiMinh),
+            // Fixed rule limits booking to a date interval in the same timezone.
+            new FixedAvailabilityRule(
+                ZonedDateTime.parse("2026-03-16T00:00:00+07:00[Asia/Ho_Chi_Minh]"),
+                ZonedDateTime.parse("2026-03-21T23:59:00+07:00[Asia/Ho_Chi_Minh]")));
+
+        ComputeSlotsRequest request = new ComputeSlotsRequest(
+            eventDuration,
+            Instant.parse("2026-03-16T00:00:00Z"),
+            Instant.parse("2026-03-19T00:00:00Z"),
+            availabilityRules,
+            EMPTY_UNAVAILABLE_TIME_RANGES);
+
+        Set<AvailabilitySlot> slots = testee.computeSlots(request);
+
+        // Intersecting the two rules in the queried window leaves only Monday 09:00-10:00 local time.
+        // In UTC this is 02:00-03:00, so with 20-minute duration we expect 3 starts: 02:00, 02:20, 02:40.
+        assertThat(slots).hasSize(3)
+            .containsExactlyInAnyOrder(new AvailabilitySlot(Instant.parse("2026-03-16T02:00:00Z"), eventDuration),
+                new AvailabilitySlot(Instant.parse("2026-03-16T02:20:00Z"), eventDuration),
+                new AvailabilitySlot(Instant.parse("2026-03-16T02:40:00Z"), eventDuration));
     }
 
     @Test


### PR DESCRIPTION
Previous logic unioned all rules (including different types), which incorrectly widened availability.  
`weekly` and `fixed` rules should constrain each other via intersection (union only within the same type).  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected availability slot calculation to properly intersect overlapping rules instead of merging them, ensuring accurate available time slots when multiple availability rules apply simultaneously.

* **Tests**
  * Added tests validating intersection of weekly and fixed availability rules, including timezone-aware slot computation and mixed rule scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->