### PR TITLE
Allow COUNTER in CORS atop DavProxy

### DIFF
--- a/app/docker-sample/nginx/nginx.conf
+++ b/app/docker-sample/nginx/nginx.conf
@@ -8,7 +8,7 @@ server {
 
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, PATCH, DELETE, REPORT, PROPFIND, PROPPATCH, MKCOL, COPY, MOVE, LOCK, UNLOCK, MKWORKSPACE, UPDATE, CHECKIN, CHECKOUT, UNCHECKOUT, VERSION-CONTROL, SEARCH, LABEL' always;
-            add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Authorization' always;
+            add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Authorization, Accept, Depth, Destination, Prefer, X-Http-Method-Override, If-Match, Overwrite' always;
             add_header 'Access-Control-Allow-Origin' "*" always;
             add_header 'Access-Control-Allow-Credentials' 'true' always;
             add_header Expires 0;
@@ -43,7 +43,7 @@ server {
 
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, PATCH, DELETE, REPORT, PROPFIND, PROPPATCH, MKCOL, COPY, MOVE, LOCK, UNLOCK, MKWORKSPACE, UPDATE, CHECKIN, CHECKOUT, UNCHECKOUT, VERSION-CONTROL, SEARCH, LABEL' always;
-            add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Authorization' always;
+            add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Authorization, Accept, Depth, Destination, Prefer, X-Http-Method-Override, If-Match, Overwrite' always;
             add_header 'Access-Control-Allow-Origin' "*" always;
             add_header 'Access-Control-Allow-Credentials' 'true' always;
             add_header Expires 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CORS configuration to extend the list of allowed HTTP request headers. The application now permits requests containing Accept, Depth, Destination, Prefer, X-Http-Method-Override, If-Match, and Overwrite headers in addition to previously supported headers. This change broadens the types of cross-origin requests the application can process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->