### PR TITLE
test(integration): adapt tmail-backend: purge RabbitMQ DLQs before healthcheck checks

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/SaaSSubscriptionIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/SaaSSubscriptionIntegrationTest.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 
 import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.backends.rabbitmq.RabbitMQConnectionFactory;
+import org.apache.james.backends.rabbitmq.RabbitMQManagementAPI;
 import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
 import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
 import org.apache.james.core.Domain;
@@ -134,6 +135,8 @@ class SaaSSubscriptionIntegrationTest {
 
     @BeforeEach
     void setUp(TwakeCalendarGuiceServer server) {
+        purgeSaaSSubscriptionDeadLetterQueues();
+
         sender = channelPool.getSender();
 
         webadminRequestSpecification = new RequestSpecBuilder()
@@ -150,6 +153,16 @@ class SaaSSubscriptionIntegrationTest {
             .statusCode(200)
             .body("checks.find { it.componentName == 'SaaSSubscriptionQueueConsumerHealthCheck' }.status",
                 equalTo("healthy")));
+    }
+
+    private void purgeSaaSSubscriptionDeadLetterQueues() {
+        try {
+            RabbitMQManagementAPI rabbitMQManagementAPI = RabbitMQManagementAPI.from(sabreDavExtension.dockerSabreDavSetup().rabbitMQConfiguration());
+            rabbitMQManagementAPI.purgeQueue("/", SaaSSubscriptionConsumer.SAAS_SUBSCRIPTION_DEAD_LETTER_QUEUE);
+            rabbitMQManagementAPI.purgeQueue("/", SaaSDomainSubscriptionConsumer.SAAS_DOMAIN_SUBSCRIPTION_DEAD_LETTER_QUEUE);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to purge SaaS subscription dead letter queues before test", e);
+        }
     }
 
     @AfterEach

--- a/app/src/test/java/com/linagora/calendar/app/TWPSyncSettingsIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TWPSyncSettingsIntegrationTest.java
@@ -51,6 +51,7 @@ import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.restapi.RestApiServerProbe;
+import com.linagora.calendar.saas.TWPCalendarSettingsModule;
 import com.linagora.tmail.saas.rabbitmq.settings.TWPSettingsConsumer;
 
 import io.restassured.RestAssured;
@@ -116,6 +117,8 @@ class TWPSyncSettingsIntegrationTest {
 
     @BeforeEach
     void setUp(TwakeCalendarGuiceServer server) {
+        purgeTWPSettingsDeadLetterQueue();
+
         server.getProbe(CalendarDataProbe.class)
             .addDomain(DOMAIN)
             .addUser(USERNAME, PASSWORD);
@@ -416,6 +419,15 @@ class TWPSyncSettingsIntegrationTest {
                             }
                         """));
         });
+    }
+
+    private void purgeTWPSettingsDeadLetterQueue() {
+        try {
+            rabbitMQExtension.managementAPI()
+                .purgeQueue("/", TWPCalendarSettingsModule.CONSUMER_CONFIG.deadLetterQueue());
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to purge TWP settings dead letter queue before healthcheck assertion", e);
+        }
     }
 
     private void publishAmqpSettingsMessage(String message) {


### PR DESCRIPTION
Reset RabbitMQ dead-letter queues in integration test setup for TWP sync
and SaaS subscription suites.
This isolates tests from cross-test message residue that could degrade
healthcheck status unexpectedly.