### PR TITLE
[Public agenda] add /api prefix for all booking-links endpoints

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
@@ -132,7 +132,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_CREATED)
             .contentType(ContentType.JSON)
@@ -154,7 +154,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_CREATED)
             .extract().jsonPath().getString("bookingLinkPublicId");
@@ -184,7 +184,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_CREATED)
             .extract().jsonPath().getString("bookingLinkPublicId");
@@ -216,7 +216,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_CREATED)
             .extract().jsonPath().getString("bookingLinkPublicId");
@@ -245,7 +245,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_CREATED)
             .extract().jsonPath().getString("bookingLinkPublicId");
@@ -269,10 +269,10 @@ class BookingLinkCreateRouteTest {
             }
             """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString());
 
-        String firstPublicId = given().body(body).when().post("/booking-links")
+        String firstPublicId = given().body(body).when().post("/api/booking-links")
             .then().statusCode(HttpStatus.SC_CREATED).extract().jsonPath().getString("bookingLinkPublicId");
 
-        String secondPublicId = given().body(body).when().post("/booking-links")
+        String secondPublicId = given().body(body).when().post("/api/booking-links")
             .then().statusCode(HttpStatus.SC_CREATED).extract().jsonPath().getString("bookingLinkPublicId");
 
         assertThat(firstPublicId).isNotEqualTo(secondPublicId);
@@ -289,7 +289,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """)
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -308,7 +308,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """)
             .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
             .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -326,7 +326,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -345,7 +345,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -364,7 +364,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -382,7 +382,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -402,7 +402,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
             .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
             .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -415,7 +415,7 @@ class BookingLinkCreateRouteTest {
         given()
             .body("")
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -428,7 +428,7 @@ class BookingLinkCreateRouteTest {
         given()
             .body("not-valid-json")
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -450,7 +450,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -472,7 +472,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
             .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
             .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -494,7 +494,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
             .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
             .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -516,7 +516,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
             .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
             .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -538,7 +538,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -560,7 +560,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
             .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
             .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
@@ -581,7 +581,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_UNAUTHORIZED);
     }
@@ -597,7 +597,7 @@ class BookingLinkCreateRouteTest {
                 }
                 """)
         .when()
