### PR TITLE
ISSUE-610 [Public agenda] Return HTTP 422 when requested booking slot is unavailable

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -495,12 +495,12 @@ class BookingLinkReservationRouteTest {
         .when()
             .post("/api/booking-links/{bookingLinkPublicId}/book")
         .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
             .contentType(JSON)
             .body("error", jsonEquals("""
                 {
-                  "code": 400,
-                  "message": "Bad Request",
+                  "code": 422,
+                  "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc %s"
                 }
                 """.formatted(inserted.publicId().value(), unavailableSlotStart)));
@@ -526,12 +526,12 @@ class BookingLinkReservationRouteTest {
         .when()
             .post("/api/booking-links/{bookingLinkPublicId}/book")
         .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
             .contentType(JSON)
             .body("error", jsonEquals("""
                 {
-                  "code": 400,
-                  "message": "Bad Request",
+                  "code": 422,
+                  "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc %s"
                 }
                 """.formatted(inserted.publicId().value(), unavailableSlotStart)));
@@ -558,12 +558,12 @@ class BookingLinkReservationRouteTest {
         .when()
             .post("/api/booking-links/{bookingLinkPublicId}/book")
         .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
             .contentType(JSON)
             .body("error", jsonEquals("""
                 {
-                  "code": 400,
-                  "message": "Bad Request",
+                  "code": 422,
+                  "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc %s"
                 }
                 """.formatted(inserted.publicId().value(), slotStartUtc)));
@@ -663,12 +663,12 @@ class BookingLinkReservationRouteTest {
         .when()
             .post("/api/booking-links/{bookingLinkPublicId}/book")
         .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
             .contentType(JSON)
             .body("error", jsonEquals("""
                 {
-                  "code": 400,
-                  "message": "Bad Request",
+                  "code": 422,
+                  "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc 2036-01-26T08:00:00Z"
                 }
                 """.formatted(inserted.publicId().value())));
@@ -704,12 +704,12 @@ class BookingLinkReservationRouteTest {
         .when()
             .post("/api/booking-links/{bookingLinkPublicId}/book")
         .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
             .contentType(JSON)
             .body("error", jsonEquals("""
                 {
-                  "code": 400,
-                  "message": "Bad Request",
+                  "code": 422,
+                  "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc 2036-01-26T09:30:00Z"
                 }
                 """.formatted(inserted.publicId().value())));

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -648,7 +648,7 @@ class BookingLinkReservationRouteTest {
     }
 
     @Test
-    void shouldReturnBadRequestWhenStartUtcDoesNotMatchAnyAvailableSlot(TwakeCalendarGuiceServer server) {
+    void shouldReturnUnprocessableEntityWhenStartUtcDoesNotMatchAnyAvailableSlot(TwakeCalendarGuiceServer server) {
         BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(
             CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
             AvailabilityRules.of(new FixedAvailabilityRule(
@@ -675,7 +675,7 @@ class BookingLinkReservationRouteTest {
     }
 
     @Test
-    void shouldReturnBadRequestWhenRequestedSlotIsBusy(TwakeCalendarGuiceServer server) {
+    void shouldReturnUnprocessableEntityWhenRequestedSlotIsBusy(TwakeCalendarGuiceServer server) {
         // Given:
         // - Booking rule allows slots from 09:00 to 12:00 UTC with 30-minute duration.
         BookingLink inserted = insertActiveBookingLink(server);

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationRoute.java
@@ -97,7 +97,7 @@ public class BookingLinkReservationRoute implements JMAPRoutes {
             }
             case SlotNotAvailableException slotNotAvailableException -> {
                 LOGGER.warn("Requested slot is unavailable (likely busy) for [{}]: {}", request.uri(), slotNotAvailableException.getMessage());
-                yield ErrorResponseHandler.handle(response, HttpResponseStatus.BAD_REQUEST, slotNotAvailableException);
+                yield ErrorResponseHandler.handle(response, HttpResponseStatus.UNPROCESSABLE_ENTITY, slotNotAvailableException);
             }
             case BookingLinkReservationException bookingLinkReservationException -> {
                 LOGGER.error("Booking operation failed for [{}]", request.uri(), bookingLinkReservationException);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API validation error responses for booking operations now return HTTP 422 (Unprocessable Entity) instead of HTTP 400 (Bad Request), giving clearer, more accurate feedback for invalid booking requests (e.g., unavailable slots, boundary misalignment, duplicate bookings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->