### PR TITLE
ISSUE-703 Add Domain to technical domain validation response

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/CheckTechnicalUserTokenRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/CheckTechnicalUserTokenRouteTest.java
@@ -68,7 +68,7 @@ class CheckTechnicalUserTokenRouteTest {
 
         public String generateToken(Domain domain) {
             return domainDAO.retrieve(domain)
-                .flatMap(openPaaSDomain -> technicalTokenService.generate(openPaaSDomain.id()))
+                .flatMap(technicalTokenService::generate)
                 .map(TechnicalTokenService.JwtToken::value)
                 .block();
         }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/CheckTechnicalUserTokenRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/CheckTechnicalUserTokenRouteTest.java
@@ -141,6 +141,7 @@ class CheckTechnicalUserTokenRouteTest {
                     "__v": 0,
                     "name": "Sabre Dav",
                     "domainId": "%s",
+                    "domain": "%s",
                     "_id": "%s",
                     "data": {
                         "principal": "principals/technicalUser"
@@ -149,7 +150,7 @@ class CheckTechnicalUserTokenRouteTest {
                     "schemaVersion": 1,
                     "type": "dav",
                     "description": "Allows to authenticate on Sabre DAV"
-                }""".formatted(domainId, technicalUserId));
+                }""".formatted(domainId, DOMAIN.asString(), technicalUserId));
     }
 
     @Test
@@ -256,6 +257,7 @@ class CheckTechnicalUserTokenRouteTest {
                     "__v": 0,
                     "name": "Sabre Dav",
                     "domainId": "%s",
+                    "domain": "%s",
                     "_id": "%s",
                     "data": {
                         "principal": "principals/technicalUser"
@@ -264,7 +266,7 @@ class CheckTechnicalUserTokenRouteTest {
                     "schemaVersion": 1,
                     "type": "dav",
                     "description": "Allows to authenticate on Sabre DAV"
-                }""".formatted(domainId1, getTechnicalUserId.apply(domainId1)));
+                }""".formatted(domainId1, DOMAIN.asString(), getTechnicalUserId.apply(domainId1)));
 
         assertThatJson(getResponse.apply(token2))
             .isEqualTo("""
@@ -272,6 +274,7 @@ class CheckTechnicalUserTokenRouteTest {
                     "__v": 0,
                     "name": "Sabre Dav",
                     "domainId": "%s",
+                    "domain": "%s",
                     "_id": "%s",
                     "data": {
                         "principal": "principals/technicalUser"
@@ -280,7 +283,7 @@ class CheckTechnicalUserTokenRouteTest {
                     "schemaVersion": 1,
                     "type": "dav",
                     "description": "Allows to authenticate on Sabre DAV"
-                }""".formatted(domainId2, getTechnicalUserId.apply(domainId2)));
+                }""".formatted(domainId2, otherDomain.asString(), getTechnicalUserId.apply(domainId2)));
     }
 
     @Test

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/ResourceParticipationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/ResourceParticipationRouteTest.java
@@ -73,11 +73,13 @@ import com.linagora.calendar.dav.SabreDavProvisioningService;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
 import com.linagora.calendar.smtp.MockSmtpServerExtension;
+import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.event.EventFields;
 import com.linagora.calendar.storage.event.EventParseUtils;
 import com.linagora.calendar.storage.model.Resource;
 import com.linagora.calendar.storage.model.ResourceId;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
 
 import io.restassured.RestAssured;
 import net.fortuna.ical4j.model.Component;
@@ -135,6 +137,7 @@ public class ResourceParticipationRouteTest {
     private OpenPaaSUser organizer;
     private OpenPaaSUser admin;
     private Resource resource;
+    private OpenPaaSDomain resourceDomain;
 
     private DavTestHelper davTestHelper;
     private TwakeCalendarGuiceServer guiceServer;
@@ -146,6 +149,8 @@ public class ResourceParticipationRouteTest {
         organizer = SABRE_DAV_EXTENSION.newTestUser(Optional.of("organizer"));
         admin = SABRE_DAV_EXTENSION.newTestUser(Optional.of("admin"));
         resource = server.getProbe(ResourceProbe.class).save(admin, "projector toshiba", "projector");
+        MongoDBOpenPaaSDomainDAO domainDAO = new MongoDBOpenPaaSDomainDAO(SABRE_DAV_EXTENSION.dockerSabreDavSetup().getMongoDB());
+        resourceDomain = domainDAO.retrieve(resource.domain()).block();
 
         davTestHelper = new DavTestHelper(SABRE_DAV_EXTENSION.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
         server.getProbe(CalendarDataProbe.class).addUserToRepository(attendee.username(), DEFAULT_USER_PASSWORD);
@@ -274,9 +279,9 @@ public class ResourceParticipationRouteTest {
 
         davTestHelper.upsertCalendar(organizer, generateCalendarData(eventUidA, resourceEmailA), eventUidA);
         Fixture.awaitAtMost.untilAsserted(() ->
-            assertThat(davTestHelper.findFirstEventId(resourceIdA, resource.domain())).isPresent());
+            assertThat(davTestHelper.findFirstEventId(resourceIdA, resourceDomain)).isPresent());
 
-        String eventPathIdA = davTestHelper.findFirstEventId(resourceIdA, resource.domain()).get();
+        String eventPathIdA = davTestHelper.findFirstEventId(resourceIdA, resourceDomain).get();
 
         // Create a second resource B (different from A)
         Resource anotherResource = server.getProbe(ResourceProbe.class)
@@ -531,7 +536,7 @@ public class ResourceParticipationRouteTest {
     private String createEventAndGetEventPathId(ResourceId resourceId, String eventUid) {
         String resourceEmail = Username.fromLocalPartWithDomain(resourceId.value(), TEST_DOMAIN).asString();
         davTestHelper.upsertCalendar(organizer, generateCalendarData(eventUid, resourceEmail), eventUid);
-        Fixture.awaitAtMost.untilAsserted(() -> assertThat(davTestHelper.findFirstEventId(resourceId, resource.domain())).isPresent());
-        return davTestHelper.findFirstEventId(resourceId, resource.domain()).get();
+        Fixture.awaitAtMost.untilAsserted(() -> assertThat(davTestHelper.findFirstEventId(resourceId, resourceDomain)).isPresent());
+        return davTestHelper.findFirstEventId(resourceId, resourceDomain).get();
     }
 }

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
@@ -229,7 +229,7 @@ public class CalendarDelegatedNotificationConsumerTest {
             calendarName, "#123456", "Calendar for testing");
         calDavClient.createNewCalendar(bob.username(), bob.id(), bobCalendar).block();
 
-        calDavClient.patchReadWriteDelegations(domain.id(), new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
+        calDavClient.patchReadWriteDelegations(domain, new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
                 List.of(alice.username()), List.of())
             .block();
 
@@ -258,7 +258,7 @@ public class CalendarDelegatedNotificationConsumerTest {
             calendarName, "#123456", "Calendar for testing");
         calDavClient.createNewCalendar(bob.username(), bob.id(), bobCalendar).block();
 
-        calDavClient.patchReadWriteDelegations(domain.id(), new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
+        calDavClient.patchReadWriteDelegations(domain, new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
                 List.of(alice.username()), List.of())
             .block();
 
@@ -290,7 +290,7 @@ public class CalendarDelegatedNotificationConsumerTest {
             calendarName, "#654321", "Calendar for invalid message test");
         calDavClient.createNewCalendar(bob.username(), bob.id(), bobCalendar).block();
 
-        calDavClient.patchReadWriteDelegations(domain.id(), new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
+        calDavClient.patchReadWriteDelegations(domain, new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
                 List.of(alice.username()), List.of())
             .block();
 
@@ -315,7 +315,7 @@ public class CalendarDelegatedNotificationConsumerTest {
         calDavClient.createNewCalendar(bob.username(), bob.id(), bobCalendar).block();
 
         // Bob delegates the calendar to Alice
-        calDavClient.patchReadWriteDelegations(domain.id(), new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
+        calDavClient.patchReadWriteDelegations(domain, new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
             List.of(alice.username()), List.of()).block();
 
         Thread.sleep(1000);
@@ -354,7 +354,7 @@ public class CalendarDelegatedNotificationConsumerTest {
         ResourceId resourceId = resourceDAO.insert(resourceInsertRequest).block();
 
         if (!administrators.isEmpty()) {
-            calDavClient.grantReadWriteRights(domain.id(), resourceId, administrators.stream()
+            calDavClient.grantReadWriteRights(domain, resourceId, administrators.stream()
                 .map(OpenPaaSUser::username)
                 .toList()).block();
         }

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarListNotificationConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarListNotificationConsumerTest.java
@@ -489,7 +489,7 @@ public class CalendarListNotificationConsumerTest {
         calDavClient.createNewCalendar(owner.username(), owner.id(), newCalendar).block();
 
         CalendarURL ownerCalendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
-        calDavClient.patchReadWriteDelegations(domain.id(), ownerCalendarURL, List.of(delegate.username()), List.of()).block();
+        calDavClient.patchReadWriteDelegations(domain, ownerCalendarURL, List.of(delegate.username()), List.of()).block();
 
         awaitAtMost.untilAsserted(() -> assertThat(eventsReceived)
             .anySatisfy(event -> {
@@ -516,8 +516,8 @@ public class CalendarListNotificationConsumerTest {
         calDavClient.createNewCalendar(owner.username(), owner.id(), newCalendar).block();
 
         CalendarURL ownerCalendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
-        calDavClient.patchReadWriteDelegations(domain.id(), ownerCalendarURL, List.of(delegate.username()), List.of()).block();
-        calDavClient.patchReadWriteDelegations(domain.id(), ownerCalendarURL, List.of(), List.of(delegate.username())).block();
+        calDavClient.patchReadWriteDelegations(domain, ownerCalendarURL, List.of(delegate.username()), List.of()).block();
+        calDavClient.patchReadWriteDelegations(domain, ownerCalendarURL, List.of(), List.of(delegate.username())).block();
 
         awaitAtMost.untilAsserted(() -> assertThat(eventsReceived)
             .anySatisfy(event -> {
@@ -544,7 +544,7 @@ public class CalendarListNotificationConsumerTest {
         calDavClient.createNewCalendar(owner.username(), owner.id(), newCalendar).block();
 
         CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
-        calDavClient.patchReadWriteDelegations(domain.id(), calendarURL, List.of(delegate.username()), List.of()).block();
+        calDavClient.patchReadWriteDelegations(domain, calendarURL, List.of(delegate.username()), List.of()).block();
 
         awaitAtMost.untilAsserted(() -> assertThat(eventsReceived)
             .anySatisfy(event -> {
@@ -570,7 +570,7 @@ public class CalendarListNotificationConsumerTest {
         calDavClient.createNewCalendar(owner.username(), owner.id(), newCalendar).block();
 
         CalendarURL ownerCalendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
-        calDavClient.patchReadWriteDelegations(domain.id(), ownerCalendarURL, List.of(delegate.username()), List.of()).block();
+        calDavClient.patchReadWriteDelegations(domain, ownerCalendarURL, List.of(delegate.username()), List.of()).block();
 
         CalendarURL delegatedCalendarURL = getDelegatedCalendarURL(delegate);
         String payload = """
@@ -611,7 +611,7 @@ public class CalendarListNotificationConsumerTest {
         calDavClient.createNewCalendar(owner.username(), owner.id(), newCalendar).block();
 
         CalendarURL ownerCalendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
-        calDavClient.patchReadWriteDelegations(domain.id(), ownerCalendarURL, List.of(delegate.username()), List.of()).block();
+        calDavClient.patchReadWriteDelegations(domain, ownerCalendarURL, List.of(delegate.username()), List.of()).block();
 
         CalendarURL delegatedCalendarURL = getDelegatedCalendarURL(delegate);
         Queue<CalendarListChangedEvent> eventsReceived = new ConcurrentLinkedQueue<>();
@@ -645,9 +645,9 @@ public class CalendarListNotificationConsumerTest {
 
         CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
         // add right
-        calDavClient.patchReadWriteDelegations(domain.id(), calendarURL, List.of(delegate.username()), List.of()).block();
+        calDavClient.patchReadWriteDelegations(domain, calendarURL, List.of(delegate.username()), List.of()).block();
         // revoke right
-        calDavClient.patchReadWriteDelegations(domain.id(), calendarURL, List.of(), List.of(delegate.username())).block();
+        calDavClient.patchReadWriteDelegations(domain, calendarURL, List.of(), List.of(delegate.username())).block();
 
         awaitAtMost.untilAsserted(() -> assertThat(eventsReceived)
             .anySatisfy(event -> {
@@ -776,18 +776,16 @@ public class CalendarListNotificationConsumerTest {
         }
 
         private ResourceId createResourceViaWebAdmin(OpenPaaSUser creator, String resourceName, List<OpenPaaSUser> administrators) {
-            OpenPaaSId domainId = domainDAO.retrieve(creator.username().getDomainPart().get())
-                .map(OpenPaaSDomain::id)
-                .block();
+            OpenPaaSDomain domain = domainDAO.retrieve(creator.username().getDomainPart().get()).block();
 
             ResourceInsertRequest resourceInsertRequest = new ResourceInsertRequest(administrators.stream()
                 .map(admin -> new ResourceAdministrator(admin.id(), "user"))
                 .toList(),
-                creator.id(), "resource description", domainId, "tv", resourceName);
+                creator.id(), "resource description", domain.id(), "tv", resourceName);
             ResourceId resourceId = resourceDAO.insert(resourceInsertRequest).block();
 
             if (!administrators.isEmpty()) {
-                calDavClient.grantReadWriteRights(domainId, resourceId, administrators.stream()
+                calDavClient.grantReadWriteRights(domain, resourceId, administrators.stream()
                     .map(OpenPaaSUser::username)
                     .toList()).block();
             }
@@ -796,9 +794,7 @@ public class CalendarListNotificationConsumerTest {
         }
 
         private void revokeResourceAdminRightsViaWebAdmin(OpenPaaSUser actor, ResourceId resourceId) {
-            OpenPaaSId domainId = domainDAO.retrieve(actor.username().getDomainPart().get())
-                .map(OpenPaaSDomain::id)
-                .block();
+            OpenPaaSDomain domain = domainDAO.retrieve(actor.username().getDomainPart().get()).block();
 
             List<Username> adminUsernames = resourceDAO.findById(resourceId).block()
                 .administrators().stream()
@@ -808,7 +804,7 @@ public class CalendarListNotificationConsumerTest {
                 .toList();
 
             if (!adminUsernames.isEmpty()) {
-                calDavClient.revokeWriteRights(domainId, resourceId, adminUsernames).block();
+                calDavClient.revokeWriteRights(domain, resourceId, adminUsernames).block();
             }
         }
     }

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
@@ -543,11 +543,11 @@ public class EventReplyEmailConsumerTest {
 
         davTestHelper.upsertCalendar(organizer, icalData, eventUid);
         Fixture.awaitAtMost.untilAsserted(() ->
-            assertThat(davTestHelper.findFirstEventId(resourceId, openPaaSDomain.id()))
+            assertThat(davTestHelper.findFirstEventId(resourceId, openPaaSDomain))
                 .withFailMessage("Event not created for resource: " + resourceId.value())
                 .isPresent());
 
-        String eventPathId = davTestHelper.findFirstEventId(resourceId, openPaaSDomain.id()).get();
+        String eventPathId = davTestHelper.findFirstEventId(resourceId, openPaaSDomain).get();
         calDavEventRepository().updatePartStat(openPaaSDomain, resourceId, eventPathId, PartStat.ACCEPTED).block();
 
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
@@ -286,7 +286,7 @@ public class EventResourceConsumerTest {
             resourceId.value());
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        String resourceEventId = awaitAtMost.until(() -> davTestHelper.findFirstEventId(resourceId, domain.id()), Optional::isPresent).get();
+        String resourceEventId = awaitAtMost.until(() -> davTestHelper.findFirstEventId(resourceId, domain), Optional::isPresent).get();
 
         // Wait for the mail to be received via mock SMTP
         awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
@@ -439,7 +439,7 @@ public class EventResourceConsumerTest {
             resourceId.value());
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        String resourceEventId = awaitAtMost.until(() -> davTestHelper.findFirstEventId(resourceId, domain.id()), Optional::isPresent).get();
+        String resourceEventId = awaitAtMost.until(() -> davTestHelper.findFirstEventId(resourceId, domain), Optional::isPresent).get();
 
         awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
 
@@ -499,7 +499,7 @@ public class EventResourceConsumerTest {
             resourceId.value());
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        String resourceEventId = awaitAtMost.until(() -> davTestHelper.findFirstEventId(resourceId, domain.id()), Optional::isPresent).get();
+        String resourceEventId = awaitAtMost.until(() -> davTestHelper.findFirstEventId(resourceId, domain), Optional::isPresent).get();
 
         awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
 
@@ -565,7 +565,7 @@ public class EventResourceConsumerTest {
             resourceId.value());
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        String resourceEventId = awaitAtMost.until(() -> davTestHelper.findFirstEventId(resourceId, domain.id()), Optional::isPresent).get();
+        String resourceEventId = awaitAtMost.until(() -> davTestHelper.findFirstEventId(resourceId, domain), Optional::isPresent).get();
 
         // Wait for the mail to be received via mock SMTP
         awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
@@ -56,6 +56,7 @@ import com.linagora.calendar.dav.dto.CalendarReportJsonResponse;
 import com.linagora.calendar.dav.dto.CalendarReportXmlResponse;
 import com.linagora.calendar.dav.model.CalendarQuery;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.TechnicalTokenService;
@@ -589,7 +590,7 @@ public class CalDavClient extends DavClient {
             .collect(OBJECT_MAPPER::createArrayNode, ArrayNode::add, ArrayNode::addAll);
     }
 
-    public Mono<Void> patchReadWriteDelegations(OpenPaaSId domainId,
+    public Mono<Void> patchReadWriteDelegations(OpenPaaSDomain domain,
                                                 CalendarURL calendarURL,
                                                 Collection<Username> addOrUpdateAdmins,
                                                 Collection<Username> revokeAdmins) {
@@ -598,7 +599,7 @@ public class CalDavClient extends DavClient {
             return Mono.empty();
         }
 
-        return httpClientWithTechnicalToken(domainId)
+        return httpClientWithTechnicalToken(domain)
             .flatMap(client -> client
                 .headers(headers -> headers.add(HttpHeaderNames.CONTENT_TYPE, JSON_CHARSET_UTF_8)
                     .add(HttpHeaderNames.ACCEPT, DEFAULT_JSON_ACCEPT))
@@ -620,14 +621,14 @@ public class CalDavClient extends DavClient {
                 .then());
     }
 
-    public Mono<Void> grantReadWriteRights(OpenPaaSId domainId, ResourceId resourceId, Collection<Username> administrators) {
+    public Mono<Void> grantReadWriteRights(OpenPaaSDomain domain, ResourceId resourceId, Collection<Username> administrators) {
         CalendarURL calendarURL = CalendarURL.from(resourceId.asOpenPaaSId());
-        return patchReadWriteDelegations(domainId, calendarURL, administrators, List.of());
+        return patchReadWriteDelegations(domain, calendarURL, administrators, List.of());
     }
 
-    public Mono<Void> revokeWriteRights(OpenPaaSId domainId, ResourceId resourceId, List<Username> administrators) {
+    public Mono<Void> revokeWriteRights(OpenPaaSDomain domain, ResourceId resourceId, List<Username> administrators) {
         CalendarURL calendarURL = CalendarURL.from(resourceId.asOpenPaaSId());
-        return patchReadWriteDelegations(domainId, calendarURL, List.of(), administrators);
+        return patchReadWriteDelegations(domain, calendarURL, List.of(), administrators);
     }
 
     public Mono<SyncToken> retrieveSyncToken(Username username, CalendarURL calendarUrl) {

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavEventRepository.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavEventRepository.java
@@ -90,7 +90,7 @@ public class CalDavEventRepository {
             .resolve(eventPathId + ".ics");
         Username resourceUsername = Username.fromLocalPartWithDomain(resourceId.value(), openPaaSDomain.domain());
         AttendeePartStatusUpdatePatch attendeePartStatusUpdatePatch = new AttendeePartStatusUpdatePatch(resourceUsername, partStat);
-        return applyModifierToEvent(client.httpClientWithTechnicalToken(openPaaSDomain.id()),
+        return applyModifierToEvent(client.httpClientWithTechnicalToken(openPaaSDomain),
             calendarEventHref, CalendarEventModifier.of(attendeePartStatusUpdatePatch));
     }
 

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CardDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CardDavClient.java
@@ -42,6 +42,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Streams;
 import com.linagora.calendar.storage.AddressBookURL;
+import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.TechnicalTokenService;
 
@@ -166,25 +167,25 @@ public class CardDavClient extends DavClient {
         };
     }
 
-    public Mono<Void> createDomainMembersAddressBook(OpenPaaSId domainId) {
-        return httpClientWithTechnicalToken(domainId)
-            .flatMap(httpClient -> createDomainMembersAddressBook(httpClient, domainId));
+    public Mono<Void> createDomainMembersAddressBook(OpenPaaSDomain domain) {
+        return httpClientWithTechnicalToken(domain)
+            .flatMap(httpClient -> createDomainMembersAddressBook(httpClient, domain));
     }
 
-    private Mono<Void> createDomainMembersAddressBook(HttpClient authenticatedClient, OpenPaaSId domainId) {
+    private Mono<Void> createDomainMembersAddressBook(HttpClient authenticatedClient, OpenPaaSDomain domain) {
         return authenticatedClient.headers(headers ->
                 headers.add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON)
                     .add(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_JSON))
             .post()
-            .uri("/addressbooks/%s.json".formatted(domainId.value()))
+            .uri("/addressbooks/%s.json".formatted(domain.id().value()))
             .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(CREATE_DOMAIN_MEMBERS_ADDRESS_BOOK_PAYLOAD)))
-            .responseSingle((res, buf) -> handleCreateAddressBookResponse(res, buf, domainId))
+            .responseSingle((res, buf) -> handleCreateAddressBookResponse(res, buf, domain))
             .retryWhen(Retry.fixedDelay(1, Duration.ofMillis(500))
                 .filter(throwable -> throwable instanceof RetryableDavClientException))
             .then();
     }
 
-    private Mono<Void> handleCreateAddressBookResponse(HttpClientResponse response, ByteBufMono byteBufMono, OpenPaaSId domainId) {
+    private Mono<Void> handleCreateAddressBookResponse(HttpClientResponse response, ByteBufMono byteBufMono, OpenPaaSDomain domain) {
         return switch (response.status().code()) {
             case 201 -> Mono.empty();
             case 404 ->
@@ -195,33 +196,33 @@ public class CardDavClient extends DavClient {
                 .filter(serverResponse -> !Strings.CS.contains(serverResponse, "The resource you tried to create already exists"))
                 .switchIfEmpty(Mono.empty())
                 .flatMap(errorBody -> Mono.error(new DavClientException(
-                    "Failed to create `domain-members` address book for domain %s: %s".formatted(domainId.value(), errorBody))));
+                    "Failed to create `domain-members` address book for domain %s: %s".formatted(domain.id().value(), errorBody))));
         };
     }
 
-    public Mono<Void> upsertContactDomainMembers(OpenPaaSId domainId, String vcardUid, byte[] vcardPayload) {
+    public Mono<Void> upsertContactDomainMembers(OpenPaaSDomain domain, String vcardUid, byte[] vcardPayload) {
         Preconditions.checkArgument(StringUtils.isNotEmpty(vcardUid), "vcardUid must not be empty");
         Preconditions.checkArgument(vcardPayload != null && vcardPayload.length > 0, "vcardPayload must not be empty");
 
-        AddressBookURL addressBookURL = new AddressBookURL(domainId, DOMAIN_MEMBERS_ADDRESS_BOOK_ID);
-        return httpClientWithTechnicalToken(domainId)
+        AddressBookURL addressBookURL = new AddressBookURL(domain.id(), DOMAIN_MEMBERS_ADDRESS_BOOK_ID);
+        return httpClientWithTechnicalToken(domain)
             .flatMap(client -> upsertContact(client, addressBookURL, vcardUid, vcardPayload)
                 .onErrorResume(DavClientException.class, exception -> {
                     if (isNotFoundPathResourceError(exception)) {
-                        return createDomainMembersAddressBook(domainId)
+                        return createDomainMembersAddressBook(domain)
                             .then(upsertContact(client, addressBookURL, vcardUid, vcardPayload))
                             .doOnSubscribe(s
-                                -> LOGGER.info("Creating domain members address book for domain {} and retrying to upsert contact", domainId.value()));
+                                -> LOGGER.info("Creating domain members address book for domain {} and retrying to upsert contact", domain.id().value()));
                     }
                     return Mono.error(exception);
                 }));
     }
 
-    public Mono<Void> deleteContactDomainMembers(OpenPaaSId domainId, String vcardUid) {
+    public Mono<Void> deleteContactDomainMembers(OpenPaaSDomain domain, String vcardUid) {
         Preconditions.checkArgument(StringUtils.isNotEmpty(vcardUid), "vcardUid must not be empty");
 
-        AddressBookURL addressBookURL = new AddressBookURL(domainId, DOMAIN_MEMBERS_ADDRESS_BOOK_ID);
-        return httpClientWithTechnicalToken(domainId)
+        AddressBookURL addressBookURL = new AddressBookURL(domain.id(), DOMAIN_MEMBERS_ADDRESS_BOOK_ID);
+        return httpClientWithTechnicalToken(domain)
             .flatMap(client -> client.headers(headers
                     -> headers.add(HttpHeaderNames.ACCEPT, HttpHeaderValues.TEXT_PLAIN))
                 .delete()
@@ -230,7 +231,7 @@ public class CardDavClient extends DavClient {
                     int statusCode = response.status().code();
 
                     if (statusCode == HttpStatus.SC_NO_CONTENT) {
-                        LOGGER.debug("Delete successful for domain {} and vcardUid {}", domainId.value(), vcardUid);
+                        LOGGER.debug("Delete successful for domain {} and vcardUid {}", domain.id().value(), vcardUid);
                         return Mono.empty();
                     }
                     return responseBodyAsString(byteBufMono)
@@ -238,18 +239,18 @@ public class CardDavClient extends DavClient {
                         .switchIfEmpty(Mono.empty())
                         .flatMap(bodyStr -> Mono.error(new DavClientException(String.format(
                             "Unexpected status code: %d when deleting contact for domain %s and vcardUid: %s\n%s",
-                            statusCode, domainId.value(), vcardUid, bodyStr))));
+                            statusCode, domain.id().value(), vcardUid, bodyStr))));
                 }));
     }
 
-    public Mono<byte[]> listContactDomainMembers(OpenPaaSId domainId) {
-        return tryListContactDomainMembers(domainId)
+    public Mono<byte[]> listContactDomainMembers(OpenPaaSDomain domain) {
+        return tryListContactDomainMembers(domain)
             .onErrorResume(DavClientException.class, exception -> {
                 if (isNotFoundPathResourceError(exception)) {
-                    return createDomainMembersAddressBook(domainId)
-                        .then(tryListContactDomainMembers(domainId))
+                    return createDomainMembersAddressBook(domain)
+                        .then(tryListContactDomainMembers(domain))
                         .doOnSubscribe(s
-                            -> LOGGER.info("Creating domain members address book for domain {} and retrying to list contacts", domainId.value()));
+                            -> LOGGER.info("Creating domain members address book for domain {} and retrying to list contacts", domain.id().value()));
                 }
                 return Mono.error(exception);
             });
@@ -261,9 +262,9 @@ public class CardDavClient extends DavClient {
             || Strings.CI.contains(ex.getMessage(), "Could not find node at path: addressbooks/"));
     }
 
-    private Mono<byte[]> tryListContactDomainMembers(OpenPaaSId domainId) {
-        AddressBookURL url = new AddressBookURL(domainId, DOMAIN_MEMBERS_ADDRESS_BOOK_ID);
-        return httpClientWithTechnicalToken(domainId)
+    private Mono<byte[]> tryListContactDomainMembers(OpenPaaSDomain domain) {
+        AddressBookURL url = new AddressBookURL(domain.id(), DOMAIN_MEMBERS_ADDRESS_BOOK_ID);
+        return httpClientWithTechnicalToken(domain)
             .flatMap(authenticatedClient -> exportContactAsVcard(authenticatedClient, url));
     }
 

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/DavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/DavClient.java
@@ -25,7 +25,7 @@ import javax.net.ssl.SSLException;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.james.core.Username;
 
-import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.TechnicalTokenService;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -71,8 +71,8 @@ public abstract class DavClient {
             headers.add(HttpHeaderNames.AUTHORIZATION, authenticationToken(username.asString())));
     }
 
-    protected Mono<HttpClient> httpClientWithTechnicalToken(OpenPaaSId domainId) {
-        return technicalTokenService.generate(domainId)
+    protected Mono<HttpClient> httpClientWithTechnicalToken(OpenPaaSDomain domain) {
+        return technicalTokenService.generate(domain)
             .map(token -> client.headers(headers -> headers
                 .add(TWAKE_CALENDAR_TOKEN_HEADER_NAME, token.value())));
     }

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
@@ -1332,12 +1332,11 @@ public class CalDavClientTest {
 
         testee.createNewCalendar(owner.username(), owner.id(), newCalendar).block();
 
-        OpenPaaSId domainId = new MongoDBOpenPaaSDomainDAO(sabreDavExtension.dockerSabreDavSetup().getMongoDB())
-            .retrieve(owner.username().getDomainPart().get())
-            .map(OpenPaaSDomain::id).block();
+        OpenPaaSDomain domain = new MongoDBOpenPaaSDomainDAO(sabreDavExtension.dockerSabreDavSetup().getMongoDB())
+            .retrieve(owner.username().getDomainPart().get()).block();
 
         CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(newCalendar.id()));
-        testee.patchReadWriteDelegations(domainId, calendarURL, List.of(delegate.username()), List.of()).block();
+        testee.patchReadWriteDelegations(domain, calendarURL, List.of(delegate.username()), List.of()).block();
 
         List<CalendarURL> delegateCalendars = testee.findUserCalendars(delegate.username(), delegate.id()).collectList().block();
 

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavEventRepositoryTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavEventRepositoryTest.java
@@ -399,11 +399,11 @@ public class CalDavEventRepositoryTest {
 
         // Wait until resource calendar sees the event
         Fixture.awaitAtMost.untilAsserted(() ->
-            assertThat(davTestHelper.findFirstEventId(resourceId, domain.id()))
+            assertThat(davTestHelper.findFirstEventId(resourceId, domain))
                 .withFailMessage("Event not created for resource: " + resourceId.value())
                 .isPresent());
 
-        String eventPathId = davTestHelper.findFirstEventId(resourceId, domain.id()).get();
+        String eventPathId = davTestHelper.findFirstEventId(resourceId, domain).get();
 
         // When: update participation status of the resource to ACCEPTED
         testee.updatePartStat(domain, resourceId, eventPathId, PartStat.ACCEPTED).block();

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CardDavClientTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CardDavClientTest.java
@@ -169,7 +169,7 @@ public class CardDavClientTest {
     @Test
     void createDomainMembersAddressBookShouldNotThrowWhenCreatedFirstTime() {
         OpenPaaSDomain domain = mongoDBOpenPaaSDomainDAO.add(Domain.of("new-domain" + UUID.randomUUID() + ".tld")).block();
-        assertThatCode(() -> testee.createDomainMembersAddressBook(domain.id()).block())
+        assertThatCode(() -> testee.createDomainMembersAddressBook(domain).block())
             .doesNotThrowAnyException();
     }
 
@@ -177,7 +177,7 @@ public class CardDavClientTest {
     void regularUserShouldSeeDomainMembersAddressBook() {
         OpenPaaSDomain domain = mongoDBOpenPaaSDomainDAO.retrieve(Domain.of(DOMAIN)).block();
 
-        testee.createDomainMembersAddressBook(domain.id()).block();
+        testee.createDomainMembersAddressBook(domain).block();
 
         String addressBooksJson = davTestHelper.listAddressBooks(user, domain.id()).block();
 
@@ -218,7 +218,7 @@ public class CardDavClientTest {
     void createDomainMembersAddressBookShouldNotThrowWhenAlreadyExists() {
         OpenPaaSDomain domain = createNewDomainMemberAddressBook();
 
-        assertThatCode(() -> testee.createDomainMembersAddressBook(domain.id())
+        assertThatCode(() -> testee.createDomainMembersAddressBook(domain)
             .block())
             .doesNotThrowAnyException();
     }
@@ -237,7 +237,7 @@ public class CardDavClientTest {
             END:VCARD
             """.formatted(vcardUid);
 
-        testee.upsertContactDomainMembers(domain.id(), vcardUid, vcard.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, vcardUid, vcard.getBytes(StandardCharsets.UTF_8)).block();
 
         assertThat(listContactDomainMembersAsVcard(domain))
             .containsIgnoringNewLines("""
@@ -261,7 +261,7 @@ public class CardDavClientTest {
             END:VCARD
             """.formatted(vcardUid);
 
-        testee.upsertContactDomainMembers(domain.id(), vcardUid, originalVcard.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, vcardUid, originalVcard.getBytes(StandardCharsets.UTF_8)).block();
 
         String updatedVcard = """
             BEGIN:VCARD
@@ -273,7 +273,7 @@ public class CardDavClientTest {
             END:VCARD
             """.formatted(vcardUid);
 
-        testee.upsertContactDomainMembers(domain.id(), vcardUid, updatedVcard.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, vcardUid, updatedVcard.getBytes(StandardCharsets.UTF_8)).block();
 
         assertThat(listContactDomainMembersAsVcard(domain))
             .containsIgnoringNewLines("""
@@ -311,8 +311,8 @@ public class CardDavClientTest {
             END:VCARD
             """.formatted(vcardUid2);
 
-        testee.upsertContactDomainMembers(domain.id(), vcardUid1, vcard1.getBytes(StandardCharsets.UTF_8)).block();
-        testee.upsertContactDomainMembers(domain.id(), vcardUid2, vcard2.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, vcardUid1, vcard1.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, vcardUid2, vcard2.getBytes(StandardCharsets.UTF_8)).block();
 
         assertThat(listContactDomainMembersAsVcard(domain))
             .containsIgnoringNewLines("""
@@ -341,7 +341,7 @@ public class CardDavClientTest {
             EMAIL:alice@example.com
             END:VCARD
             """.formatted(uidA);
-        testee.upsertContactDomainMembers(domain.id(), uidA, vcardA.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, uidA, vcardA.getBytes(StandardCharsets.UTF_8)).block();
 
         // Insert contact B
         String uidB = UUID.randomUUID().toString();
@@ -354,7 +354,7 @@ public class CardDavClientTest {
             EMAIL:bob@example.com
             END:VCARD
             """.formatted(uidB);
-        testee.upsertContactDomainMembers(domain.id(), uidB, vcardB.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, uidB, vcardB.getBytes(StandardCharsets.UTF_8)).block();
 
         // Update contact A
         String updatedVcardA = """
@@ -366,7 +366,7 @@ public class CardDavClientTest {
             EMAIL:alice.updated@example.com
             END:VCARD
             """.formatted(uidA);
-        testee.upsertContactDomainMembers(domain.id(), uidA, updatedVcardA.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, uidA, updatedVcardA.getBytes(StandardCharsets.UTF_8)).block();
 
         // Assert contact list contains updated A and unchanged B
         assertThat(listContactDomainMembersAsVcard(domain))
@@ -386,7 +386,7 @@ public class CardDavClientTest {
     void upsertContactDomainMembersShouldIsolateContactsBetweenDifferentDomains() {
         OpenPaaSDomain domain = createNewDomainMemberAddressBook();
         OpenPaaSDomain anotherDomain = createNewDomainMemberAddressBook();
-        testee.createDomainMembersAddressBook(anotherDomain.id()).block();
+        testee.createDomainMembersAddressBook(anotherDomain).block();
 
         // Insert contact into domain A
         String uidA = UUID.randomUUID().toString();
@@ -399,7 +399,7 @@ public class CardDavClientTest {
             EMAIL:alice@domain-a.com
             END:VCARD
             """.formatted(uidA);
-        testee.upsertContactDomainMembers(domain.id(), uidA, vcardA.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, uidA, vcardA.getBytes(StandardCharsets.UTF_8)).block();
 
         // Insert contact into domain B
         String uidB = UUID.randomUUID().toString();
@@ -412,7 +412,7 @@ public class CardDavClientTest {
             EMAIL:bob@domain-b.com
             END:VCARD
             """.formatted(uidB);
-        testee.upsertContactDomainMembers(anotherDomain.id(), uidB, vcardB.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(anotherDomain, uidB, vcardB.getBytes(StandardCharsets.UTF_8)).block();
 
         // Assert domain A contains only contact A
         String resultA = listContactDomainMembersAsVcard(domain);
@@ -441,7 +441,7 @@ public class CardDavClientTest {
             END:VCARD
             """.formatted(vcardUid);
 
-        assertThatThrownBy(() -> testee.upsertContactDomainMembers(domain.id(), vcardUid,
+        assertThatThrownBy(() -> testee.upsertContactDomainMembers(domain, vcardUid,
             invalidVcard.getBytes(StandardCharsets.UTF_8)).block())
             .isInstanceOf(DavClientException.class);
     }
@@ -460,7 +460,7 @@ public class CardDavClientTest {
             END:VCARD
             """.formatted(vcardUid);
 
-        testee.upsertContactDomainMembers(domain.id(), vcardUid, vcard.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, vcardUid, vcard.getBytes(StandardCharsets.UTF_8)).block();
 
         // The address book should be created automatically and the contact added
         assertThat(listContactDomainMembersAsVcard(domain))
@@ -473,23 +473,23 @@ public class CardDavClientTest {
     @Test
     void listContactDomainMembersShouldReturnEmptyVcardWhenNoContactsExist() {
         OpenPaaSDomain domain = createNewDomainMemberAddressBook();
-        assertThat(testee.listContactDomainMembers(domain.id()).blockOptional()).isEmpty();
+        assertThat(testee.listContactDomainMembers(domain).blockOptional()).isEmpty();
     }
 
     @Test
     void listContactDomainMembersShouldTriggerCreateDomainMembersAddressBookWhenNotExists() {
         OpenPaaSDomain newDomain = mongoDBOpenPaaSDomainDAO.add(Domain.of("new-domain" + UUID.randomUUID() + ".tld")).block();
 
-        assertThatCode(() -> testee.listContactDomainMembers(newDomain.id()).block())
+        assertThatCode(() -> testee.listContactDomainMembers(newDomain).block())
             .doesNotThrowAnyException();
-        assertThat(testee.listContactDomainMembers(newDomain.id()).blockOptional()).isEmpty();
+        assertThat(testee.listContactDomainMembers(newDomain).blockOptional()).isEmpty();
     }
 
     @Test
     void deleteContactDomainMembersShouldRemoveSpecifiedContactWhenExists() {
         OpenPaaSDomain domain = createNewDomainMemberAddressBook();
 
-        testee.createDomainMembersAddressBook(domain.id()).block();
+        testee.createDomainMembersAddressBook(domain).block();
 
         String uid = UUID.randomUUID().toString();
         String vcard = """
@@ -500,9 +500,9 @@ public class CardDavClientTest {
             EMAIL:john@example.com
             END:VCARD
             """.formatted(uid);
-        testee.upsertContactDomainMembers(domain.id(), uid, vcard.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, uid, vcard.getBytes(StandardCharsets.UTF_8)).block();
 
-        testee.deleteContactDomainMembers(domain.id(), uid).block();
+        testee.deleteContactDomainMembers(domain, uid).block();
 
         String result = listContactDomainMembersAsVcard(domain);
         assertThat(result).doesNotContain("UID:" + uid);
@@ -512,14 +512,14 @@ public class CardDavClientTest {
     void deleteContactDomainMembersShouldNotThrowWhenContactDoesNotExist() {
         OpenPaaSDomain domain = createNewDomainMemberAddressBook();
         String c = UUID.randomUUID().toString();
-        assertThatCode(() -> testee.deleteContactDomainMembers(domain.id(), UUID.randomUUID().toString()).block())
+        assertThatCode(() -> testee.deleteContactDomainMembers(domain, UUID.randomUUID().toString()).block())
             .doesNotThrowAnyException();
     }
 
     @Test
     void deleteContactDomainMembersShouldNotAffectOtherContactsInSameDomain() {
         OpenPaaSDomain domain = createNewDomainMemberAddressBook();
-        testee.createDomainMembersAddressBook(domain.id()).block();
+        testee.createDomainMembersAddressBook(domain).block();
 
         String uid1 = UUID.randomUUID().toString();
         String uid2 = UUID.randomUUID().toString();
@@ -537,10 +537,10 @@ public class CardDavClientTest {
             FN:Bob
             END:VCARD
             """.formatted(uid2);
-        testee.upsertContactDomainMembers(domain.id(), uid1, vcard1.getBytes(StandardCharsets.UTF_8)).block();
-        testee.upsertContactDomainMembers(domain.id(), uid2, vcard2.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, uid1, vcard1.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, uid2, vcard2.getBytes(StandardCharsets.UTF_8)).block();
 
-        testee.deleteContactDomainMembers(domain.id(), uid1).block();
+        testee.deleteContactDomainMembers(domain, uid1).block();
 
         String result = listContactDomainMembersAsVcard(domain);
         assertThat(result).contains("UID:" + uid2);
@@ -561,10 +561,10 @@ public class CardDavClientTest {
             FN:Same UID
             END:VCARD
             """.formatted(sharedUid);
-        testee.upsertContactDomainMembers(domain.id(), sharedUid, vcard.getBytes(StandardCharsets.UTF_8)).block();
-        testee.upsertContactDomainMembers(anotherDomain.id(), sharedUid, vcard.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(domain, sharedUid, vcard.getBytes(StandardCharsets.UTF_8)).block();
+        testee.upsertContactDomainMembers(anotherDomain, sharedUid, vcard.getBytes(StandardCharsets.UTF_8)).block();
 
-        testee.deleteContactDomainMembers(domain.id(), sharedUid).block();
+        testee.deleteContactDomainMembers(domain, sharedUid).block();
 
         String resultDomainA = listContactDomainMembersAsVcard(domain);
         assertThat(resultDomainA).doesNotContain("UID:" + sharedUid);
@@ -576,7 +576,7 @@ public class CardDavClientTest {
     @Test
     void deleteContactDomainMembersShouldBeNoOpWhenAddressBookNotCreated() {
         OpenPaaSDomain domain = mongoDBOpenPaaSDomainDAO.add(Domain.of("new-domain" + UUID.randomUUID() + ".tld")).block();
-        assertThatThrownBy(() -> testee.deleteContactDomainMembers(domain.id(), "any-uid").block())
+        assertThatThrownBy(() -> testee.deleteContactDomainMembers(domain, "any-uid").block())
             .isInstanceOf(DavClientException.class);
     }
 
@@ -769,12 +769,12 @@ public class CardDavClientTest {
 
     private OpenPaaSDomain createNewDomainMemberAddressBook() {
         OpenPaaSDomain newDomain = mongoDBOpenPaaSDomainDAO.add(Domain.of("new-domain" + UUID.randomUUID() + ".tld")).block();
-        testee.createDomainMembersAddressBook(newDomain.id()).block();
+        testee.createDomainMembersAddressBook(newDomain).block();
         return newDomain;
     }
 
     private String listContactDomainMembersAsVcard(OpenPaaSDomain domain) {
-        return testee.listContactDomainMembers(domain.id())
+        return testee.listContactDomainMembers(domain)
             .blockOptional()
             .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
             .orElse("");

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/DavTestHelper.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/DavTestHelper.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.dav.dto.SubscribedCalendarRequest;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.TechnicalTokenService;
@@ -186,10 +187,10 @@ public class DavTestHelper extends DavClient {
             .flatMap(e -> e.stream().findFirst());
     }
 
-    public Optional<String> findFirstEventId(ResourceId resourceId, OpenPaaSId domainId) {
+    public Optional<String> findFirstEventId(ResourceId resourceId, OpenPaaSDomain domain) {
         CalendarURL calendarURL = CalendarURL.from(resourceId.asOpenPaaSId());
 
-        return calDavClient.findUserCalendarEventIds(httpClientWithTechnicalToken(domainId), calendarURL)
+        return calDavClient.findUserCalendarEventIds(httpClientWithTechnicalToken(domain), calendarURL)
             .retryWhen(Retry.fixedDelay(2, Duration.ofMillis(500))
                 .filter(throwable -> throwable instanceof DavClientException))
             .next()
@@ -374,8 +375,8 @@ public class DavTestHelper extends DavClient {
             });
     }
 
-    public Mono<ArrayNode> getCalendarDelegateInvites(OpenPaaSId domainId, ResourceId resourceId) {
-        return httpClientWithTechnicalToken(domainId)
+    public Mono<ArrayNode> getCalendarDelegateInvites(OpenPaaSDomain domain, ResourceId resourceId) {
+        return httpClientWithTechnicalToken(domain)
             .flatMap(client ->
                 client.headers(headers -> headers.add(HttpHeaderNames.ACCEPT, "application/calendar+json"))
                     .request(HttpMethod.GET)

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CheckTechnicalUserTokenRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CheckTechnicalUserTokenRoute.java
@@ -21,6 +21,7 @@ package com.linagora.calendar.restapi.routes;
 import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -35,8 +36,10 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableMap;
 import com.linagora.calendar.restapi.ErrorResponse;
 import com.linagora.calendar.restapi.RestApiConstants;
+import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.TechnicalTokenService;
 import com.linagora.calendar.storage.TechnicalTokenService.JwtToken;
 
@@ -48,17 +51,19 @@ import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
 
 public class CheckTechnicalUserTokenRoute implements JMAPRoutes {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(CheckTechnicalUserTokenRoute.class);
     private static final String TOKEN_HEADER_NAME = "X-TECHNICAL-TOKEN";
+
     private final TechnicalTokenService technicalTokenService;
     private final MetricFactory metricFactory;
+    private final OpenPaaSDomainDAO domainDAO;
     private final ObjectMapper objectMapper;
 
     @Inject
-    public CheckTechnicalUserTokenRoute(TechnicalTokenService technicalTokenService, MetricFactory metricFactory) {
+    public CheckTechnicalUserTokenRoute(TechnicalTokenService technicalTokenService, MetricFactory metricFactory, OpenPaaSDomainDAO domainDAO) {
         this.technicalTokenService = technicalTokenService;
         this.metricFactory = metricFactory;
+        this.domainDAO = domainDAO;
         this.objectMapper = RestApiConstants.OBJECT_MAPPER_DEFAULT;
     }
 
@@ -79,7 +84,8 @@ public class CheckTechnicalUserTokenRoute implements JMAPRoutes {
         return Mono.justOrEmpty(getToken(request))
             .switchIfEmpty(Mono.error(new IllegalArgumentException("Missing technical user token in request headers " + TOKEN_HEADER_NAME)))
             .flatMap(requestToken -> technicalTokenService.claim(new JwtToken(requestToken)))
-            .map(Throwing.function(tokenClaims -> objectMapper.writeValueAsBytes(tokenClaims.data())))
+            .flatMap(this::withDomain)
+            .map(Throwing.function(objectMapper::writeValueAsBytes))
             .flatMap(bytes -> response.status(200)
                 .headers(JSON_HEADER)
                 .sendByteArray(Mono.just(bytes))
@@ -88,6 +94,14 @@ public class CheckTechnicalUserTokenRoute implements JMAPRoutes {
                 LOGGER.warn("Error while verifying technical user ", exception);
                 return doOnError(response);
             });
+    }
+
+    private Mono<Map<String, Object>> withDomain(TechnicalTokenService.TechnicalTokenInfo tokenInfo) {
+        return Mono.from(domainDAO.retrieve(tokenInfo.domainId()))
+            .map(domain -> ImmutableMap.<String, Object>builder()
+                .put("domain", domain.domain().asString())
+                .putAll(tokenInfo.data())
+                .build());
     }
 
     Mono<Void> doOnError(HttpServerResponse response) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CheckTechnicalUserTokenRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CheckTechnicalUserTokenRoute.java
@@ -21,7 +21,6 @@ package com.linagora.calendar.restapi.routes;
 import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
 
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -36,10 +35,8 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.lambdas.Throwing;
-import com.google.common.collect.ImmutableMap;
 import com.linagora.calendar.restapi.ErrorResponse;
 import com.linagora.calendar.restapi.RestApiConstants;
-import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.TechnicalTokenService;
 import com.linagora.calendar.storage.TechnicalTokenService.JwtToken;
 
@@ -51,19 +48,17 @@ import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
 
 public class CheckTechnicalUserTokenRoute implements JMAPRoutes {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CheckTechnicalUserTokenRoute.class);
     private static final String TOKEN_HEADER_NAME = "X-TECHNICAL-TOKEN";
-
     private final TechnicalTokenService technicalTokenService;
     private final MetricFactory metricFactory;
-    private final OpenPaaSDomainDAO domainDAO;
     private final ObjectMapper objectMapper;
 
     @Inject
-    public CheckTechnicalUserTokenRoute(TechnicalTokenService technicalTokenService, MetricFactory metricFactory, OpenPaaSDomainDAO domainDAO) {
+    public CheckTechnicalUserTokenRoute(TechnicalTokenService technicalTokenService, MetricFactory metricFactory) {
         this.technicalTokenService = technicalTokenService;
         this.metricFactory = metricFactory;
-        this.domainDAO = domainDAO;
         this.objectMapper = RestApiConstants.OBJECT_MAPPER_DEFAULT;
     }
 
@@ -84,8 +79,7 @@ public class CheckTechnicalUserTokenRoute implements JMAPRoutes {
         return Mono.justOrEmpty(getToken(request))
             .switchIfEmpty(Mono.error(new IllegalArgumentException("Missing technical user token in request headers " + TOKEN_HEADER_NAME)))
             .flatMap(requestToken -> technicalTokenService.claim(new JwtToken(requestToken)))
-            .flatMap(this::withDomain)
-            .map(Throwing.function(objectMapper::writeValueAsBytes))
+            .map(Throwing.function(tokenClaims -> objectMapper.writeValueAsBytes(tokenClaims.data())))
             .flatMap(bytes -> response.status(200)
                 .headers(JSON_HEADER)
                 .sendByteArray(Mono.just(bytes))
@@ -94,14 +88,6 @@ public class CheckTechnicalUserTokenRoute implements JMAPRoutes {
                 LOGGER.warn("Error while verifying technical user ", exception);
                 return doOnError(response);
             });
-    }
-
-    private Mono<Map<String, Object>> withDomain(TechnicalTokenService.TechnicalTokenInfo tokenInfo) {
-        return Mono.from(domainDAO.retrieve(tokenInfo.domainId()))
-            .map(domain -> ImmutableMap.<String, Object>builder()
-                .put("domain", domain.domain().asString())
-                .putAll(tokenInfo.data())
-                .build());
     }
 
     Mono<Void> doOnError(HttpServerResponse response) {

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceAdministratorService.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceAdministratorService.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Sets;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
@@ -55,22 +56,25 @@ public class ResourceAdministratorService {
 
     private final CalDavClient calDavClient;
     private final OpenPaaSUserDAO userDAO;
+    private final OpenPaaSDomainDAO domainDAO;
 
     @Inject
     @Singleton
-    public ResourceAdministratorService(CalDavClient calDavClient, OpenPaaSUserDAO userDAO) {
+    public ResourceAdministratorService(CalDavClient calDavClient, OpenPaaSUserDAO userDAO, OpenPaaSDomainDAO domainDAO) {
         this.calDavClient = calDavClient;
         this.userDAO = userDAO;
+        this.domainDAO = domainDAO;
     }
 
     public Mono<Void> setAdmins(OpenPaaSId domainId, ResourceId resourceId, Collection<Username> admins) {
-        return calDavClient.grantReadWriteRights(domainId, resourceId, admins)
+        return domainDAO.retrieve(domainId)
+            .flatMap(domain -> calDavClient.grantReadWriteRights(domain, resourceId, admins))
             .doOnError(err -> LOGGER.error("Error granting rights for resource {}", resourceId.value(), err));
     }
 
     public Mono<Void> revokeAdmins(Resource resource) {
-        return resolveAdminUsernames(resource)
-            .flatMap(adminUsers -> calDavClient.revokeWriteRights(resource.domain(), resource.id(), adminUsers)
+        return Mono.zip(resolveAdminUsernames(resource), domainDAO.retrieve(resource.domain()))
+            .flatMap(tuple -> calDavClient.revokeWriteRights(tuple.getT2(), resource.id(), tuple.getT1())
                 .doOnError(error -> LOGGER.error("Error revoking write rights for resource {}", resource.id().value(), error)));
     }
 
@@ -82,9 +86,9 @@ public class ResourceAdministratorService {
     }
 
     private Mono<Void> applyCalDavPatch(Resource resource, AdminChanges changes) {
-        return Mono.zip(findUsernamesByIds(changes.toAdd()), findUsernamesByIds(changes.toRemove()))
+        return Mono.zip(findUsernamesByIds(changes.toAdd()), findUsernamesByIds(changes.toRemove()), domainDAO.retrieve(resource.domain()))
             .flatMap(tuple -> calDavClient.patchReadWriteDelegations(
-                resource.domain(), CalendarURL.from(resource.id().asOpenPaaSId()), tuple.getT1(), tuple.getT2()))
+                tuple.getT3(), CalendarURL.from(resource.id().asOpenPaaSId()), tuple.getT1(), tuple.getT2()))
             .doOnError(err -> LOGGER.error("Error patching CalDAV delegation for resource {}", resource.id().value(), err));
     }
 

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceRoutes.java
@@ -329,6 +329,6 @@ public class ResourceRoutes implements Routes {
     }
 
     private RepositionResourceRightsTask getRepositionResourceRightsTask(Request request) {
-        return new RepositionResourceRightsTask(resourceDAO, userDAO, calDavClient);
+        return new RepositionResourceRightsTask(resourceDAO, userDAO, domainDAO, calDavClient);
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/DavDomainMemberUpdateApplier.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/DavDomainMemberUpdateApplier.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableList;
 import com.linagora.calendar.dav.AddressBookContact;
 import com.linagora.calendar.dav.CardDavClient;
-import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.OpenPaaSDomain;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -106,12 +106,12 @@ public interface DavDomainMemberUpdateApplier {
         private static final Logger LOGGER = LoggerFactory.getLogger(Default.class);
 
         private final CardDavClient davClient;
-        private final OpenPaaSId domainId;
+        private final OpenPaaSDomain domain;
 
         public Default(CardDavClient davClient,
-                       OpenPaaSId domainId) {
+                       OpenPaaSDomain domain) {
             this.davClient = davClient;
-            this.domainId = domainId;
+            this.domain = domain;
         }
 
         @Override
@@ -129,11 +129,11 @@ public interface DavDomainMemberUpdateApplier {
         }
 
         private ContactOperation upsertContactOperation() {
-            return contact -> davClient.upsertContactDomainMembers(domainId, contact.vcardUid(), contact.toVcardBytes());
+            return contact -> davClient.upsertContactDomainMembers(domain, contact.vcardUid(), contact.toVcardBytes());
         }
 
         private ContactOperation deleteContactOperation() {
-            return contact -> davClient.deleteContactDomainMembers(domainId, contact.vcardUid());
+            return contact -> davClient.deleteContactDomainMembers(domain, contact.vcardUid());
         }
 
         private Mono<Void> processContacts(Iterable<AddressBookContact> contacts,
@@ -150,7 +150,7 @@ public interface DavDomainMemberUpdateApplier {
                             LOGGER.error("Failed to {} contact {} for domain {}",
                                 type.name().toLowerCase(),
                                 contact.mail().map(MailAddress::asString).orElse(null),
-                                domainId.value(),
+                                domain.id().value(),
                                 e);
                             return Mono.empty();
                         }), ReactorUtils.LOW_CONCURRENCY)

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/LdapToDavDomainMembersSyncService.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/LdapToDavDomainMembersSyncService.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import com.linagora.calendar.dav.AddressBookContact;
 import com.linagora.calendar.dav.CardDavClient;
 import com.linagora.calendar.storage.OpenPaaSDomain;
-import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.ldap.LdapDomainMemberProvider;
 import com.linagora.calendar.storage.ldap.LdapUser;
 import com.linagora.calendar.webadmin.service.DavDomainMemberUpdateApplier.ContactUpdateContext;
@@ -43,14 +42,14 @@ public class LdapToDavDomainMembersSyncService {
 
     private final LdapDomainMemberProvider ldapDomainMemberProvider;
     private final CardDavClient davClient;
-    private final Function<OpenPaaSId, DavDomainMemberUpdateApplier> davDomainMemberUpdateApplierFactory;
+    private final Function<OpenPaaSDomain, DavDomainMemberUpdateApplier> davDomainMemberUpdateApplierFactory;
 
     @Inject
     public LdapToDavDomainMembersSyncService(LdapDomainMemberProvider ldapDomainMemberProvider,
                                              CardDavClient davClient) {
         this.ldapDomainMemberProvider = ldapDomainMemberProvider;
         this.davClient = davClient;
-        this.davDomainMemberUpdateApplierFactory = openPaaSId -> new DavDomainMemberUpdateApplier.Default(davClient, openPaaSId);
+        this.davDomainMemberUpdateApplierFactory = openPaaSDomain -> new DavDomainMemberUpdateApplier.Default(davClient, openPaaSDomain);
     }
 
     public Mono<UpdateResult> syncDomainMembers(OpenPaaSDomain openPaaSDomain, ContactUpdateContext contexts) {
@@ -59,13 +58,13 @@ public class LdapToDavDomainMembersSyncService {
                 List<LdapUser> ldapMembers = tuple.getT1();
                 List<AddressBookContact> davContacts = tuple.getT2();
                 DomainMemberUpdate domainMemberUpdate = DomainMemberUpdate.compute(ldapMembers, davContacts);
-                return davDomainMemberUpdateApplierFactory.apply(openPaaSDomain.id()).apply(domainMemberUpdate, contexts);
+                return davDomainMemberUpdateApplierFactory.apply(openPaaSDomain).apply(domainMemberUpdate, contexts);
             })
             .doOnSubscribe(sub -> LOGGER.info("Syncing domain: {}", openPaaSDomain.domain()));
     }
 
     private Mono<List<AddressBookContact>> fetchDavDomainMembers(OpenPaaSDomain openPaaSDomain) {
-        return davClient.listContactDomainMembers(openPaaSDomain.id())
+        return davClient.listContactDomainMembers(openPaaSDomain)
             .map(AddressBookContact::parse)
             .defaultIfEmpty(List.of())
             .doOnError(throwable -> LOGGER.error("Error fetching DAV domain members for domain: {}", openPaaSDomain.domain(), throwable));

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/RepositionResourceRightsTask.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/RepositionResourceRightsTask.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.ResourceDAO;
@@ -79,14 +80,17 @@ public class RepositionResourceRightsTask implements Task {
 
     private final ResourceDAO resourceDAO;
     private final OpenPaaSUserDAO userDAO;
+    private final OpenPaaSDomainDAO domainDAO;
     private final CalDavClient calDavClient;
     private final Context context;
 
     public RepositionResourceRightsTask(ResourceDAO resourceDAO,
                                         OpenPaaSUserDAO userDAO,
+                                        OpenPaaSDomainDAO domainDAO,
                                         CalDavClient calDavClient) {
         this.resourceDAO = resourceDAO;
         this.userDAO = userDAO;
+        this.domainDAO = domainDAO;
         this.calDavClient = calDavClient;
         this.context = new Context();
     }
@@ -106,8 +110,8 @@ public class RepositionResourceRightsTask implements Task {
     }
 
     private Mono<Task.Result> reapplyWriteRights(Resource resource, Context context) {
-        return resolveAdministratorUsernames(resource)
-            .flatMap(usernames -> calDavClient.grantReadWriteRights(resource.domain(), resource.id(), usernames)
+        return Mono.zip(resolveAdministratorUsernames(resource), domainDAO.retrieve(resource.domain()))
+            .flatMap(tuple -> calDavClient.grantReadWriteRights(tuple.getT2(), resource.id(), tuple.getT1())
                 .thenReturn(Result.COMPLETED)
                 .onErrorResume(e -> {
                     LOGGER.error("Error granting rights for resource {}", resource.id().value(), e);

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/DomainMembersAddressBookRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/DomainMembersAddressBookRoutesTest.java
@@ -58,7 +58,6 @@ import com.linagora.calendar.dav.CardDavClient;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.OpenPaaSDomain;
-import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.ldap.LdapDomainMemberProvider;
 import com.linagora.calendar.storage.ldap.LdapUser;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
@@ -268,11 +267,11 @@ public class DomainMembersAddressBookRoutesTest {
             .body("status", is("completed"))
             .body("additionalInformation.addedCount", is(2));
 
-        assertThat(listContactDomainMembersAsVcard(openPaaSDomain1.id()))
+        assertThat(listContactDomainMembersAsVcard(openPaaSDomain1))
             .contains("alice@example.com")
             .doesNotContain("bob@example.org");
 
-        assertThat(listContactDomainMembersAsVcard(openPaaSDomain2.id()))
+        assertThat(listContactDomainMembersAsVcard(openPaaSDomain2))
             .contains("bob@example.org")
             .doesNotContain("alice@example.com");
     }
@@ -322,10 +321,10 @@ public class DomainMembersAddressBookRoutesTest {
             .body("additionalInformation.ignoredDomains", hasItem(domain2.asString()));
 
         // Then: domain1 is synced, domain2 is ignored
-        assertThat(listContactDomainMembersAsVcard(openPaaSDomain1.id()))
+        assertThat(listContactDomainMembersAsVcard(openPaaSDomain1))
             .contains("alice@example.com");
 
-        assertThat(listContactDomainMembersAsVcard(openPaaSDomain2.id()))
+        assertThat(listContactDomainMembersAsVcard(openPaaSDomain2))
             .doesNotContain("bob@example.org");
     }
 
@@ -383,13 +382,13 @@ public class DomainMembersAddressBookRoutesTest {
             .body("additionalInformation.ignoredDomains", hasItem(domain3.asString()));
 
         // Then: domain1 is synced, domain2 and domain3 are ignored
-        assertThat(listContactDomainMembersAsVcard(openPaaSDomain1.id()))
+        assertThat(listContactDomainMembersAsVcard(openPaaSDomain1))
             .contains("alice@example.com");
 
-        assertThat(listContactDomainMembersAsVcard(openPaaSDomain2.id()))
+        assertThat(listContactDomainMembersAsVcard(openPaaSDomain2))
             .doesNotContain("bob@example.org");
 
-        assertThat(listContactDomainMembersAsVcard(openPaaSDomain3.id()))
+        assertThat(listContactDomainMembersAsVcard(openPaaSDomain3))
             .doesNotContain("charlie@example.net");
     }
 
@@ -438,10 +437,10 @@ public class DomainMembersAddressBookRoutesTest {
             .body("additionalInformation.addedCount", is(2));
 
         // Both domains should be synced
-        assertThat(listContactDomainMembersAsVcard(openPaaSDomain1.id()))
+        assertThat(listContactDomainMembersAsVcard(openPaaSDomain1))
             .contains("alice@example.com");
 
-        assertThat(listContactDomainMembersAsVcard(openPaaSDomain2.id()))
+        assertThat(listContactDomainMembersAsVcard(openPaaSDomain2))
             .contains("bob@example.org");
     }
 
@@ -495,7 +494,7 @@ public class DomainMembersAddressBookRoutesTest {
             .body("status", is("completed"))
             .body("additionalInformation.addedCount", is(1));
 
-        String vcard = listContactDomainMembersAsVcard(openPaaSDomain1.id());
+        String vcard = listContactDomainMembersAsVcard(openPaaSDomain1);
         assertThat(vcard)
             .contains("EMAIL:charlie@example.net");
     }
@@ -575,8 +574,8 @@ public class DomainMembersAddressBookRoutesTest {
             .build();
     }
 
-    private String listContactDomainMembersAsVcard(OpenPaaSId domainId) {
-        return cardDavClient.listContactDomainMembers(domainId)
+    private String listContactDomainMembersAsVcard(OpenPaaSDomain domain) {
+        return cardDavClient.listContactDomainMembers(domain)
             .blockOptional()
             .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
             .orElse("");

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/RepositionResourceRightsTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/RepositionResourceRightsTest.java
@@ -61,7 +61,6 @@ import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSDomain;
-import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.model.ResourceId;
@@ -88,7 +87,7 @@ public class RepositionResourceRightsTest {
     private DavTestHelper davTestHelper;
 
     private OpenPaaSUser creator;
-    private OpenPaaSId domainId;
+    private OpenPaaSDomain domain;
    
     @BeforeEach
     void setUp() throws SSLException {
@@ -101,7 +100,7 @@ public class RepositionResourceRightsTest {
         davTestHelper = sabreDavExtension.davTestHelper();
 
         TaskManager taskManager = new MemoryTaskManager(new Hostname("foo"));
-        ResourceAdministratorService resourceAdministratorService = new ResourceAdministratorService(calDavClient, userDAO);
+        ResourceAdministratorService resourceAdministratorService = new ResourceAdministratorService(calDavClient, userDAO, domainDAO);
         ResourceRoutes resourceRoutes = new ResourceRoutes(resourceDAO, domainDAO, userDAO, new JsonTransformer(), resourceAdministratorService, taskManager, calDavClient);
 
         webAdminServer = WebAdminUtils.createWebAdminServer(resourceRoutes,
@@ -114,8 +113,7 @@ public class RepositionResourceRightsTest {
             .build();
 
         creator = sabreDavExtension.newTestUser();
-        domainId = domainDAO.retrieve(creator.username().getDomainPart().get())
-            .map(OpenPaaSDomain::id).block();
+        domain = domainDAO.retrieve(creator.username().getDomainPart().get()).block();
     }
 
     @AfterEach
@@ -173,17 +171,17 @@ public class RepositionResourceRightsTest {
         ResourceId resourceId = createNewResource(creator, List.of(admin1, admin2));
 
         // Sanity check — initial invites include both admins
-        ArrayNode before = davTestHelper.getCalendarDelegateInvites(domainId, resourceId).block();
+        ArrayNode before = davTestHelper.getCalendarDelegateInvites(domain, resourceId).block();
 
         assertThat(before.findValuesAsText("href"))
             .contains("mailto:" + admin1.username().asString(), "mailto:" + admin2.username().asString());
 
         // WHEN — Manually revoke rights on DAV to simulate drift
-        calDavClient.revokeWriteRights(domainId, resourceId, List.of(admin1.username(), admin2.username())).block();
+        calDavClient.revokeWriteRights(domain, resourceId, List.of(admin1.username(), admin2.username())).block();
 
         // Assert they are indeed removed
         ArrayNode afterRevoke = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId)
+            .getCalendarDelegateInvites(domain, resourceId)
             .block();
 
         assertThat(afterRevoke.findValuesAsText("href"))
@@ -198,7 +196,7 @@ public class RepositionResourceRightsTest {
 
         // THEN — rights should be restored on DAV
         ArrayNode afterTask = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId)
+            .getCalendarDelegateInvites(domain, resourceId)
             .block();
 
         assertThat(afterTask.findValuesAsText("href"))
@@ -216,8 +214,8 @@ public class RepositionResourceRightsTest {
         ResourceId resourceId2 = createNewResource(creator, List.of(admin2));
 
         // Sanity check — both resources have their admins
-        ArrayNode before1 = davTestHelper.getCalendarDelegateInvites(domainId, resourceId1).block();
-        ArrayNode before2 = davTestHelper.getCalendarDelegateInvites(domainId, resourceId2).block();
+        ArrayNode before1 = davTestHelper.getCalendarDelegateInvites(domain, resourceId1).block();
+        ArrayNode before2 = davTestHelper.getCalendarDelegateInvites(domain, resourceId2).block();
 
         assertThat(before1.findValuesAsText("href"))
             .contains("mailto:" + admin1.username().asString());
@@ -225,14 +223,14 @@ public class RepositionResourceRightsTest {
             .contains("mailto:" + admin2.username().asString());
 
         // WHEN — revoke rights on DAV
-        calDavClient.revokeWriteRights(domainId, resourceId1, List.of(admin1.username())).block();
-        calDavClient.revokeWriteRights(domainId, resourceId2, List.of(admin2.username())).block();
+        calDavClient.revokeWriteRights(domain, resourceId1, List.of(admin1.username())).block();
+        calDavClient.revokeWriteRights(domain, resourceId2, List.of(admin2.username())).block();
 
         // Assert they are removed
         ArrayNode afterRevoke1 = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId1).block();
+            .getCalendarDelegateInvites(domain, resourceId1).block();
         ArrayNode afterRevoke2 = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId2).block();
+            .getCalendarDelegateInvites(domain, resourceId2).block();
 
         assertThat(afterRevoke1.findValuesAsText("href"))
             .doesNotContain("mailto:" + admin1.username().asString());
@@ -247,9 +245,9 @@ public class RepositionResourceRightsTest {
 
         // THEN — both resources restored
         ArrayNode afterTask1 = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId1).block();
+            .getCalendarDelegateInvites(domain, resourceId1).block();
         ArrayNode afterTask2 = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId2).block();
+            .getCalendarDelegateInvites(domain, resourceId2).block();
 
         assertThat(afterTask1.findValuesAsText("href"))
             .contains("mailto:" + admin1.username().asString());
@@ -305,7 +303,7 @@ public class RepositionResourceRightsTest {
 
         // Sanity check — initial rights
         ArrayNode before = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId)
+            .getCalendarDelegateInvites(domain, resourceId)
             .block();
         assertThat(before.findValuesAsText("href"))
             .contains("mailto:" + admin1.username().asString(), "mailto:" + admin2.username().asString());
@@ -326,7 +324,7 @@ public class RepositionResourceRightsTest {
 
         // THEN — Rights should remain unchanged
         ArrayNode after = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId)
+            .getCalendarDelegateInvites(domain, resourceId)
             .block();
 
         assertThat(after.findValuesAsText("href"))
@@ -351,20 +349,20 @@ public class RepositionResourceRightsTest {
         ResourceId resourceId2 = createNewResource(creator2, List.of(admin2));
 
         // Sanity check — ensure both admins exist initially
-        ArrayNode before1 = davTestHelper.getCalendarDelegateInvites(domain1.id(), resourceId1).block();
-        ArrayNode before2 = davTestHelper.getCalendarDelegateInvites(domain2.id(), resourceId2).block();
+        ArrayNode before1 = davTestHelper.getCalendarDelegateInvites(domain1, resourceId1).block();
+        ArrayNode before2 = davTestHelper.getCalendarDelegateInvites(domain2, resourceId2).block();
         assertThat(before1.findValuesAsText("href"))
             .contains("mailto:" + admin1.username().asString());
         assertThat(before2.findValuesAsText("href"))
             .contains("mailto:" + admin2.username().asString());
 
         // WHEN — revoke rights manually
-        calDavClient.revokeWriteRights(domain1.id(), resourceId1, List.of(admin1.username())).block();
-        calDavClient.revokeWriteRights(domain2.id(), resourceId2, List.of(admin2.username())).block();
+        calDavClient.revokeWriteRights(domain1, resourceId1, List.of(admin1.username())).block();
+        calDavClient.revokeWriteRights(domain2, resourceId2, List.of(admin2.username())).block();
 
         // Confirm both removed
-        ArrayNode afterRevoke1 = davTestHelper.getCalendarDelegateInvites(domain1.id(), resourceId1).block();
-        ArrayNode afterRevoke2 = davTestHelper.getCalendarDelegateInvites(domain2.id(), resourceId2).block();
+        ArrayNode afterRevoke1 = davTestHelper.getCalendarDelegateInvites(domain1, resourceId1).block();
+        ArrayNode afterRevoke2 = davTestHelper.getCalendarDelegateInvites(domain2, resourceId2).block();
         assertThat(afterRevoke1.findValuesAsText("href"))
             .doesNotContain("mailto:" + admin1.username().asString());
         assertThat(afterRevoke2.findValuesAsText("href"))
@@ -379,9 +377,9 @@ public class RepositionResourceRightsTest {
 
         // Both rights restored
         ArrayNode afterTask1 = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain1.id(), resourceId1).block();
+            .getCalendarDelegateInvites(domain1, resourceId1).block();
         ArrayNode afterTask2 = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain2.id(), resourceId2).block();
+            .getCalendarDelegateInvites(domain2, resourceId2).block();
         assertThat(afterTask1.findValuesAsText("href"))
             .contains("mailto:" + admin1.username().asString());
         assertThat(afterTask2.findValuesAsText("href"))
@@ -448,19 +446,19 @@ public class RepositionResourceRightsTest {
 
         // Sanity check — DAV initially contains only admin1
         ArrayNode before = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId)
+            .getCalendarDelegateInvites(domain, resourceId)
             .block();
 
         assertThat(before.findValuesAsText("href"))
             .contains("mailto:" + admin1.username().asString());
 
         // Simulate an extra DAV-only admin (ghost)
-        calDavClient.grantReadWriteRights(domainId, resourceId, List.of(ghostAdmin.username()))
+        calDavClient.grantReadWriteRights(domain, resourceId, List.of(ghostAdmin.username()))
             .block();
 
         // Confirm both admins are now on DAV
         ArrayNode withGhost = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId)
+            .getCalendarDelegateInvites(domain, resourceId)
             .block();
 
         assertThat(withGhost.findValuesAsText("href"))
@@ -476,7 +474,7 @@ public class RepositionResourceRightsTest {
 
         // THEN — both admins (backend + extra) should still be present
         ArrayNode after = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domainId, resourceId)
+            .getCalendarDelegateInvites(domain, resourceId)
             .block();
 
         assertThat(after.findValuesAsText("href"))

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/ResourceRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/ResourceRoutesTest.java
@@ -85,7 +85,7 @@ class ResourceRoutesTest {
         CalDavClient calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
         TaskManager taskManager = new MemoryTaskManager(new Hostname("foo"));
 
-        ResourceAdministratorService resourceAdministratorService = new ResourceAdministratorService(calDavClient, userDAO);
+        ResourceAdministratorService resourceAdministratorService = new ResourceAdministratorService(calDavClient, userDAO, domainDAO);
         webAdminServer = WebAdminUtils.createWebAdminServer(
             new ResourceRoutes(resourceDAO, domainDAO, userDAO,
                 new JsonTransformer(), resourceAdministratorService, taskManager, calDavClient)).start();
@@ -695,7 +695,7 @@ class ResourceRoutesTest {
         OpenPaaSDomain openPaaSDomain = domainDAO.retrieve(creator.username().getDomainPart().get()).block();
 
         ArrayNode invites = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(openPaaSDomain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(openPaaSDomain, new ResourceId(resourceId))
             .block();
 
         assertThat(invites)
@@ -773,7 +773,7 @@ class ResourceRoutesTest {
         OpenPaaSDomain openPaaSDomain = domainDAO.retrieve(creator.username().getDomainPart().get()).block();
 
         ArrayNode invites = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(openPaaSDomain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(openPaaSDomain, new ResourceId(resourceId))
             .block();
 
         assertThat(invites)
@@ -819,7 +819,7 @@ class ResourceRoutesTest {
 
         // Sanity check: ensure rights are present before delete
         ArrayNode invitesBefore = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(openPaaSDomain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(openPaaSDomain, new ResourceId(resourceId))
             .block();
 
         assertThat(invitesBefore)
@@ -838,7 +838,7 @@ class ResourceRoutesTest {
 
         // Then — DAV rights should be revoked
         ArrayNode invitesAfter = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(openPaaSDomain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(openPaaSDomain, new ResourceId(resourceId))
             .block();
 
         assertThat(invitesAfter)
@@ -878,7 +878,7 @@ class ResourceRoutesTest {
 
         // Sanity check
         ArrayNode before = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(domain, new ResourceId(resourceId))
             .block();
 
         assertThat(before.findValuesAsText("href"))
@@ -901,7 +901,7 @@ class ResourceRoutesTest {
 
         // Then — DAV invites should include both admins
         ArrayNode after = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(domain, new ResourceId(resourceId))
             .block();
 
         assertThat(after.findValuesAsText("href"))
@@ -942,7 +942,7 @@ class ResourceRoutesTest {
 
         // Sanity check — before patch
         ArrayNode before = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(domain, new ResourceId(resourceId))
             .block();
 
         assertThat(before.findValuesAsText("href"))
@@ -964,7 +964,7 @@ class ResourceRoutesTest {
 
         // Then — DAV should no longer contain admin2
         ArrayNode after = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(domain, new ResourceId(resourceId))
             .block();
 
         assertThat(after.findValuesAsText("href"))
@@ -999,7 +999,7 @@ class ResourceRoutesTest {
 
         // Sanity check — ensure admin exists before patch
         ArrayNode before = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(domain, new ResourceId(resourceId))
             .block();
 
         assertThat(before.findValuesAsText("href"))
@@ -1018,7 +1018,7 @@ class ResourceRoutesTest {
 
         // Then — DAV should remain unchanged
         ArrayNode after = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(domain, new ResourceId(resourceId))
             .block();
 
         assertThat(after.findValuesAsText("href"))
@@ -1058,7 +1058,7 @@ class ResourceRoutesTest {
 
         // Sanity check — before patch
         ArrayNode before = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(domain, new ResourceId(resourceId))
             .block();
 
         assertThat(before.findValuesAsText("href"))
@@ -1078,7 +1078,7 @@ class ResourceRoutesTest {
 
         // Then — DAV should have no admin delegations
         ArrayNode after = sabreDavExtension.davTestHelper()
-            .getCalendarDelegateInvites(domain.id(), new ResourceId(resourceId))
+            .getCalendarDelegateInvites(domain, new ResourceId(resourceId))
             .block();
 
         assertThat(after.findValuesAsText("href"))

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/service/DavDomainMemberUpdateApplierTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/service/DavDomainMemberUpdateApplierTest.java
@@ -66,12 +66,12 @@ public class DavDomainMemberUpdateApplierTest {
     void setupEach() throws Exception {
         cardDavClient = new CardDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
         openPaaSDomain = createNewDomainMemberAddressBook();
-        testee = new DavDomainMemberUpdateApplier.Default(cardDavClient, openPaaSDomain.id());
+        testee = new DavDomainMemberUpdateApplier.Default(cardDavClient, openPaaSDomain);
     }
 
     private OpenPaaSDomain createNewDomainMemberAddressBook() {
         OpenPaaSDomain newDomain = mongoDBOpenPaaSDomainDAO.add(Domain.of("new-domain" + UUID.randomUUID() + ".tld")).block();
-        cardDavClient.createDomainMembersAddressBook(newDomain.id()).block();
+        cardDavClient.createDomainMembersAddressBook(newDomain).block();
         return newDomain;
     }
 
@@ -372,13 +372,13 @@ public class DavDomainMemberUpdateApplierTest {
     }
 
     private String listContactDomainMembersAsVcard(OpenPaaSDomain domain) {
-        return cardDavClient.listContactDomainMembers(domain.id())
+        return cardDavClient.listContactDomainMembers(domain)
             .blockOptional()
             .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
             .orElse("");
     }
 
     private void insertContact(OpenPaaSDomain domain, AddressBookContact contact) {
-        cardDavClient.upsertContactDomainMembers(domain.id(), contact.vcardUid(), contact.toVcardBytes()).block();
+        cardDavClient.upsertContactDomainMembers(domain, contact.vcardUid(), contact.toVcardBytes()).block();
     }
 }

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/service/LdapToDavDomainMembersSyncServiceTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/service/LdapToDavDomainMembersSyncServiceTest.java
@@ -96,7 +96,7 @@ public class LdapToDavDomainMembersSyncServiceTest {
 
     private OpenPaaSDomain createNewDomainMemberAddressBook() {
         OpenPaaSDomain newDomain = mongoDBOpenPaaSDomainDAO.add(Domain.of("new-domain" + UUID.randomUUID() + ".tld")).block();
-        cardDavClient.createDomainMembersAddressBook(newDomain.id()).block();
+        cardDavClient.createDomainMembersAddressBook(newDomain).block();
         return newDomain;
     }
 
@@ -220,7 +220,7 @@ public class LdapToDavDomainMembersSyncServiceTest {
         UpdateResult result = testee.syncDomainMembers(openPaaSDomain, new ContactUpdateContext()).block();
 
         assertThat(result.deletedCount()).isEqualTo(1);
-        verify(cardDavClient).deleteContactDomainMembers(eq(openPaaSDomain.id()), any());
+        verify(cardDavClient).deleteContactDomainMembers(eq(openPaaSDomain), any());
 
         assertThat(listContactDomainMembersAsVcard(openPaaSDomain))
             .doesNotContain("user1@example.com");
@@ -266,7 +266,7 @@ public class LdapToDavDomainMembersSyncServiceTest {
         verify(cardDavClient, never()).upsertContactDomainMembers(any(), any(), any());
         verify(cardDavClient, never()).deleteContactDomainMembers(any(), any());
 
-        List<AddressBookContact> latestDomainMembersContact = cardDavClient.listContactDomainMembers(openPaaSDomain.id())
+        List<AddressBookContact> latestDomainMembersContact = cardDavClient.listContactDomainMembers(openPaaSDomain)
             .map(AddressBookContact::parse)
             .block();
 
@@ -319,7 +319,7 @@ public class LdapToDavDomainMembersSyncServiceTest {
     }
 
     private String listContactDomainMembersAsVcard(OpenPaaSDomain domain) {
-        return cardDavClient.listContactDomainMembers(domain.id())
+        return cardDavClient.listContactDomainMembers(domain)
             .blockOptional()
             .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
             .orElse("");

--- a/docs/apis/openpaasApi.md
+++ b/docs/apis/openpaasApi.md
@@ -603,7 +603,24 @@ With the following header:
 X-TECHNICAL-TOKEN: xyz
 ```
 
-Will return 200 if the token is valid and 404 otherwise (non-existent or expired)
+Will return 200 if the token is valid and 404 otherwise (non-existent or expired) and token details:
+
+```
+{
+   "__v": 0,
+   "name": "Sabre Dav",
+   "domainId": "xxx",
+   "domain": "linagora.com",
+   "_id": "xxx",
+   "data": {
+     "principal": "principals/technicalUser"
+   },
+   "user_type": "technical",
+   "schemaVersion": 1,
+   "type": "dav",
+   "description": "Allows to authenticate on Sabre DAV"
+}
+```
 
 ### GET /calendar/api/calendars/event/participation
 

--- a/saas/saas-rabbitmq/src/main/java/com/linagora/calendar/saas/SaaSUserSubscriptionHandler.java
+++ b/saas/saas-rabbitmq/src/main/java/com/linagora/calendar/saas/SaaSUserSubscriptionHandler.java
@@ -79,7 +79,7 @@ public class SaaSUserSubscriptionHandler implements SaaSMessageHandler {
 
     private Mono<Void> upsertUserContact(OpenPaaSDomain domain, OpenPaaSUser user) {
         return Mono.fromSupplier(Throwing.supplier(() -> AddressBookContact.builder().mail(user.username().asMailAddress()).build()))
-            .flatMap(contact -> cardDavClient.upsertContactDomainMembers(domain.id(), contact.vcardUid(), contact.toVcardBytes()))
+            .flatMap(contact -> cardDavClient.upsertContactDomainMembers(domain, contact.vcardUid(), contact.toVcardBytes()))
             .doOnSuccess(ignored -> LOGGER.info("Added user {} to domain member addressbook of domain {}",
                 user.username().asString(), domain.domain().asString()));
     }

--- a/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/SaaSUserSubscriptionHandlerTest.java
+++ b/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/SaaSUserSubscriptionHandlerTest.java
@@ -174,7 +174,7 @@ class SaaSUserSubscriptionHandlerTest {
     @Test
     void shouldNotAddContactToAddressBookWhenNotSupportSharingForDomain() {
         OpenPaaSDomain nonSharedDomain = domainDAO.add(Domain.of("nonshared.tld")).block();
-        cardDavClient.createDomainMembersAddressBook(nonSharedDomain.id()).block();
+        cardDavClient.createDomainMembersAddressBook(nonSharedDomain).block();
 
         String userEmail = "bob@" + nonSharedDomain.domain().asString();
         String json = """
@@ -199,7 +199,7 @@ class SaaSUserSubscriptionHandlerTest {
     }
 
     private String listContactDomainMembersAsVcard(OpenPaaSDomain domain) {
-        return cardDavClient.listContactDomainMembers(domain.id())
+        return cardDavClient.listContactDomainMembers(domain)
             .blockOptional()
             .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
             .orElse("");

--- a/storage-api/src/main/java/com/linagora/calendar/storage/TechnicalTokenService.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/TechnicalTokenService.java
@@ -44,7 +44,7 @@ import reactor.core.scheduler.Schedulers;
 
 public interface TechnicalTokenService {
 
-    Mono<JwtToken> generate(OpenPaaSId domainId);
+    Mono<JwtToken> generate(OpenPaaSDomain domain);
 
     Mono<TechnicalTokenInfo> claim(JwtToken token);
 
@@ -84,7 +84,7 @@ public interface TechnicalTokenService {
             }
         }
 
-        public static final Function<OpenPaaSId, Map<String, Object>> TOKEN_DATA_FUNCTION = domainId -> Map.of(
+        public static final Function<OpenPaaSDomain, Map<String, Object>> TOKEN_DATA_FUNCTION = domain -> Map.of(
             "data", Map.of("principal", "principals/technicalUser"),
             "type", "dav",
             "user_type", "technical",
@@ -92,8 +92,9 @@ public interface TechnicalTokenService {
             "__v", 0,
             "description", "Allows to authenticate on Sabre DAV",
             "name", "Sabre Dav",
-            "domainId", domainId.value(),
-            "_id", UUID.nameUUIDFromBytes(domainId.value().getBytes(StandardCharsets.UTF_8)).toString());
+            "domainId", domain.id().value(),
+            "domain", domain.domain().asString(),
+            "_id", UUID.nameUUIDFromBytes(domain.id().value().getBytes(StandardCharsets.UTF_8)).toString());
 
         private static final Logger LOGGER = LoggerFactory.getLogger(TechnicalTokenService.class);
         private static final String CLAIM_NAME_DOMAIN_ID = "domainId";
@@ -127,12 +128,12 @@ public interface TechnicalTokenService {
         }
 
         @Override
-        public Mono<JwtToken> generate(OpenPaaSId domainId) {
+        public Mono<JwtToken> generate(OpenPaaSDomain domain) {
             return Mono.fromCallable(() -> JWT.create()
                     .withIssuer(ISSUER)
-                    .withClaim(CLAIM_NAME_DOMAIN_ID, domainId.value())
+                    .withClaim(CLAIM_NAME_DOMAIN_ID, domain.id().value())
                     .withClaim(CLAIM_TECHNICAL_TOKEN, true)
-                    .withClaim(CLAIM_NAME_DATA, TOKEN_DATA_FUNCTION.apply(domainId))
+                    .withClaim(CLAIM_NAME_DATA, TOKEN_DATA_FUNCTION.apply(domain))
                     .withExpiresAt(clock.instant().plusSeconds(expiration.toSeconds()))
                     .sign(algorithm))
                 .map(JwtToken::new)

--- a/storage-api/src/test/java/com/linagora/calendar/storage/TechnicalTokenServiceTest.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/TechnicalTokenServiceTest.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Map;
 
+import org.apache.james.core.Domain;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,14 +54,14 @@ public class TechnicalTokenServiceTest {
 
     @Test
     void generateThenClaimShouldReturnExpectedInfo() {
-        OpenPaaSId domainId = new OpenPaaSId("test-domain-id");
-        JwtToken jwtToken = testee.generate(domainId).block();
+        OpenPaaSDomain domain = new OpenPaaSDomain(Domain.of("example.com"), new OpenPaaSId("test-domain-id"));
+        JwtToken jwtToken = testee.generate(domain).block();
 
         TechnicalTokenInfo technicalTokenInfo = testee.claim(jwtToken).block();
 
         assertThat(technicalTokenInfo)
             .isEqualTo(new TechnicalTokenInfo(
-                domainId,
+                domain.id(),
                 Map.of("__v", 0,
                     "data", Map.of("principal", "principals/technicalUser"),
                     "schemaVersion", 1,
@@ -68,6 +69,7 @@ public class TechnicalTokenServiceTest {
                     "name", "Sabre Dav",
                     "user_type", "technical",
                     "domainId", "test-domain-id",
+                    "domain", "example.com",
                     "_id", "4890c190-d1d6-392e-afbf-991d4ce359b6",
                     "type", "dav")
             ));
@@ -75,8 +77,8 @@ public class TechnicalTokenServiceTest {
 
     @Test
     void generateShouldReturnJwtToken() {
-        OpenPaaSId domainId = new OpenPaaSId("test-domain-id");
-        JwtToken jwtToken = testee.generate(domainId).block();
+        OpenPaaSDomain domain = new OpenPaaSDomain(Domain.of("example.com"), new OpenPaaSId("test-domain-id"));
+        JwtToken jwtToken = testee.generate(domain).block();
 
         assertThat(jwtToken.value())
             .startsWith("eyJ"); // Heuristic for detecting JWT
@@ -99,6 +101,7 @@ public class TechnicalTokenServiceTest {
                         },
                         "schemaVersion": 1,
                         "domainId": "test-domain-id",
+                        "domain": "example.com",
                         "_id": "4890c190-d1d6-392e-afbf-991d4ce359b6"
                     },
                     "exp": 4070908920
@@ -108,8 +111,8 @@ public class TechnicalTokenServiceTest {
 
     @Test
     void generateShouldProduceDifferentPayloadsForDifferentDomains() throws JsonProcessingException {
-        JwtToken jwtToken1 = testee.generate(new OpenPaaSId("domain-A")).block();
-        JwtToken jwtToken2 = testee.generate(new OpenPaaSId("domain-B")).block();
+        JwtToken jwtToken1 = testee.generate(new OpenPaaSDomain(Domain.of("domain-a.com"), new OpenPaaSId("domain-A"))).block();
+        JwtToken jwtToken2 = testee.generate(new OpenPaaSDomain(Domain.of("domain-b.com"), new OpenPaaSId("domain-B"))).block();
 
         String payload1 = decodeJWTPayloadPart(jwtToken1.value());
         String payload2 = decodeJWTPayloadPart(jwtToken2.value());
@@ -132,7 +135,7 @@ public class TechnicalTokenServiceTest {
         TechnicalTokenService.Impl technicalTokenService =
             new TechnicalTokenService.Impl("my-secret", expiration, fixedClock);
 
-        JwtToken jwtToken = technicalTokenService.generate(new OpenPaaSId("domain-id")).block();
+        JwtToken jwtToken = technicalTokenService.generate(new OpenPaaSDomain(Domain.of("example.com"), new OpenPaaSId("domain-id"))).block();
 
         String payload = decodeJWTPayloadPart(jwtToken.value());
         JsonNode json = new ObjectMapper().readTree(payload);
@@ -143,14 +146,14 @@ public class TechnicalTokenServiceTest {
 
     @Test
     void claimShouldThrowWhenTokenIsExpired() {
-        OpenPaaSId domainId = new OpenPaaSId("test-domain-id");
+        OpenPaaSDomain domain = new OpenPaaSDomain(Domain.of("example.com"), new OpenPaaSId("test-domain-id"));
         Clock fixedClock = Clock.fixed(Instant.now().minusSeconds(10), ZoneId.of("UTC"));
 
         TechnicalTokenService.Impl tokenServiceWithExpiredClock =
             new TechnicalTokenService.Impl("my-secret",
                 Duration.ofSeconds(2), fixedClock);
 
-        TechnicalTokenService.JwtToken jwtToken = tokenServiceWithExpiredClock.generate(domainId).block();
+        TechnicalTokenService.JwtToken jwtToken = tokenServiceWithExpiredClock.generate(domain).block();
 
         assertThatThrownBy(() -> tokenServiceWithExpiredClock.claim(jwtToken).block())
             .isInstanceOf(TechnicalTokenClaimException.class)
@@ -160,7 +163,7 @@ public class TechnicalTokenServiceTest {
 
     @Test
     void claimShouldFailWhenTokenIsTampered() {
-        JwtToken validToken = testee.generate(new OpenPaaSId("domain-id")).block();
+        JwtToken validToken = testee.generate(new OpenPaaSDomain(Domain.of("example.com"), new OpenPaaSId("domain-id"))).block();
 
         String[] parts = validToken.value().split("\\.");
         String fakePayload = BaseEncoding.base64Url().encode("{\"some\":\"tampered\"}".getBytes(StandardCharsets.UTF_8));
@@ -180,7 +183,7 @@ public class TechnicalTokenServiceTest {
         TechnicalTokenService.Impl tokenService1 = new TechnicalTokenService.Impl("secret-1", Duration.ofMinutes(2), clock);
         TechnicalTokenService.Impl tokenService2 = new TechnicalTokenService.Impl("secret-2", Duration.ofMinutes(2), clock);
 
-        JwtToken tokenFromOtherSecret = tokenService1.generate(new OpenPaaSId("domain-id")).block();
+        JwtToken tokenFromOtherSecret = tokenService1.generate(new OpenPaaSDomain(Domain.of("example.com"), new OpenPaaSId("domain-id"))).block();
 
         assertThatThrownBy(() -> tokenService2.claim(tokenFromOtherSecret).block())
             .isInstanceOf(TechnicalTokenClaimException.class)


### PR DESCRIPTION
alternative of https://github.com/linagora/twake-calendar-side-service/pull/704

The idea is including domain info when signing tokens (generate)
In most flows, this saves one extra query.