-            .post("/booking-links")
+            .post("/api/booking-links")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkDeleteRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkDeleteRouteTest.java
@@ -119,7 +119,7 @@ class BookingLinkDeleteRouteTest {
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
 
         when()
-            .delete("/booking-links/" + inserted.publicId().value())
+            .delete("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
     }
@@ -130,7 +130,7 @@ class BookingLinkDeleteRouteTest {
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
 
         when()
-            .delete("/booking-links/" + inserted.publicId().value())
+            .delete("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
@@ -145,7 +145,7 @@ class BookingLinkDeleteRouteTest {
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(60), ACTIVE, Optional.empty()));
 
         when()
-            .delete("/booking-links/" + toDelete.publicId().value())
+            .delete("/api/booking-links/" + toDelete.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
@@ -157,7 +157,7 @@ class BookingLinkDeleteRouteTest {
     @Test
     void shouldReturn404WhenBookingLinkDoesNotExist() {
         when()
-            .delete("/booking-links/" + UUID.randomUUID())
+            .delete("/api/booking-links/" + UUID.randomUUID())
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND);
     }
@@ -169,7 +169,7 @@ class BookingLinkDeleteRouteTest {
             new BookingLinkInsertRequest(CalendarURL.from(otherUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
 
         when()
-            .delete("/booking-links/" + otherInserted.publicId().value())
+            .delete("/api/booking-links/" + otherInserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND);
 
@@ -185,7 +185,7 @@ class BookingLinkDeleteRouteTest {
             .auth().none()
             .contentType(ContentType.JSON)
         .when()
-            .delete("/booking-links/" + inserted.publicId().value())
+            .delete("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_UNAUTHORIZED);
     }
@@ -193,7 +193,7 @@ class BookingLinkDeleteRouteTest {
     @Test
     void shouldReturn400WhenPublicIdIsNotAValidUUID() {
         when()
-            .delete("/booking-links/not-a-uuid")
+            .delete("/api/booking-links/not-a-uuid")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST);
     }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
@@ -130,7 +130,7 @@ class BookingLinkGetRouteTest {
 
         String response = given()
         .when()
-            .get("/booking-links/" + inserted.publicId().value())
+            .get("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
@@ -157,7 +157,7 @@ class BookingLinkGetRouteTest {
 
         String response = given()
         .when()
-            .get("/booking-links/" + inserted.publicId().value())
+            .get("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
@@ -190,7 +190,7 @@ class BookingLinkGetRouteTest {
 
         String response = given()
         .when()
-            .get("/booking-links/" + inserted.publicId().value())
+            .get("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
@@ -223,7 +223,7 @@ class BookingLinkGetRouteTest {
 
         String response = given()
         .when()
-            .get("/booking-links/" + inserted.publicId().value())
+            .get("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
@@ -249,7 +249,7 @@ class BookingLinkGetRouteTest {
     void shouldReturn404WhenBookingLinkDoesNotExist() {
         given()
         .when()
-            .get("/booking-links/" + UUID.randomUUID())
+            .get("/api/booking-links/" + UUID.randomUUID())
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND);
     }
@@ -262,7 +262,7 @@ class BookingLinkGetRouteTest {
 
         given()
         .when()
-            .get("/booking-links/" + inserted.publicId().value())
+            .get("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND);
     }
@@ -276,7 +276,7 @@ class BookingLinkGetRouteTest {
             .auth().none()
             .contentType(ContentType.JSON)
         .when()
-            .get("/booking-links/" + inserted.publicId().value())
+            .get("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_UNAUTHORIZED);
     }
@@ -285,7 +285,7 @@ class BookingLinkGetRouteTest {
     void shouldReturn400WhenPublicIdIsNotAValidUUID() {
         given()
         .when()
-            .get("/booking-links/invalid-uuid")
+            .get("/api/booking-links/invalid-uuid")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST);
     }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
@@ -140,7 +140,7 @@ class BookingLinkPatchRouteTest {
                 { "active": false }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
     }
@@ -155,7 +155,7 @@ class BookingLinkPatchRouteTest {
                 { "active": false }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
@@ -173,7 +173,7 @@ class BookingLinkPatchRouteTest {
                 { "durationMinutes": 60 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
@@ -203,7 +203,7 @@ class BookingLinkPatchRouteTest {
                 { "calendarUrl": "%s" }
                 """.formatted(newCalendarUrl.asUri().toString()))
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
@@ -227,7 +227,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
@@ -252,7 +252,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
@@ -274,7 +274,7 @@ class BookingLinkPatchRouteTest {
                 { "availabilityRules": null }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
@@ -294,7 +294,7 @@ class BookingLinkPatchRouteTest {
                 { "durationMinutes": 45 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
@@ -312,7 +312,7 @@ class BookingLinkPatchRouteTest {
                 { "active": false }
                 """)
         .when()
-            .patch("/booking-links/" + UUID.randomUUID())
+            .patch("/api/booking-links/" + UUID.randomUUID())
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND);
     }
@@ -328,7 +328,7 @@ class BookingLinkPatchRouteTest {
                 { "active": false }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND);
     }
@@ -343,7 +343,7 @@ class BookingLinkPatchRouteTest {
                 { "active": false, "unknownField": "value" }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("Invalid request body"));
@@ -357,7 +357,7 @@ class BookingLinkPatchRouteTest {
         given()
             .body("")
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("Request body must not be empty"));
@@ -371,7 +371,7 @@ class BookingLinkPatchRouteTest {
         given()
             .body("not-valid-json")
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("Invalid request body"));
@@ -385,7 +385,7 @@ class BookingLinkPatchRouteTest {
         given()
             .body("{}")
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
@@ -400,7 +400,7 @@ class BookingLinkPatchRouteTest {
                 { "durationMinutes": 0 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'durationMinutes' must be positive"));
@@ -416,7 +416,7 @@ class BookingLinkPatchRouteTest {
                 { "durationMinutes": -10 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'durationMinutes' must be positive"));
@@ -437,7 +437,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("Invalid 'timeZone' format"));
@@ -458,7 +458,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'dayOfWeek' must be provided for weekly rule"));
@@ -479,7 +479,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("Unknown day of week abbreviation: ABC"));
@@ -500,7 +500,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("Invalid 'start' or 'end' time format for weekly rule, expected HH:mm"));
@@ -521,7 +521,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("Invalid 'start' or 'end' date-time format for fixed rule, expected yyyy-MM-ddTHH:mm:ss"));
@@ -542,7 +542,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("Unknown availability rule type: unknown"));
@@ -560,7 +560,7 @@ class BookingLinkPatchRouteTest {
                 { "active": false }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_UNAUTHORIZED);
     }
@@ -572,7 +572,7 @@ class BookingLinkPatchRouteTest {
                 { "active": false }
                 """)
         .when()
-            .patch("/booking-links/not-a-uuid")
+            .patch("/api/booking-links/not-a-uuid")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
@@ -590,7 +590,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'timeZone' cannot be provided if 'availabilityRules' is not being updated"));
@@ -611,7 +611,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'timeZone' cannot be provided if 'availabilityRules' is being removed"));
@@ -631,7 +631,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'timeZone' must be provided when updating 'availabilityRules'"));
@@ -647,7 +647,7 @@ class BookingLinkPatchRouteTest {
                 { "calendarUrl": null }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'calendarUrl' cannot be removed"));
@@ -663,7 +663,7 @@ class BookingLinkPatchRouteTest {
                 { "durationMinutes": null }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'durationMinutes' cannot be removed"));
@@ -679,7 +679,7 @@ class BookingLinkPatchRouteTest {
                 { "active": null }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'active' cannot be removed"));
@@ -698,7 +698,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'availabilityRules' cannot be empty if provided"));
@@ -719,7 +719,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """)
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("'start' must be before 'end' for fixed rule"));
@@ -742,7 +742,7 @@ class BookingLinkPatchRouteTest {
                 { "calendarUrl": "%s" }
                 """.formatted(otherUserCalendarUrl.asUri().toString()))
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.details", equalTo("Calendar not found or access denied: " + otherUserCalendarUrl.asUri()));
@@ -762,7 +762,7 @@ class BookingLinkPatchRouteTest {
                 }
                 """.formatted(nonExistentCalendarUrl.asUri().toString()))
         .when()
-            .patch("/booking-links/" + inserted.publicId().value())
+            .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkResetPublicIdRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkResetPublicIdRouteTest.java
@@ -122,7 +122,7 @@ class BookingLinkResetPublicIdRouteTest {
 
         String response = given()
         .when()
-            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+            .post("/api/booking-links/" + inserted.publicId().value() + "/reset")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
@@ -140,7 +140,7 @@ class BookingLinkResetPublicIdRouteTest {
 
         String newPublicId = given()
         .when()
-            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+            .post("/api/booking-links/" + inserted.publicId().value() + "/reset")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .extract().jsonPath().getString("bookingLinkPublicId");
@@ -155,7 +155,7 @@ class BookingLinkResetPublicIdRouteTest {
 
         given()
         .when()
-            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+            .post("/api/booking-links/" + inserted.publicId().value() + "/reset")
         .then()
             .statusCode(HttpStatus.SC_OK);
 
@@ -169,7 +169,7 @@ class BookingLinkResetPublicIdRouteTest {
 
         String newPublicId = given()
         .when()
-            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+            .post("/api/booking-links/" + inserted.publicId().value() + "/reset")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .extract().jsonPath().getString("bookingLinkPublicId");
@@ -181,7 +181,7 @@ class BookingLinkResetPublicIdRouteTest {
     void shouldReturn404WhenBookingLinkDoesNotExist() {
         given()
         .when()
-            .post("/booking-links/" + UUID.randomUUID() + "/reset")
+            .post("/api/booking-links/" + UUID.randomUUID() + "/reset")
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND);
     }
@@ -194,7 +194,7 @@ class BookingLinkResetPublicIdRouteTest {
 
         given()
         .when()
-            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+            .post("/api/booking-links/" + inserted.publicId().value() + "/reset")
         .then()
             .statusCode(HttpStatus.SC_NOT_FOUND);
     }
@@ -208,7 +208,7 @@ class BookingLinkResetPublicIdRouteTest {
             .auth().none()
             .contentType(ContentType.JSON)
         .when()
-            .post("/booking-links/" + inserted.publicId().value() + "/reset")
+            .post("/api/booking-links/" + inserted.publicId().value() + "/reset")
         .then()
             .statusCode(HttpStatus.SC_UNAUTHORIZED);
     }
@@ -218,7 +218,7 @@ class BookingLinkResetPublicIdRouteTest {
         with()
             .contentType(ContentType.JSON)
         .when()
-            .post("/booking-links/invalid-uuid/reset")
+            .post("/api/booking-links/invalid-uuid/reset")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST);
     }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
@@ -114,7 +114,7 @@ public class BookingLinkCreateRoute extends CalendarRoute {
 
     @Override
     Endpoint endpoint() {
-        return new Endpoint(HttpMethod.POST, "/booking-links");
+        return new Endpoint(HttpMethod.POST, "/api/booking-links");
     }
 
     @Override

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkDeleteRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkDeleteRoute.java
@@ -53,7 +53,7 @@ public class BookingLinkDeleteRoute extends CalendarRoute {
 
     @Override
     Endpoint endpoint() {
-        return new Endpoint(HttpMethod.DELETE, "/booking-links/{" + PUBLIC_ID_PARAM + "}");
+        return new Endpoint(HttpMethod.DELETE, "/api/booking-links/{" + PUBLIC_ID_PARAM + "}");
     }
 
     @Override

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkGetRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkGetRoute.java
@@ -103,7 +103,7 @@ public class BookingLinkGetRoute extends CalendarRoute {
 
     @Override
     Endpoint endpoint() {
-        return new Endpoint(HttpMethod.GET, "/booking-links/{" + PUBLIC_ID_PARAM + "}");
+        return new Endpoint(HttpMethod.GET, "/api/booking-links/{" + PUBLIC_ID_PARAM + "}");
     }
 
     @Override

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
@@ -83,7 +83,7 @@ public class BookingLinkPatchRoute extends CalendarRoute {
 
     @Override
     Endpoint endpoint() {
-        return new Endpoint(HttpMethod.PATCH, "/booking-links/{" + PUBLIC_ID_PARAM + "}");
+        return new Endpoint(HttpMethod.PATCH, "/api/booking-links/{" + PUBLIC_ID_PARAM + "}");
     }
 
     @Override

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkResetPublicIdRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkResetPublicIdRoute.java
@@ -58,7 +58,7 @@ public class BookingLinkResetPublicIdRoute extends CalendarRoute {
 
     @Override
     Endpoint endpoint() {
-        return new Endpoint(HttpMethod.POST, "/booking-links/{" + PUBLIC_ID_PARAM + "}/reset");
+        return new Endpoint(HttpMethod.POST, "/api/booking-links/{" + PUBLIC_ID_PARAM + "}/reset");
     }
 
     @Override

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -50,7 +50,7 @@ The `timeZone` field at the booking link level applies to all availability rules
 
 ## Endpoints
 
-### **POST /booking-links**
+### **POST /api/booking-links**
 
 Create a new booking link for the authenticated user.
 
@@ -66,7 +66,7 @@ Create a new booking link for the authenticated user.
 
 **Sample request**
 ```
-POST /booking-links
+POST /api/booking-links
 Authorization: Bearer <token>
 Content-Type: application/json
 
@@ -102,13 +102,13 @@ Content-Type: application/json
 
 ---
 
-### **GET /booking-links/{bookingLinkPublicId}**
+### **GET /api/booking-links/{bookingLinkPublicId}**
 
 Retrieve a booking link by its public ID. Only returns the link if it belongs to the authenticated user.
 
 **Sample request**
 ```
-GET /booking-links/550e8400-e29b-41d4-a716-446655440000
+GET /api/booking-links/550e8400-e29b-41d4-a716-446655440000
 Authorization: Bearer <token>
 ```
 
@@ -143,7 +143,7 @@ Fields `availabilityRules` are omitted from the response when not set.
 
 ---
 
-### **PATCH /booking-links/{bookingLinkPublicId}**
+### **PATCH /api/booking-links/{bookingLinkPublicId}**
 
 Partially update a booking link. Only fields present in the request body are updated,
 absent fields are left unchanged. At least one field must be provided.
@@ -162,7 +162,7 @@ All fields are optional. Include only the fields to update.
 
 **Sample request — update duration and deactivate**
 ```
-PATCH /booking-links/550e8400-e29b-41d4-a716-446655440000
+PATCH /api/booking-links/550e8400-e29b-41d4-a716-446655440000
 Authorization: Bearer <token>
 Content-Type: application/json
 
@@ -174,7 +174,7 @@ Content-Type: application/json
 
 **Sample request — replace availability rules**
 ```
-PATCH /booking-links/550e8400-e29b-41d4-a716-446655440000
+PATCH /api/booking-links/550e8400-e29b-41d4-a716-446655440000
 Authorization: Bearer <token>
 Content-Type: application/json
 
@@ -188,7 +188,7 @@ Content-Type: application/json
 
 **Sample request — remove availability rules**
 ```
-PATCH /booking-links/550e8400-e29b-41d4-a716-446655440000
+PATCH /api/booking-links/550e8400-e29b-41d4-a716-446655440000
 Authorization: Bearer <token>
 Content-Type: application/json
 
@@ -212,14 +212,14 @@ HTTP/1.1 204 No Content
 
 ---
 
-### **DELETE /booking-links/{bookingLinkPublicId}**
+### **DELETE /api/booking-links/{bookingLinkPublicId}**
 
 Delete a booking link. Only deletes the link if it belongs to the authenticated user.
 Returns 404 if the booking link does not exist or belongs to another user.
 
 **Sample request**
 ```
-DELETE /booking-links/550e8400-e29b-41d4-a716-446655440000
+DELETE /api/booking-links/550e8400-e29b-41d4-a716-446655440000
 Authorization: Bearer <token>
 ```
 
@@ -238,14 +238,14 @@ HTTP/1.1 204 No Content
 
 ---
 
-### **POST /booking-links/{bookingLinkPublicId}/reset**
+### **POST /api/booking-links/{bookingLinkPublicId}/reset**
 
 Generate a new public ID for an existing booking link, invalidating the old one.
 Useful when the current public link needs to be revoked and replaced.
 
 **Sample request**
 ```
-POST /booking-links/550e8400-e29b-41d4-a716-446655440000/reset
+POST /api/booking-links/550e8400-e29b-41d4-a716-446655440000/reset
 Authorization: Bearer <token>
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Booking Link endpoints updated to use `/api/` namespace for create, read, update, delete, and public ID reset operations
* **Documentation**
  * API documentation updated to reflect endpoint path changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->