### PR TITLE
ISSUE-731 fix(alarm): handle duplicate recurrence overrides

### DIFF
--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/AlarmInstantFactoryTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/AlarmInstantFactoryTest.java
@@ -1163,6 +1163,121 @@ public class AlarmInstantFactoryTest {
         }
 
         @Test
+        void shouldUseNewestDtStampWhenRecurringOverridesHaveSameRecurrenceId() {
+            String ics = """
+                BEGIN:VCALENDAR
+                VERSION:2.0
+                BEGIN:VEVENT
+                UID:duplicate-recurrence-id
+                DTSTART:20260511T093000Z
+                DTEND:20260511T103000Z
+                RRULE:FREQ=DAILY;COUNT=1
+                ATTENDEE;PARTSTAT=ACCEPTED:mailto:jane@example.com
+                BEGIN:VALARM
+                ACTION:EMAIL
+                ATTENDEE:mailto:jane@example.com
+                TRIGGER:-PT15M
+                END:VALARM
+                END:VEVENT
+                BEGIN:VEVENT
+                UID:duplicate-recurrence-id
+                DTSTART:20260511T093000Z
+                DTEND:20260511T103000Z
+                RECURRENCE-ID:20260511T093000Z
+                SEQUENCE:2
+                DTSTAMP:20260510T182419Z
+                ATTENDEE;PARTSTAT=DECLINED:mailto:jane@example.com
+                BEGIN:VALARM
+                ACTION:EMAIL
+                ATTENDEE:mailto:jane@example.com
+                TRIGGER:-PT15M
+                END:VALARM
+                END:VEVENT
+                BEGIN:VEVENT
+                UID:duplicate-recurrence-id
+                DTSTART:20260511T093000Z
+                DTEND:20260511T103000Z
+                RECURRENCE-ID:20260511T093000Z
+                SEQUENCE:1
+                DTSTAMP:20260510T182440Z
+                ATTENDEE;PARTSTAT=ACCEPTED:mailto:jane@example.com
+                BEGIN:VALARM
+                ACTION:EMAIL
+                ATTENDEE:mailto:jane@example.com
+                TRIGGER:-PT15M
+                END:VALARM
+                END:VEVENT
+                END:VCALENDAR
+                """;
+
+            Optional<AlarmInstant> result = testee(Instant.parse("2026-05-10T00:00:00Z"))
+                .computeNextAlarmInstant(CalendarUtil.parseIcs(ics), Username.of("jane@example.com"));
+
+            assertThat(result)
+                .describedAs("The override with the latest DTSTAMP should win, even when its SEQUENCE is lower")
+                .isPresent()
+                .get()
+                .extracting(AlarmInstant::alarmTime)
+                .isEqualTo(Instant.parse("2026-05-11T09:15:00Z"));
+        }
+
+        @Test
+        void shouldUseNewestSequenceWhenDuplicateRecurringOverridesHaveSameDtStamp() {
+            String ics = """
+                BEGIN:VCALENDAR
+                VERSION:2.0
+                BEGIN:VEVENT
+                UID:duplicate-recurrence-id-same-dtstamp
+                DTSTART:20260511T093000Z
+                DTEND:20260511T103000Z
+                RRULE:FREQ=DAILY;COUNT=1
+                ATTENDEE;PARTSTAT=ACCEPTED:mailto:jane@example.com
+                BEGIN:VALARM
+                ACTION:EMAIL
+                ATTENDEE:mailto:jane@example.com
+                TRIGGER:-PT15M
+                END:VALARM
+                END:VEVENT
+                BEGIN:VEVENT
+                UID:duplicate-recurrence-id-same-dtstamp
+                DTSTART:20260511T093000Z
+                DTEND:20260511T103000Z
+                RECURRENCE-ID:20260511T093000Z
+                SEQUENCE:1
+                DTSTAMP:20260510T182440Z
+                ATTENDEE;PARTSTAT=ACCEPTED:mailto:jane@example.com
+                BEGIN:VALARM
+                ACTION:EMAIL
+                ATTENDEE:mailto:jane@example.com
+                TRIGGER:-PT15M
+                END:VALARM
+                END:VEVENT
+                BEGIN:VEVENT
+                UID:duplicate-recurrence-id-same-dtstamp
+                DTSTART:20260511T093000Z
+                DTEND:20260511T103000Z
+                RECURRENCE-ID:20260511T093000Z
+                SEQUENCE:2
+                DTSTAMP:20260510T182440Z
+                ATTENDEE;PARTSTAT=DECLINED:mailto:jane@example.com
+                BEGIN:VALARM
+                ACTION:EMAIL
+                ATTENDEE:mailto:jane@example.com
+                TRIGGER:-PT15M
+                END:VALARM
+                END:VEVENT
+                END:VCALENDAR
+                """;
+
+            Optional<AlarmInstant> result = testee(Instant.parse("2026-05-10T00:00:00Z"))
+                .computeNextAlarmInstant(CalendarUtil.parseIcs(ics), Username.of("jane@example.com"));
+
+            assertThat(result)
+                .describedAs("When DTSTAMP is equal, the override with the highest SEQUENCE should win")
+                .isEmpty();
+        }
+
+        @Test
         void shouldIterativelyReturnNextAlarmsAcrossMultipleVALARMsInRecurringEvent() {
             String ics = """
                 BEGIN:VCALENDAR

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/AlarmInstantFactory.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/AlarmInstantFactory.java
@@ -91,6 +91,9 @@ public interface AlarmInstantFactory {
             Comparator.comparing(AlarmInstant::alarmTime);
         private static final Comparator<VEvent> EARLIEST_FIRST_EVENT_COMPARATOR =
             Comparator.comparing(e -> EventParseUtils.getStartTime(e).toInstant());
+        private static final Comparator<VEvent> LATEST_OVERRIDE_EVENT_COMPARATOR =
+            Comparator.comparing(Default::extractDtStamp, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(Default::extractSequence);
 
         private final Clock clock;
 
@@ -238,7 +241,8 @@ public interface AlarmInstantFactory {
 
             Map<Temporal, VEvent> overrideMap = overrideEvents.stream()
                 .collect(Collectors.toMap(event -> normalizeTemporal(event.getRecurrenceId().getDate()),
-                    Function.identity()));
+                    Function.identity(),
+                    Default::selectLatestOverride));
 
             Instant now = clock.instant();
             Predicate<Temporal> isAfterPredicate = temporal -> {
@@ -301,6 +305,20 @@ public interface AlarmInstantFactory {
             return EventParseUtils.temporalToZonedDateTime(temporal)
                 .map(ZonedDateTime::toInstant)
                 .orElseThrow(() -> new IllegalArgumentException("Cannot convert: " + temporal));
+        }
+
+        private static VEvent selectLatestOverride(VEvent first, VEvent second) {
+            return LATEST_OVERRIDE_EVENT_COMPARATOR.compare(first, second) >= 0 ? first : second;
+        }
+
+        private static Instant extractDtStamp(VEvent event) {
+            return event.getProperty(Property.DTSTAMP)
+                .flatMap(EventParseUtils::parseTimeAsInstant)
+                .orElse(null);
+        }
+
+        private static int extractSequence(VEvent event) {
+            return event.getSequence() == null ? 0 : event.getSequence().getSequenceNo();
         }
 
     }


### PR DESCRIPTION
Add a merge strategy when recurring event overrides share the same RECURRENCE-ID. Prefer the newest DTSTAMP, then the highest SEQUENCE, so malformed ICS data does not crash alarm computation.

resolve https://github.com/linagora/twake-calendar-side-service/issues/731