### PR TITLE
ISSUE-698 fix(itip): skip REPLY delivery when attendee status is unchanged

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
@@ -41,12 +41,14 @@ import org.apache.james.backends.rabbitmq.QueueArguments;
 import org.apache.james.backends.rabbitmq.QueueArguments.Builder;
 import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
 import org.apache.james.backends.rabbitmq.ReceiverProvider;
+import org.apache.james.core.MailAddress;
 import org.apache.james.core.Username;
 import org.apache.james.lifecycle.api.Startable;
 import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.fge.lambdas.Throwing;
 import com.google.inject.name.Named;
 import com.linagora.calendar.api.CalendarUtil;
 import com.linagora.calendar.dav.CalDavClient;
@@ -60,6 +62,7 @@ import com.rabbitmq.client.BuiltinExchangeType;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.parameter.PartStat;
 import net.fortuna.ical4j.model.property.Method;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -239,7 +242,36 @@ public class ItipLocalDeliveryConsumer implements Closeable, Startable {
             && hasInvalidRequestOrganizer(localDelivery, calendar, oldEventCalendar)) {
             return SKIP;
         }
+        if (Method.VALUE_REPLY.equalsIgnoreCase(localDelivery.method())
+            && replyPartStatUnchanged(localDelivery, calendar, oldEventCalendar)) {
+            return SKIP;
+        }
         return !SKIP;
