### PR TITLE
ISSUE-655 fix(itip): filter blank/null recipients during local delivery deserialize

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
@@ -42,8 +42,6 @@ import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.name.Named;
 import com.linagora.calendar.api.CalendarUtil;
 import com.linagora.calendar.dav.CalDavClient;
@@ -88,8 +86,6 @@ public class ItipLocalDeliveryConsumer implements Closeable, Startable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ItipLocalDeliveryConsumer.class);
     private static final boolean REQUEUE_ON_NACK = true;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
-
     private final ReceiverProvider receiverProvider;
     private final Sender sender;
     private final CalDavClient calDavClient;
@@ -170,7 +166,7 @@ public class ItipLocalDeliveryConsumer implements Closeable, Startable {
     }
 
     private Mono<Void> consumeMessage(AcknowledgableDelivery ackDelivery) {
-        return Mono.fromCallable(() -> OBJECT_MAPPER.readValue(ackDelivery.getBody(), ItipLocalDeliveryDTO.class))
+        return Mono.fromCallable(() -> ItipLocalDeliveryDTO.deserialize(ackDelivery.getBody()))
             .flatMap(dto -> {
                 if (dto.recipients().size() > 1) {
                     return fanOut(dto);
@@ -195,7 +191,7 @@ public class ItipLocalDeliveryConsumer implements Closeable, Startable {
         List<OutboundMessage> outboundMessages = dto.recipients().stream()
             .map(recipient -> {
                 try {
-                    byte[] payload = OBJECT_MAPPER.writeValueAsBytes(dto.withSingleRecipient(recipient));
+                    byte[] payload = ItipLocalDeliveryDTO.serialize(dto.withSingleRecipient(recipient));
                     return new OutboundMessage(EXCHANGE_NAME, EMPTY_ROUTING_KEY, payload);
                 } catch (Exception e) {
                     throw new RuntimeException("Failed to serialize fan-out message for recipient " + recipient, e);

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
@@ -79,20 +79,21 @@ public record ItipLocalDeliveryDTO(
                 p.skipChildren();
                 return List.of();
             }
+
             List<String> recipients = new ArrayList<>();
-            while (p.nextToken() != JsonToken.END_ARRAY) {
-                if (p.currentToken() == JsonToken.VALUE_STRING) {
-                    String value = p.getValueAsString();
-                    // skip null or blank entries
-                    if (value != null) {
-                        String trimmed = value.trim();
-                        if (!trimmed.isEmpty()) {
-                            recipients.add(trimmed);
-                        }
-                    }
-                } else {
+
+            JsonToken token;
+            while ((token = p.nextToken()) != JsonToken.END_ARRAY) {
+                if (token != JsonToken.VALUE_STRING) {
                     p.skipChildren();
+                    continue;
                 }
+
+                String recipient = StringUtils.trimToNull(p.getValueAsString());
+                if (recipient == null) {
+                    continue;
+                }
+                recipients.add(recipient);
             }
             return List.copyOf(recipients);
         }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
@@ -75,14 +75,23 @@ public record ItipLocalDeliveryDTO(
     private static class RecipientListDeserializer extends JsonDeserializer<List<String>> {
         @Override
         public List<String> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (!p.isExpectedStartArrayToken()) {
+                p.skipChildren();
+                return List.of();
+            }
             List<String> recipients = new ArrayList<>();
             while (p.nextToken() != JsonToken.END_ARRAY) {
                 if (p.currentToken() == JsonToken.VALUE_STRING) {
                     String value = p.getValueAsString();
                     // skip null or blank entries
-                    if (value != null && !value.isBlank()) {
-                        recipients.add(value);
+                    if (value != null) {
+                        String trimmed = value.trim();
+                        if (!trimmed.isEmpty()) {
+                            recipients.add(trimmed);
+                        }
                     }
+                } else {
+                    p.skipChildren();
                 }
             }
             return List.copyOf(recipients);

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
@@ -18,10 +18,19 @@
 
 package com.linagora.calendar.amqp;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 /**
  * AMQP message payload for the {@code calendar:itip:localDelivery} exchange.
@@ -38,7 +47,43 @@ public record ItipLocalDeliveryDTO(
     @JsonProperty("message") String message,
     @JsonProperty("oldMessage") Optional<String> oldMessage,
     @JsonProperty("hasChange") boolean hasChange,
+    @JsonDeserialize(using = RecipientListDeserializer.class)
     @JsonProperty("recipients") List<String> recipients) {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
+
+    public static byte[] serialize(ItipLocalDeliveryDTO dto) {
+        try {
+            return OBJECT_MAPPER.writeValueAsBytes(dto);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize ItipLocalDeliveryDTO for uid " + dto.uid(), e);
+        }
+    }
+
+    public static ItipLocalDeliveryDTO deserialize(byte[] payload) {
+        try {
+            return OBJECT_MAPPER.readValue(payload, ItipLocalDeliveryDTO.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to deserialize ItipLocalDeliveryDTO: " + new String(payload), e);
+        }
+    }
+
+    private static class RecipientListDeserializer extends JsonDeserializer<List<String>> {
+        @Override
+        public List<String> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            List<String> recipients = new ArrayList<>();
+            while (p.nextToken() != JsonToken.END_ARRAY) {
+                if (p.currentToken() == JsonToken.VALUE_STRING) {
+                    String value = p.getValueAsString();
+                    // skip null or blank entries
+                    if (value != null && !value.isBlank()) {
+                        recipients.add(value);
+                    }
+                }
+            }
+            return List.copyOf(recipients);
+        }
+    }
 
     /** Returns a copy of this DTO with a single recipient (used during fan-out). */
     public ItipLocalDeliveryDTO withSingleRecipient(String recipient) {
@@ -52,7 +97,7 @@ public record ItipLocalDeliveryDTO(
 
     /** Strips the {@code mailto:} prefix from the single recipient address. */
     public String strippedRecipient() {
-        return stripMailto(recipients.get(0));
+        return stripMailto(recipients.getFirst());
     }
 
     private static String stripMailto(String address) {

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
@@ -19,9 +19,12 @@
 package com.linagora.calendar.amqp;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
@@ -64,7 +67,8 @@ public record ItipLocalDeliveryDTO(
         try {
             return OBJECT_MAPPER.readValue(payload, ItipLocalDeliveryDTO.class);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to deserialize ItipLocalDeliveryDTO: " + new String(payload), e);
+            String preview = new String(payload, StandardCharsets.UTF_8);
+            throw new RuntimeException("Failed to deserialize ItipLocalDeliveryDTO: " + StringUtils.left(preview, 512), e);
         }
     }
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTOTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTOTest.java
@@ -1,0 +1,104 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class ItipLocalDeliveryDTOTest {
+
+    @Test
+    // This payload can appear when delete the event has no organizer field.
+    void deserializeShouldFilterBlankRecipients() {
+        byte[] payload = """
+            {
+                "sender": "mailto:user_2186a080-8f20-40f7-a557-6f51f6845662@open-paas.org",
+                "method": "REPLY",
+                "uid": "47d90176-b477-4fe1-91b3-a36ec0cfc67b",
+                "message": "BEGIN:VCALENDAR",
+                "hasChange": true,
+                "recipients": [
+                    ""
+                ],
+                "calendarId": "69d74abb8f3e5c321a999c75"
+            }
+            """.getBytes(StandardCharsets.UTF_8);
+
+        ItipLocalDeliveryDTO actual = ItipLocalDeliveryDTO.deserialize(payload);
+        assertThat(actual.recipients())
+            .hasSize(0);
+    }
+
+    @Test
+    void deserializeSerializedPayloadShouldReturnOriginalValue() {
+        ItipLocalDeliveryDTO expected = new ItipLocalDeliveryDTO(
+            "mailto:sender@example.com",
+            "REQUEST",
+            "uid-1",
+            "calendar-1",
+            "MSG",
+            Optional.of("OLD_MSG"),
+            true,
+            List.of("mailto:alice@example.com"));
+
+        byte[] payload = ItipLocalDeliveryDTO.serialize(expected);
+
+        ItipLocalDeliveryDTO actual = ItipLocalDeliveryDTO.deserialize(payload);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void deserializeShouldSucceedWhenAllFieldsArePresent() {
+        byte[] payload = """
+            {
+                "sender": "mailto:sender@example.com",
+                "method": "REQUEST",
+                "uid": "uid-123",
+                "calendarId": "calendar-123",
+                "message": "BEGIN:VCALENDAR",
+                "oldMessage": "BEGIN:VCALENDAR:OLD",
+                "hasChange": true,
+                "recipients": [
+                    "mailto:alice@example.com",
+                    "mailto:bob@example.com"
+                ]
+            }
+            """.getBytes(StandardCharsets.UTF_8);
+
+        ItipLocalDeliveryDTO actual = ItipLocalDeliveryDTO.deserialize(payload);
+
+        ItipLocalDeliveryDTO expected = new ItipLocalDeliveryDTO(
+            "mailto:sender@example.com",
+            "REQUEST",
+            "uid-123",
+            "calendar-123",
+            "BEGIN:VCALENDAR",
+            Optional.of("BEGIN:VCALENDAR:OLD"),
+            true,
+            List.of("mailto:alice@example.com", "mailto:bob@example.com"));
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Fix Exception
```
java.lang.IllegalArgumentException: username should not be null or empty after being trimmed
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
	at org.apache.james.core.Username.of(Username.java:36)
	at com.linagora.calendar.amqp.ItipLocalDeliveryConsumer.processSingleRecipient(ItipLocalDeliveryConsumer.java:215)
	at com.linagora.calendar.amqp.ItipLocalDeliveryConsumer.lambda$consumeMessage$3(ItipLocalDeliveryConsumer.java:179)
```

**Root Cause**
This happens when Bob deletes an event that has no `ORGANIZER` field.
In this case, esn-sabre can publish an iTIP localDelivery payload like:
```json
{
  "sender": "mailto:user_2186a080-8f20-40f7-a557-6f51f6845662@open-paas.org",
  "method": "REPLY",
  "uid": "47d90176-b477-4fe1-91b3-a36ec0cfc67b",
  "message": "BEGIN:VCALENDAR...",
  "hasChange": true,
  "recipients": [""],
  "calendarId": "69d74abb8f3e5c321a999c75"
}

```
`recipients` contains a blank value, which later leads to invalid username creation.

**Fix**
Updated iTIP DTO deserialization to sanitize recipients:

remove null / blank values
This prevents invalid recipient entries from reaching `processSingleRecipient`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized message byte serialization/deserialization and improved recipient handling to ignore invalid or blank entries.
  * Adjusted single-recipient selection logic for delivery payloads.

* **Tests**
  * Added tests covering serialization round-trips, full-payload deserialization, and recipient-filtering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->