### PR TITLE
ISSUE-655 [Async Scheduling] – API checks event expiration before publishing email notifications

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarEventUtils.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarEventUtils.java
@@ -1,0 +1,134 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.linagora.calendar.storage.event.EventParseUtils;
+
+import net.fortuna.ical4j.model.Property;
+import net.fortuna.ical4j.model.Recur;
+import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.ExDate;
+import net.fortuna.ical4j.model.property.RDate;
+import net.fortuna.ical4j.model.property.RRule;
+
+public class CalendarEventUtils {
+
+    public static boolean vEventExpired(VEvent vevent, Clock clock) {
+        Optional<ZonedDateTime> startDateTime = vevent.getProperty(Property.DTSTART)
+            .flatMap(EventParseUtils::parseTime);
+        if (startDateTime.isEmpty()) {
+            return false;
+        }
+
+        Instant now = clock.instant();
+        if (hasNoRecurrence(vevent)) {
+            return startDateTime.get().toInstant().isBefore(now);
+        }
+
+        return recurrenceExpired(vevent, startDateTime.get(), now);
+    }
+
+    private static boolean recurrenceExpired(VEvent vevent, ZonedDateTime startDateTime, Instant now) {
+        Set<Instant> excludedDates = extractExcludedDates(vevent);
+        boolean hasUpcomingFromRRule = hasUpcomingFromRRule(vevent, startDateTime, excludedDates, now);
+        boolean hasUpcomingFromRDate = hasUpcomingRDate(vevent, excludedDates, now);
+        return !hasUpcomingFromRRule && !hasUpcomingFromRDate;
+    }
+
+    private static boolean hasUpcomingFromRRule(VEvent vevent, ZonedDateTime startDateTime, Set<Instant> excludedDates, Instant now) {
+        return extractRecur(vevent)
+            .map(recur -> isInfinite(recur) || hasUpcomingOccurrenceFromRRule(startDateTime, recur, excludedDates, now))
+            .orElseGet(() -> !startDateTime.toInstant().isBefore(now));
+    }
+
+    private static boolean hasUpcomingRDate(VEvent vevent, Set<Instant> excludedDates, Instant now) {
+        return vevent.getProperties(Property.RDATE).stream()
+            .filter(RDate.class::isInstance)
+            .map(RDate.class::cast)
+            .flatMap(rDate -> ((List<Temporal>) rDate.getDates()).stream())
+            .flatMap(date -> toInstant(date).stream())
+            .anyMatch(instant -> !excludedDates.contains(instant) && !instant.isBefore(now));
+    }
+
+    private static Optional<Recur<Temporal>> extractRecur(VEvent vEvent) {
+        return vEvent.getProperty(Property.RRULE)
+            .filter(RRule.class::isInstance)
+            .map(RRule.class::cast)
+            .map(RRule::getRecur)
+            .map(recur -> (Recur<Temporal>) recur);
+    }
+
+    private static boolean hasNoRecurrence(VEvent vevent) {
+        return vevent.getProperty(Property.RRULE).isEmpty() && vevent.getProperty(Property.RDATE).isEmpty();
+    }
+
+    private static boolean isInfinite(Recur<Temporal> recur) {
+        return recur.getUntil() == null && recur.getCount() <= 0;
+    }
+
+    private static boolean hasUpcomingOccurrenceFromRRule(ZonedDateTime startDateTime,
+                                                          Recur<Temporal> recur,
+                                                          Set<Instant> excludedDates,
+                                                          Instant now) {
+        Temporal current = startDateTime;
+
+        while (true) {
+            Optional<Instant> instantOpt = toInstant(current);
+            if (instantOpt.isPresent()) {
+                Instant instant = instantOpt.get();
+                if (!excludedDates.contains(instant) && !instant.isBefore(now)) {
+                    return true;
+                }
+            }
+
+            Temporal next = recur.getNextDate(startDateTime, current);
+            if (next == null || next.equals(current)) {
+                return false;
+            }
+            current = next;
+        }
+    }
+
+    private static Set<Instant> extractExcludedDates(VEvent vevent) {
+        return vevent.getProperties(Property.EXDATE).stream()
+            .map(ExDate.class::cast)
+            .flatMap(exDate -> ((List<Temporal>) exDate.getDates()).stream()
+                .flatMap(date -> toInstant(date).stream()))
+            .collect(Collectors.toSet());
+    }
+
+    private static Optional<Instant> toInstant(Temporal temporal) {
+        if (temporal instanceof LocalDate localDate) {
+            return Optional.of(localDate.atStartOfDay(ZoneOffset.UTC).toInstant());
+        }
+        return EventParseUtils.temporalToZonedDateTime(temporal)
+            .map(ZonedDateTime::toInstant);
+    }
+}

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarEventUtilsTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarEventUtilsTest.java
@@ -1,0 +1,302 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.Test;
+
+import com.linagora.calendar.api.CalendarUtil;
+
+import net.fortuna.ical4j.model.Component;
+import net.fortuna.ical4j.model.component.VEvent;
+
+class CalendarEventUtilsTest {
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void shouldBeExpiredWhenDtStartIsInPast() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:past-single@test
+            DTSTART:20000101T100000Z
+            DTEND:20000101T110000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isTrue();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenDtStartIsInFuture() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:future-single@test
+            DTSTART:29990101T100000Z
+            DTEND:29990101T110000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    @Test
+    void shouldBeExpiredEvenWhenDtEndAvailable() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:past-with-dtend@test
+            DTSTART:20251230T100000Z
+            DTEND:20260120T100000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isTrue();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenRRuleIsInfinite() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:infinite-recurring@test
+            DTSTART:20000101T100000Z
+            RRULE:FREQ=DAILY
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    @Test
+    void shouldBeExpiredWhenRRuleWithCountAndAllOccurrencesInPast() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-count-all-past@test
+            DTSTART:20251220T100000Z
+            RRULE:FREQ=DAILY;COUNT=3
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isTrue();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenRRuleWithCountAndAllOccurrencesInFuture() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-count-all-future@test
+            DTSTART:20260110T100000Z
+            RRULE:FREQ=DAILY;COUNT=3
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenRRuleWithCountAndOneOccurrenceInFuture() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-count-one-future@test
+            DTSTART:20251230T100000Z
+            RRULE:FREQ=DAILY;COUNT=3
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenOnlyRDateHasFutureOccurrence() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rdate-only@test
+            DTSTART:20251220T100000Z
+            RDATE:20260110T100000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    @Test
+    void shouldBeExpiredWhenOnlyRDateOccurrencesAreInPast() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rdate-only-all-past@test
+            DTSTART:20251220T100000Z
+            RDATE:20251221T100000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isTrue();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenRRuleIsPastButHasFutureRDate() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-with-rdate@test
+            DTSTART:20251220T100000Z
+            RRULE:FREQ=DAILY;COUNT=2
+            RDATE:20260110T100000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    @Test
+    void shouldBeExpiredWhenRRuleWithUntilInPast() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-until-past@test
+            DTSTART:20251220T100000Z
+            RRULE:FREQ=DAILY;UNTIL=20251225T100000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isTrue();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenRRuleWithUntilInFuture() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-until-future@test
+            DTSTART:20251220T100000Z
+            RRULE:FREQ=DAILY;UNTIL=20260110T100000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    @Test
+    void shouldBeExpiredWhenAllDayRRuleWithCountAllInPast() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:all-day-rrule-past@test
+            DTSTART;VALUE=DATE:20251220
+            RRULE:FREQ=DAILY;COUNT=3
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isTrue();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenAllDayRRuleWithCountHasFutureOccurrence() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:all-day-rrule-future@test
+            DTSTART;VALUE=DATE:20251231
+            RRULE:FREQ=DAILY;COUNT=3
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    @Test
+    void shouldBeExpiredWhenRRuleHasOnlyPastRDate() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-rdate-only-past@test
+            DTSTART:20251220T100000Z
+            RRULE:FREQ=DAILY;COUNT=2
+            RDATE:20251222T100000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isTrue();
+    }
+
+    @Test
+    void shouldBeExpiredWhenFutureRRuleOccurrenceIsExcludedByExDate() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-future-excluded@test
+            DTSTART:20251230T100000Z
+            RRULE:FREQ=DAILY;COUNT=3
+            EXDATE:20260101T100000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isTrue();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenRRuleIsInfiniteEvenIfRDateIsPast() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-infinite-rdate-past@test
+            DTSTART:20251220T100000Z
+            RRULE:FREQ=WEEKLY
+            RDATE:20251222T100000Z
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    @Test
+    void shouldBeExpiredWhenRRuleValueDoesNotProduceFutureOccurrence() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:rrule-invalid@test
+            DTSTART:20251220T100000Z
+            RRULE:THIS-IS-NOT-A-VALID-RRULE
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isTrue();
+    }
+
+    @Test
+    void shouldNotBeExpiredWhenDtStartMissing() {
+        VEvent vEvent = parseSingleVEvent("""
+            BEGIN:VEVENT
+            UID:no-dtstart@test
+            RRULE:FREQ=DAILY;COUNT=2
+            END:VEVENT
+            """);
+
+        assertThat(CalendarEventUtils.vEventExpired(vEvent, TEST_CLOCK)).isFalse();
+    }
+
+    private VEvent parseSingleVEvent(String vEventIcs) {
+        String calendarIcs = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//CalendarEventUtilsTest//EN
+            %s
+            END:VCALENDAR
+            """.formatted(vEventIcs);
+
+        return CalendarUtil.parseIcs(calendarIcs).getComponents().stream()
+            .filter(component -> Component.VEVENT.equals(component.getName()))
+            .map(VEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+    }
+}


### PR DESCRIPTION
The API is not yet included in the POC PR.
It is similar to the API [\ESN\CalDAV\Schedule\IMipPlugin::testIfEventIsExpired](https://github.com/linagora/esn-sabre/blob/31dad9e189cd614ddded64a83c49b4d1c291a3c3/lib/CalDAV/Schedule/IMipPlugin.php#L160) in esn-sabre.

Its purpose is to determine whether a VEVENT has already expired before publishing the email notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event expiration detection that evaluates calendar events as expired or active based on start dates, recurrence rules, and excluded dates.

* **Tests**
  * Added comprehensive test suite validating event expiration across various scenarios including all-day events, recurring patterns, and date exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->