+    }
+
+    private boolean replyPartStatUnchanged(ItipLocalDeliveryDTO localDelivery,
+                                           Calendar newCalendar,
+                                           Optional<Calendar> oldCalendar) {
+
+        MailAddress attendee = Throwing.supplier(localDelivery::senderAsMailAddress).get();
+        VEvent newVEvent = EventParseUtils.getFirstEvent(newCalendar);
+        Optional<PartStat> newPartStat = EventParseUtils.findAttendeePartStat(newVEvent, attendee);
+
+        if (newPartStat.isEmpty()) {
+            return !SKIP;
+        }
+
+        Optional<String> newRecurrenceId = EventParseUtils.getRecurrenceId(newVEvent);
+        Optional<PartStat> oldPartStat = oldCalendar.flatMap(oldCal -> {
+            if (newRecurrenceId.isPresent()) {
+                return EventParseUtils.findInstanceByRecurrenceId(oldCal, newRecurrenceId.get())
+                    .map(instance -> EventParseUtils.findAttendeePartStat(instance, attendee))
+                    .orElseGet(() -> EventParseUtils.findAttendeePartStat(EventParseUtils.getMasterRecurrenceEvent(oldCal), attendee));
+            }
+            return EventParseUtils.findAttendeePartStat(EventParseUtils.getFirstEvent(oldCal), attendee);
+        });
+
+        return newPartStat.equals(oldPartStat);
     }
 
     private Mono<Void> sendItipIfNecessary(ItipLocalDeliveryDTO localDelivery,

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
@@ -24,7 +24,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.mail.internet.AddressException;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.james.core.MailAddress;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
@@ -107,6 +110,10 @@ public record ItipLocalDeliveryDTO(
     /** Strips the {@code mailto:} prefix from the sender address. */
     public String strippedSender() {
         return stripMailto(sender);
+    }
+
+    public MailAddress senderAsMailAddress() throws AddressException {
+        return new MailAddress(strippedSender());
     }
 
     /** Strips the {@code mailto:} prefix from the single recipient address. */

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
@@ -613,6 +613,345 @@ public class ItipLocalDeliveryConsumerTest {
             assertThat(channel.basicGet(ItipLocalDeliveryConsumer.DEAD_LETTER_QUEUE, true)).isNotNull());
     }
 
+    @Test
+    void shouldCallItipAndEmailWhenReplyPartStatChanged() {
+        when(localRecipientResolver.resolve(Username.of(BOB)))
+            .thenReturn(Mono.just(Optional.of(new OpenPaaSId(LOCAL_USER_ID))));
+        stubItipNoContent();
+        declareQueueBoundToExchange(EventEmailConsumer.EXCHANGE_NAME, testEmailQueue);
+        List<JsonNode> emailMessages = consumeJsonMessages(testEmailQueue);
+
+        String replyIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REPLY
+            BEGIN:VEVENT
+            UID:{UID}
+            SUMMARY:Test Meeting
+            DTSTART;TZID=Europe/Paris:20260401T100000
+            DTEND;TZID=Europe/Paris:20260401T110000
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+        String oldIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REQUEST
+            BEGIN:VEVENT
+            UID:{UID}
+            SUMMARY:Test Meeting
+            DTSTART;TZID=Europe/Paris:20260401T100000
+            DTEND;TZID=Europe/Paris:20260401T110000
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+
+        String payload = """
+            {
+              "sender": "mailto:%s",
+              "method": "REPLY",
+              "uid": "%s",
+              "calendarId": "%s",
+              "message": %s,
+              "oldMessage": %s,
+              "hasChange": true,
+              "recipients": ["mailto:%s"]
+            }
+            """.formatted(ALICE, EVENT_UID, CALENDAR_ID, jsonString(replyIcal), jsonString(oldIcal), BOB);
+
+        publishToConsumer(payload);
+
+        AWAIT_AT_MOST.untilAsserted(() -> {
+            WireMock.verify(WireMock.postRequestedFor(WireMock.urlEqualTo("/itip")));
+            assertThat(emailMessages).hasSize(1);
+        });
+    }
+
+    @Test
+    void shouldIgnoreReplyWhenReplyPartStatUnchanged() {
+        declareQueueBoundToExchange(EventEmailConsumer.EXCHANGE_NAME, testEmailQueue);
+        List<JsonNode> emailMessages = consumeJsonMessages(testEmailQueue);
+
+        String replyIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REPLY
+            BEGIN:VEVENT
+            UID:{UID}
+            SUMMARY:Test Meeting
+            DTSTART;TZID=Europe/Paris:20260401T100000
+            DTEND;TZID=Europe/Paris:20260401T110000
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+        String oldIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REQUEST
+            BEGIN:VEVENT
+            UID:{UID}
+            SUMMARY:Test Meeting
+            DTSTART;TZID=Europe/Paris:20260401T100000
+            DTEND;TZID=Europe/Paris:20260401T110000
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+
+        String payload = """
+            {
+              "sender": "mailto:%s",
+              "method": "REPLY",
+              "uid": "%s",
+              "calendarId": "%s",
+              "message": %s,
+              "oldMessage": %s,
+              "hasChange": true,
+              "recipients": ["mailto:%s"]
+            }
+            """.formatted(ALICE, EVENT_UID, CALENDAR_ID, jsonString(replyIcal), jsonString(oldIcal), BOB);
+
+        publishToConsumer(payload);
+
+        AWAIT_AT_MOST.untilAsserted(() -> {
+            WireMock.verify(0, WireMock.postRequestedFor(WireMock.urlEqualTo("/itip")));
+            assertThat(emailMessages).isEmpty();
+        });
+    }
+
+    @Test
+    void shouldCallItipAndEmailWhenReplyPartStatDiffersFromMasterWithoutOldInstance() {
+        when(localRecipientResolver.resolve(Username.of(BOB)))
+            .thenReturn(Mono.just(Optional.of(new OpenPaaSId(LOCAL_USER_ID))));
+        stubItipNoContent();
+        declareQueueBoundToExchange(EventEmailConsumer.EXCHANGE_NAME, testEmailQueue);
+        List<JsonNode> emailMessages = consumeJsonMessages(testEmailQueue);
+
+        String replyIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REPLY
+            BEGIN:VEVENT
+            UID:{UID}
+            RECURRENCE-ID;TZID=Europe/Paris:20260402T100000
+            SUMMARY:Recurring meeting override
+            DTSTART;TZID=Europe/Paris:20260402T100000
+            DTEND;TZID=Europe/Paris:20260402T110000
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+        String oldIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REQUEST
+            BEGIN:VEVENT
+            UID:{UID}
+            SUMMARY:Recurring meeting
+            DTSTART;TZID=Europe/Paris:20260401T100000
+            DTEND;TZID=Europe/Paris:20260401T110000
+            RRULE:FREQ=DAILY;COUNT=2
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+
+        String payload = """
+            {
+              "sender": "mailto:%s",
+              "method": "REPLY",
+              "uid": "%s",
+              "calendarId": "%s",
+              "message": %s,
+              "oldMessage": %s,
+              "hasChange": true,
+              "recipients": ["mailto:%s"]
+            }
+            """.formatted(ALICE, EVENT_UID, CALENDAR_ID, jsonString(replyIcal), jsonString(oldIcal), BOB);
+
+        publishToConsumer(payload);
+
+        AWAIT_AT_MOST.untilAsserted(() -> {
+            WireMock.verify(WireMock.postRequestedFor(WireMock.urlEqualTo("/itip")));
+            assertThat(emailMessages).hasSize(1);
+        });
+    }
+
+    @Test
+    void shouldCallItipAndEmailWhenReplyPartStatDiffersFromMasterWithOldInstance() {
+        when(localRecipientResolver.resolve(Username.of(BOB)))
+            .thenReturn(Mono.just(Optional.of(new OpenPaaSId(LOCAL_USER_ID))));
+        stubItipNoContent();
+        declareQueueBoundToExchange(EventEmailConsumer.EXCHANGE_NAME, testEmailQueue);
+        List<JsonNode> emailMessages = consumeJsonMessages(testEmailQueue);
+
+        String replyIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REPLY
+            BEGIN:VEVENT
+            UID:{UID}
+            RECURRENCE-ID;TZID=Europe/Paris:20260402T100000
+            SUMMARY:Recurring meeting override
+            DTSTART;TZID=Europe/Paris:20260402T100000
+            DTEND;TZID=Europe/Paris:20260402T110000
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+        String oldIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REQUEST
+            BEGIN:VEVENT
+            UID:{UID}
+            SUMMARY:Recurring meeting
+            DTSTART;TZID=Europe/Paris:20260401T100000
+            DTEND;TZID=Europe/Paris:20260401T110000
+            RRULE:FREQ=DAILY;COUNT=2
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{ATTENDEE}
+            END:VEVENT
+            BEGIN:VEVENT
+            UID:{UID}
+            RECURRENCE-ID;TZID=Europe/Paris:20260402T100000
+            SUMMARY:Recurring meeting override
+            DTSTART;TZID=Europe/Paris:20260402T100000
+            DTEND;TZID=Europe/Paris:20260402T110000
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+
+        String payload = """
+            {
+              "sender": "mailto:%s",
+              "method": "REPLY",
+              "uid": "%s",
+              "calendarId": "%s",
+              "message": %s,
+              "oldMessage": %s,
+              "hasChange": true,
+              "recipients": ["mailto:%s"]
+            }
+            """.formatted(ALICE, EVENT_UID, CALENDAR_ID, jsonString(replyIcal), jsonString(oldIcal), BOB);
+
+        publishToConsumer(payload);
+
+        AWAIT_AT_MOST.untilAsserted(() -> {
+            WireMock.verify(WireMock.postRequestedFor(WireMock.urlEqualTo("/itip")));
+            assertThat(emailMessages).hasSize(1);
+        });
+    }
+
+    @Test
+    void shouldIgnoreReplyWhenPartStatMatchesMasterWithoutOldInstance() {
+        declareQueueBoundToExchange(EventEmailConsumer.EXCHANGE_NAME, testEmailQueue);
+        List<JsonNode> emailMessages = consumeJsonMessages(testEmailQueue);
+
+        String replyIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REPLY
+            BEGIN:VEVENT
+            UID:{UID}
+            RECURRENCE-ID;TZID=Europe/Paris:20260402T100000
+            SUMMARY:Recurring meeting override
+            DTSTART;TZID=Europe/Paris:20260402T100000
+            DTEND;TZID=Europe/Paris:20260402T110000
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+        String oldIcal = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Test//Test//EN
+            METHOD:REQUEST
+            BEGIN:VEVENT
+            UID:{UID}
+            SUMMARY:Recurring meeting
+            DTSTART;TZID=Europe/Paris:20260401T100000
+            DTEND;TZID=Europe/Paris:20260401T110000
+            RRULE:FREQ=DAILY;COUNT=2
+            ORGANIZER:mailto:{ORGANIZER}
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:{ATTENDEE}
+            END:VEVENT
+            END:VCALENDAR
+            """
+            .replace("{UID}", EVENT_UID)
+            .replace("{ORGANIZER}", BOB)
+            .replace("{ATTENDEE}", ALICE);
+
+        String payload = """
+            {
+              "sender": "mailto:%s",
+              "method": "REPLY",
+              "uid": "%s",
+              "calendarId": "%s",
+              "message": %s,
+              "oldMessage": %s,
+              "hasChange": true,
+              "recipients": ["mailto:%s"]
+            }
+            """.formatted(ALICE, EVENT_UID, CALENDAR_ID, jsonString(replyIcal), jsonString(oldIcal), BOB);
+
+        publishToConsumer(payload);
+
+        AWAIT_AT_MOST.untilAsserted(() -> {
+            WireMock.verify(0, WireMock.postRequestedFor(WireMock.urlEqualTo("/itip")));
+            assertThat(emailMessages).isEmpty();
+        });
+    }
+
     private List<JsonNode> consumeJsonMessages(String queueName) {
         List<JsonNode> messages = new ArrayList<>();
         try {

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/EventParseUtils.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/EventParseUtils.java
@@ -156,6 +156,22 @@ public class EventParseUtils {
         return attendees;
     }
 
+    public static Optional<PartStat> findAttendeePartStat(VEvent vEvent, MailAddress attendee) {
+        return getAttendees(vEvent).stream()
+            .filter(person -> Strings.CI.equals(person.email().asString(), attendee.asString()))
+            .findFirst()
+            .flatMap(EventFields.Person::partStat);
+    }
+
+    public static Optional<VEvent> findInstanceByRecurrenceId(Calendar calendar, String recurrenceId) {
+        return calendar.getComponents(Component.VEVENT).stream()
+            .map(VEvent.class::cast)
+            .filter(vEvent -> getRecurrenceId(vEvent)
+                .filter(id -> Strings.CI.equals(id, recurrenceId))
+                .isPresent())
+            .findFirst();
+    }
+
     private static List<EventFields.Person> deduplicatePeopleByEmail(List<EventFields.Person> people) {
         return people.stream()
             .collect(Collectors.collectingAndThen(

--- a/storage-api/src/test/java/com/linagora/calendar/storage/event/EventParseUtilsTest.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/event/EventParseUtilsTest.java
@@ -39,6 +39,7 @@ import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;
 import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.parameter.PartStat;
 
 class EventParseUtilsTest {
 
@@ -248,6 +249,75 @@ class EventParseUtilsTest {
         VEvent event = (VEvent) calendar.getComponent(Component.VEVENT).get();
 
         assertThat(EventParseUtils.getOrganizer(event)).isEqualTo(new EventFields.Person("Test Organizer", new MailAddress("organizer@abc.com")));
+    }
+
+    @Test
+    void findAttendeePartStatShouldMatchAttendeeCaseInsensitive() throws AddressException {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            UID:event-1
+            DTSTART:20250911T100000Z
+            DTEND:20250911T120000Z
+            ATTENDEE;CN=Test Attendee;PARTSTAT=ACCEPTED:mailto:attendee@abc.com
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+        VEvent event = (VEvent) calendar.getComponent(Component.VEVENT).get();
+
+        assertThat(EventParseUtils.findAttendeePartStat(event, new MailAddress("ATTENDEE@ABC.COM")))
+            .contains(PartStat.ACCEPTED);
+    }
+
+    @Test
+    void findInstanceByRecurrenceIdShouldFindMatchingInstance() {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            UID:event-1
+            DTSTART:20250411T090000Z
+            DTEND:20250411T100000Z
+            RRULE:FREQ=WEEKLY;BYDAY=FR
+            END:VEVENT
+            BEGIN:VEVENT
+            UID:event-1
+            RECURRENCE-ID:20250418T090000Z
+            DTSTART:20250418T090000Z
+            DTEND:20250418T110000Z
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+        Optional<VEvent> instance = EventParseUtils.findInstanceByRecurrenceId(calendar, "20250418T090000Z");
+
+        assertThat(instance).isPresent();
+        assertThat(instance.flatMap(EventParseUtils::getRecurrenceId))
+            .contains("20250418T090000Z");
+    }
+
+    @Test
+    void findInstanceByRecurrenceIdShouldReturnEmptyWhenNoMatch() {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            UID:event-1
+            DTSTART:20250411T090000Z
+            DTEND:20250411T100000Z
+            RRULE:FREQ=WEEKLY;BYDAY=FR
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+
+        assertThat(EventParseUtils.findInstanceByRecurrenceId(calendar, "20250418T090000Z"))
+            .isEmpty();
     }
 
     @Nested


### PR DESCRIPTION
Add REPLY-specific filtering to compare sender attendee PARTSTAT between new and previous calendar data before sending iTIP/email notifications.

resolve https://github.com/linagora/twake-calendar-side-service/issues/698