### PR TITLE
ISSUE-649 Different timezones for different availability rules

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
@@ -188,10 +188,9 @@ class BookingLinkCreateRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 30,
                     "active": true,
-                    "timeZone": "Asia/Ho_Chi_Minh",
                     "availabilityRules": [
-                        { "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "type": "weekly" },
-                        { "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "type": "weekly" }
+                        { "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "type": "weekly", "timeZone": "Asia/Ho_Chi_Minh" },
+                        { "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "type": "weekly", "timeZone": "Europe/London" }
                     ]
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
@@ -209,7 +208,7 @@ class BookingLinkCreateRouteTest {
         assertThat(stored.active()).isTrue();
         assertThat(stored.availabilityRules()).isEqualTo(Optional.of(AvailabilityRules.of(
             new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(12, 0), ZoneId.of("Asia/Ho_Chi_Minh")),
-            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(17, 0), ZoneId.of("Asia/Ho_Chi_Minh"))
+            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(17, 0), ZoneId.of("Europe/London"))
         )));
     }
 
@@ -221,9 +220,8 @@ class BookingLinkCreateRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 60,
                     "active": false,
-                    "timeZone": "UTC",
                     "availabilityRules": [
-                        { "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00", "type": "fixed" }
+                        { "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00", "type": "fixed", "timeZone": "UTC" }
                     ]
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
@@ -251,8 +249,8 @@ class BookingLinkCreateRouteTest {
                     "durationMinutes": 30,
                     "active": true,
                     "availabilityRules": [
-                        { "dayOfWeek": "TUE", "start": "09:00", "end": "17:00", "type": "weekly" },
-                        { "start": "2026-01-26T00:00:00", "end": "2026-01-30T00:00:00", "type": "fixed" }
+                        { "dayOfWeek": "TUE", "start": "09:00", "end": "17:00", "type": "weekly", "timeZone": "Asia/Ho_Chi_Minh" },
+                        { "start": "2026-01-26T00:00:00", "end": "2026-01-30T00:00:00", "type": "fixed", "timeZone": "Europe/London" }
                     ]
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
@@ -266,8 +264,8 @@ class BookingLinkCreateRouteTest {
 
         assertThat(stored.availabilityRules().orElseThrow().values()).hasSize(2);
         assertThat(stored.availabilityRules()).isEqualTo(Optional.of(AvailabilityRules.of(
-            new WeeklyAvailabilityRule(DayOfWeek.TUESDAY, LocalTime.of(9, 0), LocalTime.of(17, 0), ZoneId.of("Europe/Paris")),
-            new FixedAvailabilityRule(LocalDateTime.parse("2026-01-26T00:00:00").atZone(ZoneId.of("Europe/Paris")), LocalDateTime.parse("2026-01-30T00:00:00").atZone(ZoneId.of("Europe/Paris")))
+            new WeeklyAvailabilityRule(DayOfWeek.TUESDAY, LocalTime.of(9, 0), LocalTime.of(17, 0), ZoneId.of("Asia/Ho_Chi_Minh")),
+            new FixedAvailabilityRule(LocalDateTime.parse("2026-01-26T00:00:00").atZone(ZoneId.of("Europe/London")), LocalDateTime.parse("2026-01-30T00:00:00").atZone(ZoneId.of("Europe/London")))
         )));
     }
 
@@ -436,9 +434,8 @@ class BookingLinkCreateRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 30,
                     "active": true,
-                    "timeZone": "Invalid/Timezone",
                     "availabilityRules": [
-                        { "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "type": "weekly" }
+                        { "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "type": "weekly", "timeZone": "Invalid/Timezone" }
                     ]
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
@@ -448,7 +445,7 @@ class BookingLinkCreateRouteTest {
             .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body("error.code", equalTo(400))
             .body("error.message", equalTo("Bad request"))
-            .body("error.details", equalTo("Invalid 'timeZone' format"));
+            .body("error.details", equalTo("Invalid 'timeZone' format: Invalid/Timezone"));
     }
 
     @Test
@@ -607,24 +604,6 @@ class BookingLinkCreateRouteTest {
             .body("error.code", equalTo(400))
             .body("error.message", equalTo("Bad request"))
             .body("error.details", equalTo("'type' is required in availability rule"));
-    }
-
-    @Test
-    void shouldReturn400WhenTimeZoneProvidedWithoutAvailabilityRules() {
-        given()
-            .body("""
-                {
-                    "calendarUrl": "%s",
-                    "durationMinutes": 30,
-                    "active": true,
-                    "timeZone": "UTC"
-                }
-                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
-        .when()
-            .post("/api/booking-links")
-        .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
-            .body("error.details", equalTo("'timeZone' cannot be provided when 'availabilityRules' is null or empty"));
     }
 
     @Test

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
@@ -151,7 +151,7 @@ class BookingLinkGetRouteTest {
     void shouldReturn200WithWeeklyAvailabilityRules() {
         AvailabilityRules rules = AvailabilityRules.of(
             new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(12, 0), ZONE_HO_CHI_MINH),
-            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(17, 0), ZONE_HO_CHI_MINH));
+            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(17, 0), ZoneId.of("Europe/London")));
         BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.of(rules)));
 
@@ -170,10 +170,9 @@ class BookingLinkGetRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 30,
                     "active": true,
-                    "timeZone": "Asia/Ho_Chi_Minh",
                     "availabilityRules": [
-                        { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00" },
-                        { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00" }
+                        { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Asia/Ho_Chi_Minh" },
+                        { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "timeZone": "Europe/London" }
                     ]
                 }
                 """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));
@@ -203,9 +202,8 @@ class BookingLinkGetRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 60,
                     "active": false,
-                    "timeZone": "UTC",
                     "availabilityRules": [
-                        { "type": "fixed", "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00" }
+                        { "type": "fixed", "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00", "timeZone": "UTC" }
                     ]
                 }
                 """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));
@@ -216,8 +214,8 @@ class BookingLinkGetRouteTest {
         AvailabilityRules rules = AvailabilityRules.of(
             new WeeklyAvailabilityRule(DayOfWeek.TUESDAY, LocalTime.of(9, 0), LocalTime.of(17, 0), ZONE_HO_CHI_MINH),
             new FixedAvailabilityRule(
-                LocalDateTime.parse("2026-01-26T00:00:00").atZone(ZONE_HO_CHI_MINH),
-                LocalDateTime.parse("2026-01-30T00:00:00").atZone(ZONE_HO_CHI_MINH)));
+                LocalDateTime.parse("2026-01-26T00:00:00").atZone(ZoneId.of("Europe/London")),
+                LocalDateTime.parse("2026-01-30T00:00:00").atZone(ZoneId.of("Europe/London"))));
         BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.of(rules)));
 
@@ -236,10 +234,9 @@ class BookingLinkGetRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 30,
                     "active": true,
-                    "timeZone": "Asia/Ho_Chi_Minh",
                     "availabilityRules": [
-                        { "type": "weekly", "dayOfWeek": "TUE", "start": "09:00", "end": "17:00" },
-                        { "type": "fixed", "start": "2026-01-26T00:00:00", "end": "2026-01-30T00:00:00" }
+                        { "type": "weekly", "dayOfWeek": "TUE", "start": "09:00", "end": "17:00", "timeZone": "Asia/Ho_Chi_Minh" },
+                        { "type": "fixed", "start": "2026-01-26T00:00:00", "end": "2026-01-30T00:00:00", "timeZone": "Europe/London" }
                     ]
                 }
                 """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
@@ -219,10 +219,9 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "Asia/Ho_Chi_Minh",
                     "availabilityRules": [
-                        { "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "type": "weekly" },
-                        { "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "type": "weekly" }
+                        { "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "type": "weekly", "timeZone": "Asia/Ho_Chi_Minh" },
+                        { "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "type": "weekly", "timeZone": "Europe/London" }
                     ]
                 }
                 """)
@@ -234,7 +233,7 @@ class BookingLinkPatchRouteTest {
         BookingLink updated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
         assertThat(updated.availabilityRules()).isEqualTo(Optional.of(AvailabilityRules.of(
             new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(12, 0), ZONE_HO_CHI_MINH),
-            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(17, 0), ZONE_HO_CHI_MINH))));
+            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(17, 0), ZoneId.of("Europe/London")))));
     }
 
     @Test
@@ -245,9 +244,8 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "UTC",
                     "availabilityRules": [
-                        { "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00", "type": "fixed" }
+                        { "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00", "type": "fixed", "timeZone": "UTC" }
                     ]
                 }
                 """)
@@ -430,9 +428,8 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "Invalid/Timezone",
                     "availabilityRules": [
-                        { "dayOfWeek": "MON", "start": "09:00", "end": "17:00", "type": "weekly" }
+                        { "dayOfWeek": "MON", "start": "09:00", "end": "17:00", "type": "weekly", "timeZone": "Invalid/Timezone" }
                     ]
                 }
                 """)
@@ -440,7 +437,7 @@ class BookingLinkPatchRouteTest {
             .patch("/api/booking-links/" + inserted.publicId().value())
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST)
-            .body("error.details", equalTo("Invalid 'timeZone' format"));
+            .body("error.details", equalTo("Invalid 'timeZone' format: Invalid/Timezone"));
     }
 
     @Test
@@ -451,7 +448,6 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "UTC",
                     "availabilityRules": [
                         { "start": "09:00", "end": "12:00", "type": "weekly" }
                     ]
@@ -472,7 +468,6 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "UTC",
                     "availabilityRules": [
                         { "dayOfWeek": "ABC", "start": "09:00", "end": "12:00", "type": "weekly" }
                     ]
@@ -493,7 +488,6 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "UTC",
                     "availabilityRules": [
                         { "dayOfWeek": "MON", "start": "invalid", "end": "12:00", "type": "weekly" }
                     ]
@@ -514,9 +508,8 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "UTC",
                     "availabilityRules": [
-                        { "start": "not-a-date", "end": "2026-01-30T00:00:00", "type": "fixed" }
+                        { "start": "not-a-date", "end": "2026-01-30T00:00:00", "type": "fixed", "timeZone": "UTC" }
                     ]
                 }
                 """)
@@ -535,7 +528,6 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "UTC",
                     "availabilityRules": [
                         { "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "type": "unknown" }
                     ]
@@ -575,66 +567,6 @@ class BookingLinkPatchRouteTest {
             .patch("/api/booking-links/not-a-uuid")
         .then()
             .statusCode(HttpStatus.SC_BAD_REQUEST);
-    }
-
-    @Test
-    void shouldReturn400WhenTimeZoneIsProvidedWithoutAvailabilityRules() {
-        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
-            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
-
-        given()
-            .body("""
-                {
-                    "timeZone": "UTC",
-                    "active": false
-                }
-                """)
-        .when()
-            .patch("/api/booking-links/" + inserted.publicId().value())
-        .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
-            .body("error.details", equalTo("'timeZone' cannot be provided if 'availabilityRules' is not being updated"));
-    }
-
-    @Test
-    void shouldReturn400WhenTimeZoneIsProvidedWhenAvailabilityRulesIsRemoved() {
-        AvailabilityRules existingRules = AvailabilityRules.of(
-            new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(17, 0), UTC));
-        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
-            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.of(existingRules)));
-
-        given()
-            .body("""
-                {
-                    "timeZone": "UTC",
-                    "availabilityRules": null
-                }
-                """)
-        .when()
-            .patch("/api/booking-links/" + inserted.publicId().value())
-        .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
-            .body("error.details", equalTo("'timeZone' cannot be provided if 'availabilityRules' is being removed"));
-    }
-
-    @Test
-    void shouldReturn400WhenAvailabilityRulesAreUpdatedWithoutTimeZone() {
-        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
-            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
-
-        given()
-            .body("""
-                {
-                    "availabilityRules": [
-                        { "dayOfWeek": "MON", "start": "09:00", "end": "17:00", "type": "weekly" }
-                    ]
-                }
-                """)
-        .when()
-            .patch("/api/booking-links/" + inserted.publicId().value())
-        .then()
-            .statusCode(HttpStatus.SC_BAD_REQUEST)
-            .body("error.details", equalTo("'timeZone' must be provided when updating 'availabilityRules'"));
     }
 
     @Test
@@ -693,7 +625,6 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "UTC",
                     "availabilityRules": []
                 }
                 """)
@@ -712,9 +643,8 @@ class BookingLinkPatchRouteTest {
         given()
             .body("""
                 {
-                    "timeZone": "UTC",
                     "availabilityRules": [
-                        { "start": "2026-01-30T00:00:00", "end": "2026-01-26T00:00:00", "type": "fixed" }
+                        { "start": "2026-01-30T00:00:00", "end": "2026-01-26T00:00:00", "type": "fixed", "timeZone": "UTC" }
                     ]
                 }
                 """)

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
@@ -22,7 +22,6 @@ import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
 import static com.linagora.calendar.restapi.RestApiConstants.OBJECT_MAPPER_DEFAULT;
 import static com.linagora.calendar.storage.configuration.resolver.BusinessHoursSettingReader.BUSINESS_HOURS_IDENTIFIER;
 
-import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.LocalTime;
@@ -65,10 +64,7 @@ public class BookingLinkCreateRoute extends CalendarRoute {
     public record CreateBookingLinkRequestDTO(@JsonProperty("calendarUrl") String calendarUrl,
                                               @JsonProperty("durationMinutes") Integer durationMinutes,
                                               @JsonProperty("active") Boolean active,
-                                              @JsonProperty("timeZone") Optional<String> timeZone,
                                               @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules) {
-
-        private static final boolean ABSENT = true;
 
         public static BookingLinkInsertRequest toBookingLinkInsertRequest(CreateBookingLinkRequestDTO request,
                                                                           ZoneId defaultZone,
@@ -78,40 +74,23 @@ public class BookingLinkCreateRoute extends CalendarRoute {
             Preconditions.checkArgument(request.durationMinutes > 0, "'durationMinutes' must be positive");
             Preconditions.checkArgument(!Objects.isNull(request.active), "'active' is required");
 
-            if (request.timeZone.isPresent() && request.availabilityRules.map(List::isEmpty).orElse(ABSENT)) {
-                throw new IllegalArgumentException("'timeZone' cannot be provided when 'availabilityRules' is null or empty");
-            }
-
             CalendarURL calendarURL = CalendarURL.parse(request.calendarUrl);
             Duration duration = Duration.ofMinutes(request.durationMinutes);
-            ZoneId timeZone = getTimeZone(request, defaultZone);
 
-            Optional<AvailabilityRules> availabilityRules = getAvailabilityRules(request, timeZone).or(() -> defaultAvailabilityRules);
+            Optional<AvailabilityRules> availabilityRules = getAvailabilityRules(request, defaultZone).or(() -> defaultAvailabilityRules);
 
             return new BookingLinkInsertRequest(calendarURL, duration, request.active, availabilityRules);
         }
 
-        private static ZoneId getTimeZone(CreateBookingLinkRequestDTO request, ZoneId defaultZone) {
-            try {
-                return request.timeZone()
-                    .map(ZoneId::of)
-                    .orElse(defaultZone);
-            } catch (DateTimeException e) {
-                throw new IllegalArgumentException("Invalid 'timeZone' format", e);
-            }
-        }
-
-        private static Optional<AvailabilityRules> getAvailabilityRules(CreateBookingLinkRequestDTO request, ZoneId timeZone) {
+        private static Optional<AvailabilityRules> getAvailabilityRules(CreateBookingLinkRequestDTO request, ZoneId defaultZone) {
             return request.availabilityRules()
                 .filter(rules -> !rules.isEmpty())
                 .map(rules -> rules.stream()
-                    .map(dto -> dto.toAvailabilityRule(timeZone))
+                    .map(dto -> dto.toAvailabilityRule(defaultZone))
                     .toList())
                 .map(AvailabilityRules::new);
         }
     }
-
-    public static final ZoneId UTC = ZoneId.of("UTC");
     private static final String BOOKING_LINK_PUBLIC_ID = "bookingLinkPublicId";
 
     private static final DateTimeFormatter BUSINESS_HOURS_TIME_FORMATTER = DateTimeFormatter.ofPattern("H:m");

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkGetRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkGetRoute.java
@@ -21,7 +21,6 @@ package com.linagora.calendar.restapi.routes;
 import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
 import static com.linagora.calendar.restapi.RestApiConstants.OBJECT_MAPPER_DEFAULT;
 
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -35,9 +34,6 @@ import org.apache.james.metrics.api.MetricFactory;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.linagora.calendar.api.booking.AvailabilityRule;
-import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
-import com.linagora.calendar.api.booking.AvailabilityRule.WeeklyAvailabilityRule;
 import com.linagora.calendar.restapi.routes.dto.AvailabilityRuleDTO;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
@@ -57,10 +53,7 @@ public class BookingLinkGetRoute extends CalendarRoute {
                                  @JsonProperty("calendarUrl") String calendarUrl,
                                  @JsonProperty("durationMinutes") long durationMinutes,
                                  @JsonProperty("active") boolean active,
-                                 @JsonProperty("timeZone") Optional<String> timeZone,
                                  @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules) {
-
-        public static final String UTC = "UTC";
 
         public static BookingLinkDTO from(BookingLink bookingLink) {
             Optional<List<AvailabilityRuleDTO>> ruleDTOs = bookingLink.availabilityRules()
@@ -68,24 +61,12 @@ public class BookingLinkGetRoute extends CalendarRoute {
                     .map(AvailabilityRuleDTO::from)
                     .toList());
 
-            Optional<String> timeZone = bookingLink.availabilityRules()
-                .flatMap(rules -> rules.values().stream().findFirst())
-                .map(BookingLinkDTO::extractTimeZone);
-
             return new BookingLinkDTO(
                 bookingLink.publicId().value().toString(),
                 bookingLink.calendarUrl().asUri().toString(),
                 bookingLink.duration().toMinutes(),
                 bookingLink.active(),
-                timeZone,
                 ruleDTOs);
-        }
-
-        private static String extractTimeZone(AvailabilityRule rule) {
-            return switch (rule) {
-                case WeeklyAvailabilityRule weekly -> weekly.timeZone().map(ZoneId::getId).orElse(UTC);
-                case FixedAvailabilityRule fixed -> fixed.start().getZone().getId();
-            };
         }
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
@@ -20,7 +20,6 @@ package com.linagora.calendar.restapi.routes;
 
 import static com.linagora.calendar.restapi.RestApiConstants.OBJECT_MAPPER_DEFAULT;
 
-import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.List;
@@ -28,6 +27,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import org.apache.james.jmap.Endpoint;
 import org.apache.james.jmap.http.Authenticator;
@@ -46,6 +46,7 @@ import com.linagora.calendar.storage.booking.BookingLinkDAO;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
 import com.linagora.calendar.storage.booking.BookingLinkPatchRequest;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
 
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -60,25 +61,27 @@ public class BookingLinkPatchRoute extends CalendarRoute {
     private static final String FIELD_DURATION_MINUTES = "durationMinutes";
     private static final String FIELD_ACTIVE = "active";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
-    private static final String FIELD_TIME_ZONE = "timeZone";
 
     public record PatchDto(@JsonProperty(FIELD_CALENDAR_URL) Optional<String> calendarUrl,
                            @JsonProperty(FIELD_DURATION_MINUTES) Optional<Integer> durationMinutes,
                            @JsonProperty(FIELD_ACTIVE) Optional<Boolean> active,
-                           @JsonProperty(FIELD_TIME_ZONE) Optional<String> timeZone,
                            @JsonProperty(FIELD_AVAILABILITY_RULES) Optional<List<AvailabilityRuleDTO>> availabilityRules) {
     }
 
     private final BookingLinkDAO bookingLinkDAO;
     private final CalDavClient calDavClient;
+    private final SettingsBasedResolver settingsResolver;
 
     @Inject
     public BookingLinkPatchRoute(Authenticator authenticator,
                                  MetricFactory metricFactory,
-                                 BookingLinkDAO bookingLinkDAO, CalDavClient calDavClient) {
+                                 BookingLinkDAO bookingLinkDAO,
+                                 CalDavClient calDavClient,
+                                 @Named("businessHours") SettingsBasedResolver settingsResolver) {
         super(authenticator, metricFactory);
         this.bookingLinkDAO = bookingLinkDAO;
         this.calDavClient = calDavClient;
+        this.settingsResolver = settingsResolver;
     }
 
     @Override
@@ -92,7 +95,8 @@ public class BookingLinkPatchRoute extends CalendarRoute {
 
         return request.receive().aggregate().asByteArray()
             .switchIfEmpty(Mono.error(new IllegalArgumentException("Request body must not be empty")))
-            .map(this::parsePatchRequest)
+            .flatMap(body -> settingsResolver.resolveOrDefault(session.getUser())
+                .map(resolvedSettings -> parsePatchRequest(body, resolvedSettings.zoneId())))
             .flatMap(patchRequest ->
                 patchRequest.calendarUrl().toOptional().map(calendarURL ->
                     validateCalendarAccess(calendarURL, session).thenReturn(patchRequest)).orElse(Mono.just(patchRequest)))
@@ -112,7 +116,7 @@ public class BookingLinkPatchRoute extends CalendarRoute {
             });
     }
 
-    private BookingLinkPatchRequest parsePatchRequest(byte[] body) {
+    private BookingLinkPatchRequest parsePatchRequest(byte[] body, ZoneId defaultTimeZone) {
         try {
             JsonNode node = OBJECT_MAPPER_DEFAULT.readTree(body);
             PatchDto dto = parseJSONtoPatchDto(body);
@@ -120,7 +124,7 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                 parseCalendarUrl(node, dto),
                 parseDuration(node, dto),
                 parseActive(node, dto),
-                parseAvailabilityRules(node, dto));
+                parseAvailabilityRules(node, dto, defaultTimeZone));
         } catch (IllegalArgumentException e) {
             throw e;
         } catch (Exception e) {
@@ -166,31 +170,18 @@ public class BookingLinkPatchRoute extends CalendarRoute {
         return dto.active.map(ValuePatch::modifyTo).orElseThrow(() -> new IllegalArgumentException("'active' cannot be removed"));
     }
 
-    private ValuePatch<AvailabilityRules> parseAvailabilityRules(JsonNode node, PatchDto dto) {
+    private ValuePatch<AvailabilityRules> parseAvailabilityRules(JsonNode node, PatchDto dto, ZoneId defaultTimeZone) {
         if (!node.has(FIELD_AVAILABILITY_RULES)) {
-            Preconditions.checkArgument(dto.timeZone().isEmpty(), "'timeZone' cannot be provided if 'availabilityRules' is not being updated");
             return ValuePatch.keep();
         }
         return dto.availabilityRules.map(rules -> rules.stream()
-            .map(availabilityRuleDTO -> availabilityRuleDTO.toAvailabilityRule(
-                dto.timeZone().map(this::toZoneId).orElseThrow(() -> new IllegalArgumentException("'timeZone' must be provided when updating 'availabilityRules'"))))
+            .map(availabilityRuleDTO -> availabilityRuleDTO.toAvailabilityRule(defaultTimeZone))
             .toList())
             .map(ruleList -> {
                 Preconditions.checkArgument(!ruleList.isEmpty(), "'availabilityRules' cannot be empty if provided");
                 return new AvailabilityRules(ruleList);
             })
             .map(ValuePatch::modifyTo)
-            .orElseGet(() -> {
-                Preconditions.checkArgument(dto.timeZone().isEmpty(), "'timeZone' cannot be provided if 'availabilityRules' is being removed");
-                return ValuePatch.remove();
-            });
-    }
-
-    private ZoneId toZoneId(String timeZone) {
-        try {
-            return ZoneId.of(timeZone);
-        } catch (DateTimeException e) {
-            throw new IllegalArgumentException("Invalid 'timeZone' format", e);
-        }
+            .orElseGet(ValuePatch::remove);
     }
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/AvailabilityRuleDTO.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/AvailabilityRuleDTO.java
@@ -18,6 +18,7 @@
 
 package com.linagora.calendar.restapi.routes.dto;
 
+import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -40,7 +41,8 @@ import com.linagora.calendar.restapi.DayOfWeekUtil;
 public record AvailabilityRuleDTO(@JsonProperty("type") AvailabilityRuleType type,
                                   @JsonProperty("dayOfWeek") Optional<String> dayOfWeek,
                                   @JsonProperty("start") String start,
-                                  @JsonProperty("end") String end) {
+                                  @JsonProperty("end") String end,
+                                  @JsonProperty("timeZone") Optional<String> timeZone) {
 
     private static final DateTimeFormatter LOCAL_DATE_TIME_FORMAT =
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
@@ -55,32 +57,34 @@ public record AvailabilityRuleDTO(@JsonProperty("type") AvailabilityRuleType typ
 
     public static AvailabilityRuleDTO fromWeekly(AvailabilityRule.WeeklyAvailabilityRule rule) {
         return new AvailabilityRuleDTO(AvailabilityRuleType.WEEKLY, Optional.of(DayOfWeekUtil.toAbbreviation(rule.dayOfWeek())),
-            rule.start().toString(), rule.end().toString());
+            rule.start().toString(), rule.end().toString(), rule.timeZone().map(ZoneId::getId));
     }
 
     public static AvailabilityRuleDTO fromFixed(AvailabilityRule.FixedAvailabilityRule rule) {
         return new AvailabilityRuleDTO(AvailabilityRuleType.FIXED, NO_DAY_OF_WEEK,
             rule.start().toLocalDateTime().format(LOCAL_DATE_TIME_FORMAT),
-            rule.end().toLocalDateTime().format(LOCAL_DATE_TIME_FORMAT));
+            rule.end().toLocalDateTime().format(LOCAL_DATE_TIME_FORMAT),
+            Optional.of(rule.start().getZone().getId()));
     }
 
-    public AvailabilityRule toAvailabilityRule(ZoneId timeZone) {
+    public AvailabilityRule toAvailabilityRule(ZoneId defaultTimeZone) {
         Preconditions.checkArgument(!Objects.isNull(type), "'type' is required in availability rule");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(start), "'start' is required in availability rule");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(end), "'end' is required in availability rule");
+        ZoneId effectiveTimeZone = resolveTimeZone(defaultTimeZone);
         return switch (type) {
             case WEEKLY -> {
                 DayOfWeek dayOfWeekObject = getDayOfWeek();
                 try {
-                    yield new AvailabilityRule.WeeklyAvailabilityRule(dayOfWeekObject, LocalTime.parse(start), LocalTime.parse(end), timeZone);
+                    yield new AvailabilityRule.WeeklyAvailabilityRule(dayOfWeekObject, LocalTime.parse(start), LocalTime.parse(end), effectiveTimeZone);
                 } catch (DateTimeParseException e) {
                     throw new IllegalArgumentException("Invalid 'start' or 'end' time format for weekly rule, expected HH:mm", e);
                 }
             }
             case FIXED -> {
                 try {
-                    ZonedDateTime startDateTime = LocalDateTime.parse(start).atZone(timeZone);
-                    ZonedDateTime endDateTime = LocalDateTime.parse(end).atZone(timeZone);
+                    ZonedDateTime startDateTime = LocalDateTime.parse(start).atZone(effectiveTimeZone);
+                    ZonedDateTime endDateTime = LocalDateTime.parse(end).atZone(effectiveTimeZone);
                     if (startDateTime.isAfter(endDateTime) || startDateTime.isEqual(endDateTime)) {
                         throw new IllegalArgumentException("'start' must be before 'end' for fixed rule");
                     }
@@ -90,6 +94,16 @@ public record AvailabilityRuleDTO(@JsonProperty("type") AvailabilityRuleType typ
                 }
             }
         };
+    }
+
+    private ZoneId resolveTimeZone(ZoneId defaultTimeZone) {
+        return timeZone.map(tz -> {
+            try {
+                return ZoneId.of(tz);
+            } catch (DateTimeException e) {
+                throw new IllegalArgumentException("Invalid 'timeZone' format: " + tz, e);
+            }
+        }).orElse(defaultTimeZone);
     }
 
     private DayOfWeek getDayOfWeek() {

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -1,14 +1,15 @@
 # Booking Link API
 
-This document describes the Booking Link endpoints for managing user booking links.
+This document describes the Booking Link endpoints for managing user booking links (authenticated users) and using booking links to book events (public users).
 
 ---
 
 ## Overview
 
-A booking link allows an authenticated user to expose availability slots for scheduling.
+Booking link API allows an authenticated user to expose availability slots for scheduling.
 Each booking link is identified by a UUID public ID, scoped to a calendar, and can define
-availability rules (weekly recurring or fixed date ranges).
+availability rules (weekly recurring or fixed date ranges). 
+Public users can use booking links to book events.
 
 ---
 
@@ -22,29 +23,28 @@ availability rules (weekly recurring or fixed date ranges).
 | `calendarUrl`       | string           | Calendar URI in the form `/calendars/{baseId}/{calendarId}`                 |
 | `durationMinutes`   | integer          | Duration of each bookable slot in minutes (must be positive)                |
 | `active`            | boolean          | Whether the booking link is active                                          |
-| `timeZone`          | string           | IANA timezone used for availability rules (e.g. `Asia/Ho_Chi_Minh`, `UTC`) |
 | `availabilityRules` | array (optional) | List of availability rule objects (weekly or fixed)                         |
 
 ### Availability rule object
 
 **Weekly rule** — repeats on a given day of the week:
 
-| Field       | Type   | Description                                         |
-|-------------|--------|-----------------------------------------------------|
-| `type`      | string | `"weekly"`                                          |
+| Field       | Type   | Description                                                                |
+|-------------|--------|----------------------------------------------------------------------------|
+| `type`      | string | `"weekly"`                                                                 |
 | `dayOfWeek` | string | Three-letter abbreviation: `MON`, `TUE`, `WED`, `THU`, `FRI`, `SAT`, `SUN` |
-| `start`     | string | Start time in `HH:mm` format                        |
-| `end`       | string | End time in `HH:mm` format                          |
+| `start`     | string | Start time in `HH:mm` format                                               |
+| `end`       | string | End time in `HH:mm` format                                                 |
+| `timeZone`  | string | IANA timezone for this rule (e.g. `Asia/Ho_Chi_Minh`, `UTC`). Default to the timezone setting of the user, then to the default configured timezone then UTC if omitted. |
 
 **Fixed rule** — a one-time date range:
 
-| Field   | Type   | Description                                          |
-|---------|--------|------------------------------------------------------|
-| `type`  | string | `"fixed"`                                            |
-| `start` | string | Start date-time in `yyyy-MM-ddTHH:mm:ss` format      |
-| `end`   | string | End date-time in `yyyy-MM-ddTHH:mm:ss` format        |
-
-The `timeZone` field at the booking link level applies to all availability rules.
+| Field      | Type   | Description                                         |
+|------------|--------|-----------------------------------------------------|
+| `type`     | string | `"fixed"`                                           |
+| `start`    | string | Start date-time in `yyyy-MM-ddTHH:mm:ss` format     |
+| `end`      | string | End date-time in `yyyy-MM-ddTHH:mm:ss` format       |
+| `timeZone` | string | IANA timezone used to interpret `start` and `end`. Default to the timezone setting of the user, then to the default configured timezone then UTC if omitted. |
 
 ---
 
@@ -56,13 +56,12 @@ Create a new booking link for the authenticated user.
 
 **Request body**
 
-| Field               | Required | Description                                                                                                                                                               |
-|---------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `calendarUrl`       | yes      | Calendar URI (must be accessible by the user)                                                                                                                             |
-| `durationMinutes`   | yes      | Slot duration in minutes, must be positive                                                                                                                                |
-| `active`            | yes      | Whether the booking link is active                                                                                                                                        |
-| `timeZone`          | no       | Default to the timezone setting of the user, then to the default configured timezone then UTC if omitted. Cannot be provided when `availabilityRules` is absent or empty. |
-| `availabilityRules` | no       | List of availability rules. Default to the business hours setting of the user, then to the default configured business hours when omitted.                                |
+| Field               | Required | Description                                                                                                                                              |
+|---------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `calendarUrl`       | yes      | Calendar URI (must be accessible by the user)                                                                                                            |
+| `durationMinutes`   | yes      | Slot duration in minutes, must be positive                                                                                                               |
+| `active`            | yes      | Whether the booking link is active                                                                                                                       |
+| `availabilityRules` | no       | List of availability rules. Defaults to business hours from user settings when omitted. Each rule may specify its own `timeZone` (see availability rule object above). |
 
 **Sample request**
 ```
@@ -74,11 +73,10 @@ Content-Type: application/json
     "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
     "durationMinutes": 30,
     "active": true,
-    "timeZone": "Asia/Ho_Chi_Minh",
     "availabilityRules": [
-        { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00" },
-        { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00" },
-        { "type": "fixed", "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00" }
+        { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Asia/Ho_Chi_Minh" },
+        { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "timeZone": "Europe/London" },
+        { "type": "fixed", "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00", "timeZone": "UTC" }
     ]
 }
 ```
@@ -97,7 +95,7 @@ Content-Type: application/json
 
 | Status | Cause                                          |
 |--------|------------------------------------------------|
-| 400    | Missing or invalid field, unknown rule type, calendar not found or inaccessible, `timeZone` provided without non-empty `availabilityRules` |
+| 400    | Missing or invalid field, unknown rule type, invalid `timeZone`, calendar not found or inaccessible |
 | 401    | Unauthenticated                                |
 
 ---
@@ -122,11 +120,10 @@ Content-Type: application/json
     "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
     "durationMinutes": 30,
     "active": true,
-    "timeZone": "Asia/Ho_Chi_Minh",
     "availabilityRules": [
-        { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00" },
-        { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00" },
-        { "type": "fixed", "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00" }
+        { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Asia/Ho_Chi_Minh" },
+        { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "timeZone": "Europe/London" },
+        { "type": "fixed", "start": "2026-01-26T02:00:00", "end": "2026-01-30T02:00:00", "timeZone": "UTC" }
     ]
 }
 ```
@@ -152,13 +149,12 @@ absent fields are left unchanged. At least one field must be provided.
 
 All fields are optional. Include only the fields to update.
 
-| Field               | Description                                                           |
-|---------------------|-----------------------------------------------------------------------|
-| `calendarUrl`       | New calendar URI                                                      |
-| `durationMinutes`   | New slot duration in minutes, must be positive                        |
-| `active`            | New active state                                                      |
-| `timeZone`          | Timezone applied when parsing updated availability rules              |
-| `availabilityRules` | Replaces all existing rules. Set to `null` to remove all rules        |
+| Field               | Description                                                                                                      |
+|---------------------|------------------------------------------------------------------------------------------------------------------|
+| `calendarUrl`       | New calendar URI                                                                                                 |
+| `durationMinutes`   | New slot duration in minutes, must be positive                                                                   |
+| `active`            | New active state                                                                                                 |
+| `availabilityRules` | Replaces all existing rules. Set to `null` to remove all rules. Each rule may specify its own `timeZone`. |
 
 **Sample request — update duration and deactivate**
 ```
@@ -179,9 +175,8 @@ Authorization: Bearer <token>
 Content-Type: application/json
 
 {
-    "timeZone": "UTC",
     "availabilityRules": [
-        { "type": "weekly", "dayOfWeek": "FRI", "start": "14:00", "end": "18:00" }
+        { "type": "weekly", "dayOfWeek": "FRI", "start": "14:00", "end": "18:00", "timeZone": "UTC" }
     ]
 }
 ```
@@ -206,7 +201,7 @@ HTTP/1.1 204 No Content
 
 | Status | Cause                                                             |
 |--------|-------------------------------------------------------------------|
-| 400    | No field provided, invalid value, calendar not found or inaccessible |
+| 400    | No field provided, invalid value, invalid `timeZone`, calendar not found or inaccessible |
 | 401    | Unauthenticated                                                   |
 | 404    | Booking link not found or belongs to another user                 |
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Timezone configuration for booking links is now specified within individual availability rules rather than at the top level of the request or response.

* **Documentation**
  * Updated API documentation with examples reflecting the new per-rule timezone structure for both weekly and fixed availability rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->