### PR TITLE
ISSUE-734 Improve CI test time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,12 +23,48 @@ pipeline {
                 sh 'mkdir .build'
                 dir(".build") {
                     withCredentials([gitUsernamePassword(credentialsId: 'github')]) {
-                        sh 'git clone https://github.com/linagora/tmail-backend.git'
+                        sh 'git clone --depth 1 https://github.com/linagora/tmail-backend.git'
                     }
                     dir("tmail-backend") {
-                        sh 'git submodule init'
-                        sh 'git submodule update'
-                        sh 'mvn clean install -Dmaven.javadoc.skip=true -DskipTests -T1C'
+                        sh 'git submodule update --init --depth 1 james-project'
+                        script {
+                            def tmailBackendModules = [
+                                ':tmail-backend-parent',
+                                ':james-project',
+                                ':james-server-guice',
+                                ':logback-json-classic',
+                                ':tmail-saas-rabbitmq',
+                                ':jmap-extensions',
+                                ':apache-james-backends-opensearch',
+                                ':apache-james-backends-rabbitmq',
+                                ':apache-james-backends-redis',
+                                ':james-server-data-ldap',
+                                ':james-server-data-memory',
+                                ':james-server-guice-common',
+                                ':james-server-guice-data-ldap',
+                                ':james-server-guice-opensearch',
+                                ':james-server-guice-webadmin',
+                                ':james-server-testing',
+                                ':james-server-webadmin-data',
+                                ':mock-smtp-server',
+                                ':queue-rabbitmq-guice',
+                                ':testing-base',
+                                ':james-core',
+                                ':james-server-core',
+                                ':james-server-jwt',
+                                ':metrics-api',
+                                ':metrics-tests',
+                                ':event-bus-api',
+                                ':james-server-jmap',
+                                ':james-server-guice-configuration',
+                                ':james-server-webadmin-core',
+                                ':apache-james-mailbox-store',
+                                ':james-server-data-api',
+                                ':james-server-util'
+                            ].join(',')
+
+                            sh "mvn clean install -Dmaven.javadoc.skip=true -DskipTests -T1C -pl ${tmailBackendModules} -am"
+                        }
                     }
                 }
             }

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -243,7 +243,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <reuseForks>false</reuseForks>
+                    <forkCount>2</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <systemPropertyVariables>
+                        <james.exit.on.startup.error>false</james.exit.on.startup.error>
+                    </systemPropertyVariables>
                     <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
                     <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
                 </configuration>
@@ -395,7 +399,11 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>-Xms512m -Xmx1024m</argLine>
-                            <reuseForks>false</reuseForks>
+                            <forkCount>2</forkCount>
+                            <reuseForks>true</reuseForks>
+                            <systemPropertyVariables>
+                                <james.exit.on.startup.error>false</james.exit.on.startup.error>
+                            </systemPropertyVariables>
                             <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
                             <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
                         </configuration>

--- a/app/src/test/java/com/linagora/calendar/app/LdapTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/LdapTest.java
@@ -23,7 +23,6 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -48,7 +47,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.google.inject.Module;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavModuleTestHelper;
-import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.TechnicalTokenService;
 
@@ -83,7 +81,7 @@ class LdapTest {
 
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavExtension sabreDavExtension = SabreDavExtension.perClass();
 
     @RegisterExtension
     @Order(2)
@@ -123,42 +121,27 @@ class LdapTest {
             .body()
             .asString();
 
-        assertThatJson(body).withOptions(IGNORING_ARRAY_ORDER).isEqualTo("""
-            {
-               "status" : "healthy",
-               "checks" : [ {
-                 "componentName" : "Guice application lifecycle",
-                 "escapedComponentName" : "Guice%20application%20lifecycle",
-                 "status" : "healthy",
-                 "cause" : null
-               }, {
-                 "componentName" : "MongoDB",
-                 "escapedComponentName" : "MongoDB",
-                 "status" : "healthy",
-                 "cause" : null
-               }, {
-                 "componentName" : "LDAP User Server",
-                 "escapedComponentName" : "LDAP%20User%20Server",
-                 "status" : "healthy",
-                 "cause" : null
-               }, {
-                 "componentName" : "RabbitMQ backend",
-                 "escapedComponentName" : "RabbitMQ%20backend",
-                 "status" : "healthy",
-                 "cause" : null
-               }, {
-                 "componentName" : "CalendarQueueConsumers",
-                 "escapedComponentName" : "CalendarQueueConsumers",
-                 "status" : "healthy",
-                 "cause" : null
-               }, {
-                 "componentName" : "RabbitMQDeadLetterQueueEmptiness",
-                 "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
-                 "status" : "healthy",
-                 "cause" : null
-               } ]
-            }
-            """);
+        assertThatJson(body)
+            .inPath("checks")
+            .isArray()
+            .anySatisfy(node ->
+                assertThatJson(node).isEqualTo("""
+                    {
+                      "componentName" : "Guice application lifecycle",
+                      "escapedComponentName" : "Guice%20application%20lifecycle",
+                      "status" : "healthy",
+                      "cause" : null
+                    }
+                    """))
+            .anySatisfy(node ->
+                assertThatJson(node).isEqualTo("""
+                    {
+                      "componentName" : "LDAP User Server",
+                      "escapedComponentName" : "LDAP%20User%20Server",
+                      "status" : "healthy",
+                      "cause" : null
+                    }
+                    """));
     }
 
     @Test

--- a/app/src/test/java/com/linagora/calendar/app/MongoTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/MongoTest.java
@@ -22,7 +22,6 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
@@ -41,7 +40,6 @@ import org.mockserver.integration.ClientAndServer;
 import com.google.inject.name.Names;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavModuleTestHelper;
-import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -69,7 +67,7 @@ class MongoTest {
     private OpenPaaSId userId;
 
     @RegisterExtension
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavExtension sabreDavExtension = SabreDavExtension.perClass();
 
     @RegisterExtension
     TwakeCalendarExtension twakeCalendarExtension = new TwakeCalendarExtension(TwakeCalendarConfiguration.builder()
@@ -136,37 +134,27 @@ class MongoTest {
             .body()
             .asString();
 
-        assertThatJson(body).withOptions(IGNORING_ARRAY_ORDER).isEqualTo("""
-            {
-              "status" : "healthy",
-              "checks" : [ {
-                "componentName" : "Guice application lifecycle",
-                "escapedComponentName" : "Guice%20application%20lifecycle",
-                "status" : "healthy",
-                "cause" : null
-              }, {
-                "componentName" : "MongoDB",
-                "escapedComponentName" : "MongoDB",
-                "status" : "healthy",
-                "cause" : null
-              }, {
-                "componentName" : "RabbitMQ backend",
-                "escapedComponentName" : "RabbitMQ%20backend",
-                "status" : "healthy",
-                "cause" : null
-              }, {
-                "componentName" : "RabbitMQDeadLetterQueueEmptiness",
-                "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
-                "status" : "healthy",
-                "cause" : null
-              }, {
-                "componentName" : "CalendarQueueConsumers",
-                "escapedComponentName" : "CalendarQueueConsumers",
-                "status" : "healthy",
-                "cause" : null
-              } ]
-            }
-            """);
+        assertThatJson(body)
+            .inPath("checks")
+            .isArray()
+            .anySatisfy(node ->
+                assertThatJson(node).isEqualTo("""
+                    {
+                      "componentName" : "Guice application lifecycle",
+                      "escapedComponentName" : "Guice%20application%20lifecycle",
+                      "status" : "healthy",
+                      "cause" : null
+                    }
+                    """))
+            .anySatisfy(node ->
+                assertThatJson(node).isEqualTo("""
+                    {
+                      "componentName" : "MongoDB",
+                      "escapedComponentName" : "MongoDB",
+                      "status" : "healthy",
+                      "cause" : null
+                    }
+                    """));
     }
 
     private static void targetRestAPI(TwakeCalendarGuiceServer server) {

--- a/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
@@ -39,7 +39,6 @@ import com.google.inject.multibindings.Multibinder;
 import com.linagora.calendar.app.modules.ScheduledReconnectionHandler;
 import com.linagora.calendar.app.modules.ScheduledReconnectionHandler.RabbitMQManagementAPI;
 import com.linagora.calendar.app.modules.ScheduledReconnectionHandler.ScheduledReconnectionHandlerConfiguration;
-import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.amqp.EventIndexerConsumer;
 
@@ -50,7 +49,7 @@ public class ScheduledReconnectionHandlerTest {
         .with()
         .pollDelay(Duration.ofMillis(500))
         .await();
-    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(30, TimeUnit.SECONDS);
+    private final ConditionFactory awaitAtMost = calmlyAwait.atMost(60, TimeUnit.SECONDS);
 
     static class ScheduledReconnectionHandlerProbe implements GuiceProbe {
         private final ScheduledReconnectionHandler scheduledReconnectionHandler;
@@ -67,13 +66,9 @@ public class ScheduledReconnectionHandlerTest {
         }
     }
 
-    static {
-        System.setProperty("scheduled.consumer.reconnection.delayStartUp", "10s");
-    }
-
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavExtension sabreDavExtension = SabreDavExtension.perClass();
 
     @RegisterExtension
     @Order(2)

--- a/app/src/test/java/com/linagora/calendar/app/TwakeCalendarExtension.java
+++ b/app/src/test/java/com/linagora/calendar/app/TwakeCalendarExtension.java
@@ -31,6 +31,8 @@ import org.junit.rules.TemporaryFolder;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
 
+import io.restassured.RestAssured;
+
 public class TwakeCalendarExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
     private final TwakeCalendarConfiguration.Builder configuration;
@@ -53,8 +55,16 @@ public class TwakeCalendarExtension implements BeforeEachCallback, AfterEachCall
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext){
-        temporaryFolder.delete();
+    public void afterEach(ExtensionContext extensionContext) {
+        try {
+            if (server != null) {
+                server.stop();
+            }
+        } finally {
+            RestAssured.reset();
+            temporaryFolder.delete();
+            server = null;
+        }
     }
 
     @Override

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteTest.java
@@ -46,7 +46,6 @@ import com.linagora.calendar.app.TwakeCalendarExtension;
 import com.linagora.calendar.app.TwakeCalendarGuiceServer;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavTestHelper;
-import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.OpenPaaSUser;
 
@@ -59,7 +58,7 @@ class OpensearchDavCalendarSearchRouteTest implements CalendarSearchRouteContrac
 
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavExtension sabreDavExtension = SabreDavExtension.perClass();
 
     @RegisterExtension
     @Order(2)
@@ -267,43 +266,26 @@ class OpensearchDavCalendarSearchRouteTest implements CalendarSearchRouteContrac
             .asString();
 
         assertThatJson(body)
-            .withOptions(Option.IGNORING_ARRAY_ORDER)
-            .isEqualTo("""
-                {
-                   "status" : "healthy",
-                   "checks" : [ {
-                     "componentName" : "Guice application lifecycle",
-                     "escapedComponentName" : "Guice%20application%20lifecycle",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "MongoDB",
-                     "escapedComponentName" : "MongoDB",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "OpenSearch Backend",
-                     "escapedComponentName" : "OpenSearch%20Backend",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "RabbitMQ backend",
-                     "escapedComponentName" : "RabbitMQ%20backend",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "CalendarQueueConsumers",
-                     "escapedComponentName" : "CalendarQueueConsumers",
-                     "status" : "healthy",
-                     "cause" : null
-                   }, {
-                     "componentName" : "RabbitMQDeadLetterQueueEmptiness",
-                     "escapedComponentName" : "RabbitMQDeadLetterQueueEmptiness",
-                     "status" : "healthy",
-                     "cause" : null
-                   } ]
-                }
-                """);
+            .inPath("checks")
+            .isArray()
+            .anySatisfy(node ->
+                assertThatJson(node).isEqualTo("""
+                    {
+                      "componentName" : "Guice application lifecycle",
+                      "escapedComponentName" : "Guice%20application%20lifecycle",
+                      "status" : "healthy",
+                      "cause" : null
+                    }
+                    """))
+            .anySatisfy(node ->
+                assertThatJson(node).isEqualTo("""
+                    {
+                      "componentName" : "OpenSearch Backend",
+                      "escapedComponentName" : "OpenSearch%20Backend",
+                      "status" : "healthy",
+                      "cause" : null
+                    }
+                    """));
     }
 
     private RequestSpecification webAdminSpec(TwakeCalendarGuiceServer server) {

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
@@ -101,6 +101,10 @@ class WebsocketRouteTest {
     private static final ConditionFactory NEGATIVE_AWAIT = await()
         .during(1, SECONDS)
         .pollInterval(200, MILLISECONDS);
+    private static final OkHttpClient WS_CLIENT = new OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .build();
 
     static class EventBusProbe implements GuiceProbe {
         private final EventBus eventBus;
@@ -154,6 +158,9 @@ class WebsocketRouteTest {
     @AfterAll
     static void afterAll() {
         RestAssured.reset();
+        WS_CLIENT.dispatcher().cancelAll();
+        WS_CLIENT.connectionPool().evictAll();
+        WS_CLIENT.dispatcher().executorService().close();
     }
 
     private CalDavClient calDavClient;
@@ -186,9 +193,9 @@ class WebsocketRouteTest {
 
     @AfterEach
     void tearDown() {
-        if (webSocket != null) {
-            webSocket.close(1000, "test finished");
-        }
+        closeWebSocket(webSocket);
+        webSocket = null;
+        WS_CLIENT.dispatcher().cancelAll();
     }
 
     @Test
@@ -216,22 +223,24 @@ class WebsocketRouteTest {
     void websocketShouldRejectInvalidTicket() throws Exception {
         BlockingQueue<Throwable> errors = new LinkedBlockingQueue<>();
 
-        OkHttpClient client = new OkHttpClient.Builder().build();
-
         Request wsRequest = new Request.Builder()
             .url("ws://localhost:" + restApiPort + "/ws?ticket=INVALID")
             .build();
 
-        client.newWebSocket(wsRequest, new WebSocketListener() {
+        WebSocket invalidTicketWebSocket = WS_CLIENT.newWebSocket(wsRequest, new WebSocketListener() {
             @Override
             public void onFailure(@NotNull WebSocket webSocket, Throwable throwable, Response response) {
                 errors.offer(throwable);
             }
         });
 
-        Throwable result = errors.poll(3, TimeUnit.SECONDS);
-        assertThat(result)
-            .isNotNull();
+        try {
+            Throwable result = errors.poll(3, TimeUnit.SECONDS);
+            assertThat(result)
+                .isNotNull();
+        } finally {
+            closeWebSocket(invalidTicketWebSocket);
+        }
     }
 
     @Test
@@ -873,10 +882,12 @@ class WebsocketRouteTest {
         BlockingQueue<String> messages1 = new LinkedBlockingQueue<>();
         BlockingQueue<String> messages2 = new LinkedBlockingQueue<>();
 
-        WebSocket ws1 = connectWebSocket(restApiPort, generateTicket(bob), messages1);
-        WebSocket ws2 = connectWebSocket(restApiPort, generateTicket(bob), messages2);
-
+        WebSocket ws1 = null;
+        WebSocket ws2 = null;
         try {
+            ws1 = connectWebSocket(restApiPort, generateTicket(bob), messages1);
+            ws2 = connectWebSocket(restApiPort, generateTicket(bob), messages2);
+
             // And: both WS1 & WS2 register the same calendar
             ws1.send("""
                 { "register": ["%s"] }
@@ -925,8 +936,8 @@ class WebsocketRouteTest {
                     { "%s" : { "syncToken" : "${json-unit.ignore}" } }
                     """.formatted(calendarUri));
         } finally {
-            ws1.close(1000, "done");
-            ws2.close(1000, "done");
+            closeWebSocket(ws1);
+            closeWebSocket(ws2);
         }
     }
 
@@ -940,10 +951,12 @@ class WebsocketRouteTest {
         BlockingQueue<String> messages1 = new LinkedBlockingQueue<>();
         BlockingQueue<String> messages2 = new LinkedBlockingQueue<>();
 
-        WebSocket ws1 = connectWebSocket(restApiPort, generateTicket(bob), messages1);
-        WebSocket ws2 = connectWebSocket(restApiPort, generateTicket(bob), messages2);
-
+        WebSocket ws1 = null;
+        WebSocket ws2 = null;
         try {
+            ws1 = connectWebSocket(restApiPort, generateTicket(bob), messages1);
+            ws2 = connectWebSocket(restApiPort, generateTicket(bob), messages2);
+
             // And: WS1 registers calendar
             ws1.send("""
                 { "register": ["%s"] }
@@ -999,8 +1012,8 @@ class WebsocketRouteTest {
                     { "%s" : { "syncToken" : "${json-unit.ignore}" } }
                     """.formatted(calendarUri));
         } finally {
-            ws1.close(1000, "done");
-            ws2.close(1000, "done");
+            closeWebSocket(ws1);
+            closeWebSocket(ws2);
         }
     }
 
@@ -1179,10 +1192,12 @@ class WebsocketRouteTest {
         BlockingQueue<String> messages1 = new LinkedBlockingQueue<>();
         BlockingQueue<String> messages2 = new LinkedBlockingQueue<>();
 
-        WebSocket ws1 = connectWebSocket(restApiPort, generateTicket(bob), messages1);
-        WebSocket ws2 = connectWebSocket(restApiPort, generateTicket(bob), messages2);
-
+        WebSocket ws1 = null;
+        WebSocket ws2 = null;
         try {
+            ws1 = connectWebSocket(restApiPort, generateTicket(bob), messages1);
+            ws2 = connectWebSocket(restApiPort, generateTicket(bob), messages2);
+
             // WS1 enables display notification
             ws1.send("{\"enableDisplayNotification\": true}");
             awaitMessage(messages1, msg -> msg.contains("displayNotificationEnabled"));
@@ -1215,8 +1230,8 @@ class WebsocketRouteTest {
                         .noneSatisfy(msg -> assertThat(msg).contains("\"alarms\""));
                 });
         } finally {
-            ws1.close(1000, "done");
-            ws2.close(1000, "done");
+            closeWebSocket(ws1);
+            closeWebSocket(ws2);
         }
     }
 
@@ -1225,10 +1240,12 @@ class WebsocketRouteTest {
         BlockingQueue<String> messages1 = new LinkedBlockingQueue<>();
         BlockingQueue<String> messages2 = new LinkedBlockingQueue<>();
 
-        WebSocket ws1 = connectWebSocket(restApiPort, generateTicket(bob), messages1);
-        WebSocket ws2 = connectWebSocket(restApiPort, generateTicket(bob), messages2);
-
+        WebSocket ws1 = null;
+        WebSocket ws2 = null;
         try {
+            ws1 = connectWebSocket(restApiPort, generateTicket(bob), messages1);
+            ws2 = connectWebSocket(restApiPort, generateTicket(bob), messages2);
+
             // Both clients enable display notification
             ws1.send("{\"enableDisplayNotification\": true}");
             String ack1 = awaitMessage(messages1, msg -> msg.contains("displayNotificationEnabled"));
@@ -1259,8 +1276,8 @@ class WebsocketRouteTest {
                 .node("alarms[0].eventSummary")
                 .isStringEqualTo("Test Meeting");
         } finally {
-            ws1.close(1000, "done");
-            ws2.close(1000, "done");
+            closeWebSocket(ws1);
+            closeWebSocket(ws2);
         }
     }
 
@@ -1428,14 +1445,10 @@ class WebsocketRouteTest {
     }
 
     private WebSocket connectWebSocket(int port, String ticket, BlockingQueue<String> messages) {
-        OkHttpClient client = new OkHttpClient.Builder()
-            .connectTimeout(5, TimeUnit.SECONDS)
-            .readTimeout(10, TimeUnit.SECONDS)
-            .build();
         Request wsRequest = new Request.Builder()
             .url("ws://localhost:" + port + "/ws?ticket=" + ticket)
             .build();
-        WebSocket webSocket=  client.newWebSocket(wsRequest, new WebSocketListener() {
+        WebSocket webSocket = WS_CLIENT.newWebSocket(wsRequest, new WebSocketListener() {
             @Override
             public void onMessage(WebSocket webSocket, String text) {
                 messages.offer(text);
@@ -1445,6 +1458,14 @@ class WebsocketRouteTest {
         // warm up
         awaitMessage(messages, msg -> msg.contains("\"calendarListRegistered\""));
         return webSocket;
+    }
+
+    private void closeWebSocket(WebSocket webSocket) {
+        if (webSocket == null) {
+            return;
+        }
+        webSocket.close(1000, "test finished");
+        webSocket.cancel();
     }
 
     @Test

--- a/calendar-amqp/pom.xml
+++ b/calendar-amqp/pom.xml
@@ -156,7 +156,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <reuseForks>false</reuseForks>
+                    <forkCount>2</forkCount>
+                    <reuseForks>true</reuseForks>
                     <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
                     <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
                 </configuration>

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
@@ -163,7 +163,6 @@ public class CalendarDelegatedNotificationConsumerTest {
             .thenReturn(Mono.just(new SettingsBasedResolver.ResolvedSettings(
                 Map.of(LANGUAGE_IDENTIFIER, Locale.ENGLISH))));
         setupConsumer();
-        clearSmtpMock();
     }
 
     @AfterEach
@@ -209,11 +208,6 @@ public class CalendarDelegatedNotificationConsumerTest {
     private final Supplier<JsonPath> smtpMailsResponseSupplier = () -> given(mockSMTPRequestSpecification())
         .get("/smtpMails")
         .jsonPath();
-
-    private void clearSmtpMock() {
-        given(mockSMTPRequestSpecification()).delete("/smtpMails").then();
-        given(mockSMTPRequestSpecification()).delete("/smtpBehaviors").then();
-    }
 
     static RequestSpecification mockSMTPRequestSpecification() {
         return new RequestSpecBuilder()

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCancelEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCancelEmailConsumerTest.java
@@ -37,7 +37,6 @@ import java.nio.file.Paths;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Locale;
 import java.util.Map;
@@ -99,8 +98,6 @@ import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import net.fortuna.ical4j.model.parameter.PartStat;
 import reactor.core.publisher.Mono;
-import reactor.rabbitmq.QueueSpecification;
-import reactor.rabbitmq.Sender;
 
 public class EventCancelEmailConsumerTest {
     private final ConditionFactory calmlyAwait = Awaitility.with()
@@ -154,7 +151,7 @@ public class EventCancelEmailConsumerTest {
 
     private OpenPaaSUser organizer;
     private OpenPaaSUser attendee;
-    private Sender sender;
+    private EventEmailConsumer consumer;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -167,18 +164,15 @@ public class EventCancelEmailConsumerTest {
                     LANGUAGE_IDENTIFIER, Locale.ENGLISH,
                     TIMEZONE_IDENTIFIER, ZoneId.of("Asia/Ho_Chi_Minh")))));
 
+        sabreDavExtension.deleteRabbitMQQueues(EventEmailConsumer.QUEUE_NAME, EventEmailConsumer.DEAD_LETTER_QUEUE);
         setupEventEmailConsumer();
-        clearSmtpMock();
     }
 
     @AfterEach
     void afterEach() {
-        Arrays.stream(EventIndexerConsumer.Queue
-                .values())
-            .map(EventIndexerConsumer.Queue::queueName)
-            .forEach(queueName -> sender.delete(QueueSpecification.queue().name(queueName))
-                .block());
-
+        if (consumer != null) {
+            consumer.close();
+        }
         Mockito.reset(settingsResolver);
         Mockito.reset(eventEmailFilter);
     }
@@ -229,16 +223,10 @@ public class EventCancelEmailConsumerTest {
             usersRepository, resourceDAO, domainDAO,
             settingsResolver, actionLinkFactory);
 
-        EventEmailConsumer consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
+        consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
             eventEmailFilter, new RecordingMetricFactory());
         consumer.init();
 
-        sender = channelPool.getSender();
-    }
-
-    private void clearSmtpMock() {
-        given(mockSMTPRequestSpecification()).delete("/smtpMails").then();
-        given(mockSMTPRequestSpecification()).delete("/smtpBehaviors").then();
     }
 
     static RequestSpecification mockSMTPRequestSpecification() {
@@ -262,7 +250,7 @@ public class EventCancelEmailConsumerTest {
         awaitAtMost.atMost(Duration.ofSeconds(20))
             .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
 
-        clearSmtpMock();
+        mockSmtpExtension.clear();
 
         davTestHelper.deleteCalendar(organizer, eventUid);
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCounterEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCounterEmailConsumerTest.java
@@ -37,7 +37,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -97,8 +96,6 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import reactor.core.publisher.Mono;
-import reactor.rabbitmq.QueueSpecification;
-import reactor.rabbitmq.Sender;
 
 public class EventCounterEmailConsumerTest {
     private final ConditionFactory calmlyAwait = Awaitility.with()
@@ -152,25 +149,22 @@ public class EventCounterEmailConsumerTest {
 
     private OpenPaaSUser organizer;
     private OpenPaaSUser attendee;
-    private Sender sender;
+    private EventEmailConsumer consumer;
 
     @BeforeEach
     public void setUp() throws Exception {
         organizer = sabreDavExtension.newTestUser();
         attendee = sabreDavExtension.newTestUser();
 
+        sabreDavExtension.deleteRabbitMQQueues(EventEmailConsumer.QUEUE_NAME, EventEmailConsumer.DEAD_LETTER_QUEUE);
         setupEventEmailConsumer();
-        clearSmtpMock();
     }
 
     @AfterEach
     void afterEach() {
-        Arrays.stream(EventIndexerConsumer.Queue
-                .values())
-            .map(EventIndexerConsumer.Queue::queueName)
-            .forEach(queueName -> sender.delete(QueueSpecification.queue().name(queueName))
-                .block());
-
+        if (consumer != null) {
+            consumer.close();
+        }
         Mockito.reset(settingsResolver);
         Mockito.reset(eventEmailFilter);
     }
@@ -221,16 +215,10 @@ public class EventCounterEmailConsumerTest {
             settingsResolver,
             actionLinkFactory);
 
-        EventEmailConsumer consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
+        consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
             eventEmailFilter, new RecordingMetricFactory());
         consumer.init();
 
-        sender = channelPool.getSender();
-    }
-
-    private void clearSmtpMock() {
-        given(mockSMTPRequestSpecification()).delete("/smtpMails").then();
-        given(mockSMTPRequestSpecification()).delete("/smtpBehaviors").then();
     }
 
     static RequestSpecification mockSMTPRequestSpecification() {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventInviteEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventInviteEmailConsumerTest.java
@@ -36,7 +36,6 @@ import java.nio.file.Paths;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Locale;
 import java.util.Map;
@@ -100,8 +99,6 @@ import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import net.fortuna.ical4j.model.parameter.PartStat;
 import reactor.core.publisher.Mono;
-import reactor.rabbitmq.QueueSpecification;
-import reactor.rabbitmq.Sender;
 
 public class EventInviteEmailConsumerTest {
     static final boolean INTERNAL_USER = true;
@@ -158,7 +155,6 @@ public class EventInviteEmailConsumerTest {
 
     private OpenPaaSUser organizer;
     private OpenPaaSUser attendee;
-    private Sender sender;
     private UsersRepository usersRepository;
     private EventEmailConsumer consumer;
 
@@ -172,8 +168,8 @@ public class EventInviteEmailConsumerTest {
                 Map.of(
                     LANGUAGE_IDENTIFIER, Locale.ENGLISH,
                     TIMEZONE_IDENTIFIER, ZoneId.of("Asia/Ho_Chi_Minh")))));
+        sabreDavExtension.deleteRabbitMQQueues(EventEmailConsumer.QUEUE_NAME, EventEmailConsumer.DEAD_LETTER_QUEUE);
         setupEventEmailConsumer();
-        clearSmtpMock();
     }
 
     @AfterEach
@@ -181,13 +177,6 @@ public class EventInviteEmailConsumerTest {
         if (consumer != null) {
             consumer.close();
         }
-
-        Arrays.stream(EventIndexerConsumer.Queue
-                .values())
-            .map(EventIndexerConsumer.Queue::queueName)
-            .forEach(queueName -> sender.delete(QueueSpecification.queue().name(queueName))
-                .block());
-
         Mockito.reset(settingsResolver);
         Mockito.reset(eventEmailFilter);
     }
@@ -245,12 +234,6 @@ public class EventInviteEmailConsumerTest {
             eventEmailFilter, new RecordingMetricFactory());
         consumer.init();
 
-        sender = channelPool.getSender();
-    }
-
-    private void clearSmtpMock() {
-        given(mockSMTPRequestSpecification()).delete("/smtpMails").then();
-        given(mockSMTPRequestSpecification()).delete("/smtpBehaviors").then();
     }
 
     static RequestSpecification mockSMTPRequestSpecification() {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
@@ -36,7 +36,6 @@ import java.nio.file.Paths;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Locale;
@@ -101,7 +100,6 @@ import io.restassured.specification.RequestSpecification;
 import net.fortuna.ical4j.model.parameter.PartStat;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.OutboundMessage;
-import reactor.rabbitmq.QueueSpecification;
 import reactor.rabbitmq.Sender;
 
 public class EventPublicAgendaEmailConsumerTest {
@@ -178,8 +176,8 @@ public class EventPublicAgendaEmailConsumerTest {
                     LANGUAGE_IDENTIFIER, Locale.ENGLISH,
                     TIMEZONE_IDENTIFIER, ZoneId.of("Asia/Ho_Chi_Minh")))));
 
+        sabreDavExtension.deleteRabbitMQQueues(EventEmailConsumer.QUEUE_NAME, EventEmailConsumer.DEAD_LETTER_QUEUE);
         setupEventEmailConsumer();
-        clearSmtpMock();
     }
 
     @AfterEach
@@ -187,11 +185,6 @@ public class EventPublicAgendaEmailConsumerTest {
         if (consumer != null) {
             consumer.close();
         }
-
-        Arrays.stream(EventIndexerConsumer.Queue.values())
-            .map(EventIndexerConsumer.Queue::queueName)
-            .forEach(queueName -> sender.delete(QueueSpecification.queue().name(queueName)).block());
-
         Mockito.reset(settingsResolver);
         Mockito.reset(eventEmailFilter);
     }
@@ -250,11 +243,6 @@ public class EventPublicAgendaEmailConsumerTest {
         sender = channelPool.getSender();
     }
 
-    private void clearSmtpMock() {
-        given(mockSMTPRequestSpecification()).delete("/smtpMails").then();
-        given(mockSMTPRequestSpecification()).delete("/smtpBehaviors").then();
-    }
-
     static RequestSpecification mockSMTPRequestSpecification() {
         return new RequestSpecBuilder()
             .setPort(mockSmtpExtension.getMockSmtp().getRestApiPort())
@@ -283,7 +271,7 @@ public class EventPublicAgendaEmailConsumerTest {
         calmlyAwaitDuringNoEmail
             .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
 
-        clearSmtpMock();
+        mockSmtpExtension.clear();
         String updatedCalendarData = generatePublicAgendaCalendar(eventUid, organizer.username().asString(),
             attendee.username().asString(), PartStat.ACCEPTED, UPDATED_SEQUENCE);
         davTestHelper.upsertCalendar(organizer, updatedCalendarData, eventUid);
@@ -320,7 +308,7 @@ public class EventPublicAgendaEmailConsumerTest {
         calmlyAwaitDuringNoEmail
             .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
 
-        clearSmtpMock();
+        mockSmtpExtension.clear();
         String updatedCalendarData = generatePublicAgendaCalendar(eventUid, organizer.username().asString(),
             attendee.username().asString(), PartStat.NEEDS_ACTION, UPDATED_SEQUENCE);
         davTestHelper.upsertCalendar(organizer, updatedCalendarData, eventUid);
@@ -345,7 +333,7 @@ public class EventPublicAgendaEmailConsumerTest {
         calmlyAwaitDuringNoEmail
             .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
 
-        clearSmtpMock();
+        mockSmtpExtension.clear();
         String updatedCalendarData = generatePublicAgendaCalendar(eventUid, organizer.username().asString(),
             attendee.username().asString(), PartStat.ACCEPTED, UPDATED_SEQUENCE);
         davTestHelper.upsertCalendar(organizer, updatedCalendarData, eventUid);
@@ -377,7 +365,7 @@ public class EventPublicAgendaEmailConsumerTest {
             .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
 
         // When: organizer updates participation from NEEDS_ACTION to ACCEPTED.
-        clearSmtpMock();
+        mockSmtpExtension.clear();
         String updatedCalendarData = generatePublicAgendaCalendar(eventUid, organizer.username().asString(),
             attendee.username().asString(), PartStat.ACCEPTED, UPDATED_SEQUENCE, externalAttendeeEmail);
         davTestHelper.upsertCalendar(organizer, updatedCalendarData, eventUid);
@@ -415,7 +403,7 @@ public class EventPublicAgendaEmailConsumerTest {
             .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
 
         // When: organizer accepts the booking.
-        clearSmtpMock();
+        mockSmtpExtension.clear();
         String updatedCalendarData = generatePublicAgendaCalendar(eventUid, organizer.username().asString(),
             attendee.username().asString(), PartStat.ACCEPTED, UPDATED_SEQUENCE, additionalAttendeeEmail);
         davTestHelper.upsertCalendar(organizer, updatedCalendarData, eventUid);

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
@@ -40,7 +40,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -79,7 +78,6 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
 
 import com.github.fge.lambdas.Throwing;
-import com.linagora.calendar.smtp.EventEmailFilter;
 import com.linagora.calendar.api.EventParticipationActionLinkFactory;
 import com.linagora.calendar.api.Participation;
 import com.linagora.calendar.api.ParticipationTokenSigner;
@@ -89,6 +87,7 @@ import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.smtp.EventEmailFilter;
 import com.linagora.calendar.smtp.MailSender;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
 import com.linagora.calendar.smtp.MockSmtpServerExtension;
@@ -113,8 +112,6 @@ import io.restassured.specification.RequestSpecification;
 import net.fortuna.ical4j.model.parameter.PartStat;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.OutboundMessage;
-import reactor.rabbitmq.QueueSpecification;
-import reactor.rabbitmq.Sender;
 
 public class EventReplyEmailConsumerTest {
     private final ConditionFactory calmlyAwait = Awaitility.with()
@@ -170,7 +167,7 @@ public class EventReplyEmailConsumerTest {
     private MongoDBResourceDAO resourceDAO;
     private OpenPaaSUser organizer;
     private OpenPaaSUser attendee;
-    private Sender sender;
+    private EventEmailConsumer consumer;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -179,18 +176,15 @@ public class EventReplyEmailConsumerTest {
 
         when(settingsResolver.resolveOrDefault(any(Username.class), any(Username.class)))
             .thenReturn(Mono.just(SettingsBasedResolver.ResolvedSettings.DEFAULT));
+        sabreDavExtension.deleteRabbitMQQueues(EventEmailConsumer.QUEUE_NAME, EventEmailConsumer.DEAD_LETTER_QUEUE);
         setupEventEmailConsumer();
-        clearSmtpMock();
     }
 
     @AfterEach
     void afterEach() {
-        Arrays.stream(EventIndexerConsumer.Queue
-                .values())
-            .map(EventIndexerConsumer.Queue::queueName)
-            .forEach(queueName -> sender.delete(QueueSpecification.queue().name(queueName))
-                .block());
-
+        if (consumer != null) {
+            consumer.close();
+        }
         Mockito.reset(settingsResolver);
         Mockito.reset(eventEmailFilter);
     }
@@ -240,16 +234,10 @@ public class EventReplyEmailConsumerTest {
             settingsResolver,
             actionLinkFactory);
 
-        EventEmailConsumer consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
+        consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
             eventEmailFilter, new RecordingMetricFactory());
         consumer.init();
 
-        sender = channelPool.getSender();
-    }
-
-    private void clearSmtpMock() {
-        given(mockSMTPRequestSpecification()).delete("/smtpMails").then();
-        given(mockSMTPRequestSpecification()).delete("/smtpBehaviors").then();
     }
 
     static RequestSpecification mockSMTPRequestSpecification() {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
@@ -186,7 +186,6 @@ public class EventResourceConsumerTest {
                     LANGUAGE_IDENTIFIER, Locale.ENGLISH,
                     TIMEZONE_IDENTIFIER, ZoneId.of("Asia/Ho_Chi_Minh")))));
         setupEventResourceConsumer();
-        clearSmtpMock();
     }
 
     @AfterEach
@@ -247,11 +246,6 @@ public class EventResourceConsumerTest {
         consumer.init();
 
         sender = channelPool.getSender();
-    }
-
-    private void clearSmtpMock() {
-        given(mockSMTPRequestSpecification()).delete("/smtpMails").then();
-        given(mockSMTPRequestSpecification()).delete("/smtpBehaviors").then();
     }
 
     static RequestSpecification mockSMTPRequestSpecification() {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventUpdateEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventUpdateEmailConsumerTest.java
@@ -37,7 +37,6 @@ import java.nio.file.Paths;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Locale;
 import java.util.Map;
@@ -98,8 +97,6 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import reactor.core.publisher.Mono;
-import reactor.rabbitmq.QueueSpecification;
-import reactor.rabbitmq.Sender;
 
 public class EventUpdateEmailConsumerTest {
     private final ConditionFactory calmlyAwait = Awaitility.with()
@@ -153,7 +150,7 @@ public class EventUpdateEmailConsumerTest {
 
     private OpenPaaSUser organizer;
     private OpenPaaSUser attendee;
-    private Sender sender;
+    private EventEmailConsumer consumer;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -166,18 +163,15 @@ public class EventUpdateEmailConsumerTest {
                     LANGUAGE_IDENTIFIER, Locale.ENGLISH,
                     TIMEZONE_IDENTIFIER, ZoneId.of("Asia/Ho_Chi_Minh")))));
 
+        sabreDavExtension.deleteRabbitMQQueues(EventEmailConsumer.QUEUE_NAME, EventEmailConsumer.DEAD_LETTER_QUEUE);
         setupEventEmailConsumer();
-        clearSmtpMock();
     }
 
     @AfterEach
     void afterEach() {
-        Arrays.stream(EventIndexerConsumer.Queue
-                .values())
-            .map(EventIndexerConsumer.Queue::queueName)
-            .forEach(queueName -> sender.delete(QueueSpecification.queue().name(queueName))
-                .block());
-
+        if (consumer != null) {
+            consumer.close();
+        }
         Mockito.reset(settingsResolver);
         Mockito.reset(eventEmailFilter);
     }
@@ -230,16 +224,10 @@ public class EventUpdateEmailConsumerTest {
             settingsResolver,
             actionLinkFactory);
 
-        EventEmailConsumer consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
+        consumer = new EventEmailConsumer(channelPool, QueueArguments.Builder::new, mailHandler,
             eventEmailFilter, new RecordingMetricFactory());
         consumer.init();
 
-        sender = channelPool.getSender();
-    }
-
-    private void clearSmtpMock() {
-        given(mockSMTPRequestSpecification()).delete("/smtpMails").then();
-        given(mockSMTPRequestSpecification()).delete("/smtpBehaviors").then();
     }
 
     static RequestSpecification mockSMTPRequestSpecification() {
@@ -267,7 +255,7 @@ public class EventUpdateEmailConsumerTest {
         awaitAtMost.atMost(Duration.ofSeconds(20))
             .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
 
-        clearSmtpMock();
+        mockSmtpExtension.clear();
 
         String updatedCalendarData = generateCalendarData(
             eventUid,

--- a/calendar-dav/pom.xml
+++ b/calendar-dav/pom.xml
@@ -127,7 +127,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <reuseForks>false</reuseForks>
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
                     <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
                     <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
                 </configuration>

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/DavModuleTestHelper.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/DavModuleTestHelper.java
@@ -61,7 +61,7 @@ public class DavModuleTestHelper {
                 .maxRetries(3)
                 .minDelayInMs(10)
                 .connectionTimeoutInMs(100)
-                .channelRpcTimeoutInMs(100)
+                .channelRpcTimeoutInMs(5000)
                 .handshakeTimeoutInMs(100)
                 .shutdownTimeoutInMs(100)
                 .networkRecoveryIntervalInMs(100)

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/DockerSabreDavSetup.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/DockerSabreDavSetup.java
@@ -19,6 +19,9 @@
 
 package com.linagora.calendar.dav;
 
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+import static org.mockserver.model.HttpResponse.response;
+
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -33,24 +36,35 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
 import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.bson.UuidRepresentation;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.HttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ComposeContainer;
 import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.base.Preconditions;
+import com.linagora.calendar.storage.TechnicalTokenService;
 import com.linagora.calendar.storage.mongodb.MongoDBConfiguration;
-import com.linagora.calendar.storage.mongodb.MongoDBConnectionFactory;
+import com.linagora.calendar.storage.mongodb.MongoCommandMetricsListener;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 
+import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
 public class DockerSabreDavSetup {
     public static final DockerSabreDavSetup SINGLETON = new DockerSabreDavSetup();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DockerSabreDavSetup.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public enum DockerService {
         MOCK_ESN("esn", 1080),
@@ -82,6 +96,13 @@ public class DockerSabreDavSetup {
 
     private final ComposeContainer environment;
     private SabreDavProvisioningService sabreDavProvisioningService;
+    private MockServerClient mockServerClient;
+    private MongoClient mongoClient;
+    private MongoDatabase mongoDatabase;
+    private volatile boolean started;
+    private volatile boolean stopped;
+    private boolean mockAuthenticationTokenEndpointConfigured;
+    private volatile Thread shutdownHook;
 
     public DockerSabreDavSetup() {
         try {
@@ -103,20 +124,88 @@ public class DockerSabreDavSetup {
         }
     }
 
-    public void start() {
-        environment.start();
-        for (DockerService dockerService : DockerService.values()) {
-            LOGGER.debug("Started service: {} with mapping port: {}", dockerService.serviceName(), getPort(dockerService));
+    public synchronized void start() {
+        if (started) {
+            LOGGER.debug("Sabre DAV Docker Compose stack already started");
+            return;
         }
-        sabreDavProvisioningService = new SabreDavProvisioningService(getMongoDbIpAddress().toString());
+        Preconditions.checkState(!stopped, "DockerSabreDavSetup was already stopped and cannot be reused.");
+        
+        try {
+            environment.start();
+            for (DockerService dockerService : DockerService.values()) {
+                LOGGER.debug("Started service: {} with mapping port: {}", dockerService.serviceName(), getPort(dockerService));
+            }
+            mongoClient = newMongoClient();
+            mongoDatabase = mongoClient.getDatabase(SabreDavProvisioningService.DATABASE);
+            sabreDavProvisioningService = new SabreDavProvisioningService(mongoDatabase);
+            started = true;
+        } catch (RuntimeException e) {
+            stopNow();
+            throw e;
+        }
     }
 
     public void stop() {
+        stopNow();
+    }
+
+    private synchronized void stopNow() {
+        if (mockServerClient != null) {
+            mockServerClient.close();
+            mockServerClient = null;
+        }
+        mockAuthenticationTokenEndpointConfigured = false;
+        if (mongoClient != null) {
+            mongoClient.close();
+            mongoClient = null;
+            mongoDatabase = null;
+        }
         environment.stop();
+        sabreDavProvisioningService = null;
+        started = false;
+        stopped = true;
+    }
+
+    synchronized void stopOnJvmExit() {
+        if (shutdownHook == null) {
+            shutdownHook = new Thread(this::stopNow, "calendar-dav-docker-compose-shutdown");
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+        }
     }
 
     public ContainerState getRabbitMqContainer() {
         return environment.getContainerByServiceName(DockerService.RABBITMQ.serviceName()).orElseThrow();
+    }
+
+    public synchronized MockServerClient getMockServerClient() {
+        Preconditions.checkState(started, "Sabre DAV Docker Compose stack should be started before creating MockServerClient");
+        if (mockServerClient == null) {
+            mockServerClient = new MockServerClient(getHost(DockerService.MOCK_ESN), getPort(DockerService.MOCK_ESN));
+        }
+        return mockServerClient;
+    }
+
+    public synchronized void setupMockAuthenticationTokenEndpoint() {
+        if (mockAuthenticationTokenEndpointConfigured) {
+            return;
+        }
+
+        MockServerClient client = getMockServerClient();
+        client.when(HttpRequest.request()
+                .withMethod("GET")
+                .withPath("/api/technicalToken/introspect"))
+            .respond(httpRequest -> {
+                String token = httpRequest.getFirstHeader("X-TECHNICAL-TOKEN");
+                return response()
+                    .withStatusCode(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(TECHNICAL_TOKEN_SERVICE_TESTING.claim(new TechnicalTokenService.JwtToken(token))
+                        .map(Throwing.function(tokenInfo -> objectMapper.writeValueAsString(tokenInfo.data())))
+                        .onErrorResume(e -> Mono.just("error: " + e.getMessage()))
+                        .block());
+            });
+        mockAuthenticationTokenEndpointConfigured = true;
     }
 
     public URI rabbitMqUri() {
@@ -192,7 +281,18 @@ public class DockerSabreDavSetup {
     }
 
     public MongoDatabase getMongoDB() {
-        return MongoDBConnectionFactory.instantiateDB(mongoDBConfiguration(), new RecordingMetricFactory());
+        return Preconditions.checkNotNull(mongoDatabase, "MongoDB not initialized");
+    }
+
+    private MongoClient newMongoClient() {
+        MongoDBConfiguration configuration = mongoDBConfiguration();
+        MongoClientSettings settings = MongoClientSettings.builder()
+            .applyConnectionString(new ConnectionString(configuration.mongoURL()))
+            .addCommandListener(new MongoCommandMetricsListener(new RecordingMetricFactory()))
+            .uuidRepresentation(UuidRepresentation.STANDARD)
+            .build();
+
+        return MongoClients.create(settings);
     }
 
     public RabbitMQConfiguration rabbitMQConfiguration() {
@@ -203,7 +303,7 @@ public class DockerSabreDavSetup {
             .maxRetries(3)
             .minDelayInMs(10)
             .connectionTimeoutInMs(100)
-            .channelRpcTimeoutInMs(100)
+            .channelRpcTimeoutInMs(5000)
             .handshakeTimeoutInMs(100)
             .shutdownTimeoutInMs(100)
             .networkRecoveryIntervalInMs(100)

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/SabreDavExtension.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/SabreDavExtension.java
@@ -26,12 +26,13 @@
 
 package com.linagora.calendar.dav;
 
-import static com.linagora.calendar.dav.DockerSabreDavSetup.DockerService.MOCK_ESN;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static com.rabbitmq.client.BuiltinExchangeType.FANOUT;
-import static org.mockserver.model.HttpResponse.response;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.net.ssl.SSLException;
@@ -44,15 +45,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
-import org.mockserver.client.MockServerClient;
-import org.mockserver.model.HttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.storage.OpenPaaSUser;
-import com.linagora.calendar.storage.TechnicalTokenService;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
 import com.linagora.calendar.storage.mongodb.MongoDBResourceDAO;
@@ -67,37 +63,89 @@ import reactor.rabbitmq.RabbitFlux;
 import reactor.rabbitmq.Sender;
 import reactor.rabbitmq.SenderOptions;
 
-public record SabreDavExtension(DockerSabreDavSetup dockerSabreDavSetup) implements BeforeAllCallback, AfterAllCallback,
+public record SabreDavExtension(DockerSabreDavSetup dockerSabreDavSetup, DockerLifecycle dockerLifecycle) implements BeforeAllCallback, AfterAllCallback,
     AfterEachCallback, ParameterResolver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SabreDavExtension.class);
+    private static final String DEFAULT_VHOST = "%2F";
     private static final List<String> CLEANUP_COLLECTIONS = List.of(
         MongoDBOpenPaaSDomainDAO.COLLECTION,
         MongoDBOpenPaaSUserDAO.COLLECTION,
         MongoDBUploadedFileDAO.COLLECTION,
         MongoDBSecretLinkStore.COLLECTION,
         MongoDBResourceDAO.COLLECTION);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static MockServerClient mockServerClient;
+
+    public enum DockerLifecycle {
+        SHARED {
+            @Override
+            void beforeAll(DockerSabreDavSetup dockerSabreDavSetup) {
+                dockerSabreDavSetup.start();
+                dockerSabreDavSetup.stopOnJvmExit();
+            }
+
+            @Override
+            void afterAll(DockerSabreDavSetup dockerSabreDavSetup) {
+            }
+        },
+        PER_CLASS {
+            @Override
+            void beforeAll(DockerSabreDavSetup dockerSabreDavSetup) {
+                dockerSabreDavSetup.start();
+            }
+
+            @Override
+            void afterAll(DockerSabreDavSetup dockerSabreDavSetup) {
+                dockerSabreDavSetup.stop();
+            }
+        };
+
+        abstract void beforeAll(DockerSabreDavSetup dockerSabreDavSetup);
+
+        abstract void afterAll(DockerSabreDavSetup dockerSabreDavSetup);
+    }
+
+    public SabreDavExtension(DockerSabreDavSetup dockerSabreDavSetup) {
+        this(dockerSabreDavSetup, DockerLifecycle.SHARED);
+    }
+
+    public static SabreDavExtension shared() {
+        return new SabreDavExtension(DockerSabreDavSetup.SINGLETON, DockerLifecycle.SHARED);
+    }
+
+    public static SabreDavExtension perClass() {
+        return new SabreDavExtension(new DockerSabreDavSetup(), DockerLifecycle.PER_CLASS);
+    }
+
+    public SabreDavExtension {
+        Objects.requireNonNull(dockerSabreDavSetup);
+        Objects.requireNonNull(dockerLifecycle);
+        if (dockerLifecycle == DockerLifecycle.SHARED && dockerSabreDavSetup != DockerSabreDavSetup.SINGLETON) {
+            throw new IllegalArgumentException("SHARED requires DockerSabreDavSetup.SINGLETON. Use SabreDavExtension.perClass() for a dedicated stack.");
+        }
+        if (dockerLifecycle == DockerLifecycle.PER_CLASS && dockerSabreDavSetup == DockerSabreDavSetup.SINGLETON) {
+            throw new IllegalArgumentException("PER_CLASS requires a dedicated DockerSabreDavSetup. Use SabreDavExtension.perClass().");
+        }
+    }
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
-        dockerSabreDavSetup.start();
-        mockServerClient = new MockServerClient(dockerSabreDavSetup.getHost(MOCK_ESN), dockerSabreDavSetup.getPort(MOCK_ESN));
+        dockerLifecycle.beforeAll(dockerSabreDavSetup);
         provisionQueueExchanges();
-        setupMockAuthenticationTokenEndpoint();
+        dockerSabreDavSetup.setupMockAuthenticationTokenEndpoint();
     }
 
     @Override
     public void afterAll(ExtensionContext extensionContext) {
-        if (mockServerClient != null) {
-            mockServerClient.close();
-        }
-        dockerSabreDavSetup.stop();
+        dockerLifecycle.afterAll(dockerSabreDavSetup);
     }
 
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
+        cleanupMongoCollections();
+        provisionQueueExchanges();
+    }
+
+    private void cleanupMongoCollections() {
         MongoDatabase mongoDatabase = dockerSabreDavSetup.getMongoDB();
         for (String collection : CLEANUP_COLLECTIONS) {
             Mono.from(mongoDatabase.getCollection(collection).deleteMany(new Document())).block();
@@ -127,23 +175,6 @@ public record SabreDavExtension(DockerSabreDavSetup dockerSabreDavSetup) impleme
         return openPaasUser;
     }
 
-    private void setupMockAuthenticationTokenEndpoint() {
-        mockServerClient
-            .when(HttpRequest.request()
-                .withMethod("GET")
-                .withPath("/api/technicalToken/introspect"))
-            .respond(httpRequest -> {
-                String token = httpRequest.getFirstHeader("X-TECHNICAL-TOKEN");
-                return response()
-                    .withStatusCode(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(TECHNICAL_TOKEN_SERVICE_TESTING.claim(new TechnicalTokenService.JwtToken(token))
-                        .map(Throwing.function(tokenInfo -> objectMapper.writeValueAsString(tokenInfo.data())))
-                        .onErrorResume(e -> Mono.just("error: " + e.getMessage()))
-                        .block());
-            });
-    }
-
     private void provisionQueueExchanges() {
         LOGGER.debug("Provisioning RabbitMQ exchanges...");
         try {
@@ -165,6 +196,33 @@ public record SabreDavExtension(DockerSabreDavSetup dockerSabreDavSetup) impleme
         } catch (Exception e) {
             throw new RuntimeException("Failed to provision RabbitMQ exchanges", e);
         }
+    }
+
+    public void deleteRabbitMQQueues(String... queueNames) {
+        for (String queueName : queueNames) {
+            deleteRabbitMQQueue(queueName);
+        }
+    }
+
+    private void deleteRabbitMQQueue(String queueName) {
+        dockerSabreDavSetup.rabbitmqAdminHttpclient()
+            .delete()
+            .uri("/api/queues/" + DEFAULT_VHOST + "/" + encode(queueName))
+            .responseSingle((response, body) -> {
+                int statusCode = response.status().code();
+                if (statusCode == 204 || statusCode == 404) {
+                    return Mono.empty();
+                }
+                return body.asString(StandardCharsets.UTF_8)
+                    .defaultIfEmpty("")
+                    .flatMap(errorBody -> Mono.error(new IllegalStateException(
+                        "Failed to delete RabbitMQ queue " + queueName + ": " + statusCode + " " + errorBody)));
+            })
+            .block();
+    }
+
+    private String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 
     public DavTestHelper davTestHelper() {

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/SabreDavProvisioningService.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/SabreDavProvisioningService.java
@@ -36,7 +36,6 @@ import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
-import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 
 import reactor.core.publisher.Mono;
@@ -47,10 +46,6 @@ public class SabreDavProvisioningService {
 
     private final MongoDBOpenPaaSDomainDAO domainDAO;
     private final MongoDBOpenPaaSUserDAO userDAO;
-
-    public SabreDavProvisioningService(String mongoUri) {
-        this(MongoClients.create(mongoUri).getDatabase(DATABASE));
-    }
 
     public SabreDavProvisioningService(MongoDatabase database) {
         domainDAO = new MongoDBOpenPaaSDomainDAO(database);

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/SabreDavProvisioningService.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/SabreDavProvisioningService.java
@@ -36,7 +36,6 @@ import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
-import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 
@@ -50,8 +49,10 @@ public class SabreDavProvisioningService {
     private final MongoDBOpenPaaSUserDAO userDAO;
 
     public SabreDavProvisioningService(String mongoUri) {
-        MongoClient mongoClient = MongoClients.create(mongoUri);
-        MongoDatabase database = mongoClient.getDatabase(DATABASE);
+        this(MongoClients.create(mongoUri).getDatabase(DATABASE));
+    }
+
+    public SabreDavProvisioningService(MongoDatabase database) {
         domainDAO = new MongoDBOpenPaaSDomainDAO(database);
         userDAO = new MongoDBOpenPaaSUserDAO(database, domainDAO);
 

--- a/calendar-smtp/src/test/java/com/linagora/calendar/smtp/MockSmtpServerExtension.java
+++ b/calendar-smtp/src/test/java/com/linagora/calendar/smtp/MockSmtpServerExtension.java
@@ -25,8 +25,8 @@ import org.apache.james.util.Host;
 import org.apache.james.util.docker.DockerContainer;
 import org.apache.james.util.docker.Images;
 import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-public class MockSmtpServerExtension implements AfterEachCallback, BeforeAllCallback,
+public class MockSmtpServerExtension implements BeforeEachCallback, BeforeAllCallback,
     AfterAllCallback, ParameterResolver {
 
     public static class DockerMockSmtp {
@@ -90,7 +90,11 @@ public class MockSmtpServerExtension implements AfterEachCallback, BeforeAllCall
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) throws Exception {
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        clear();
+    }
+
+    public void clear() {
         dockerMockSmtp.getConfigurationClient()
             .cleanServer();
     }

--- a/calendar-webadmin/pom.xml
+++ b/calendar-webadmin/pom.xml
@@ -130,7 +130,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <reuseForks>false</reuseForks>
+                    <forkCount>4</forkCount>
+                    <reuseForks>true</reuseForks>
                     <!-- Fail tests longer than 20 minutes, prevent form random locking tests -->
                     <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
                 </configuration>

--- a/storage-mongodb/src/test/java/com/linagora/calendar/storage/mongodb/DockerMongoDBExtension.java
+++ b/storage-mongodb/src/test/java/com/linagora/calendar/storage/mongodb/DockerMongoDBExtension.java
@@ -21,14 +21,18 @@ package com.linagora.calendar.storage.mongodb;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.james.metrics.tests.RecordingMetricFactory;
 import org.bson.Document;
+import org.bson.UuidRepresentation;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.MongoDBContainer;
 
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 
 import reactor.core.publisher.Mono;
@@ -63,6 +67,9 @@ public class DockerMongoDBExtension implements BeforeAllCallback, AfterAllCallba
 
     @Override
     public void afterAll(ExtensionContext extensionContext) throws Exception {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
         mongoDBContainer.stop();
     }
 
@@ -84,11 +91,22 @@ public class DockerMongoDBExtension implements BeforeAllCallback, AfterAllCallba
     }
 
     private static MongoDatabase db;
+    private static MongoClient mongoClient;
 
     static void init() {
         mongoDBConfiguration = new MongoDBConfiguration(mongoDBContainer.getConnectionString() + "/?socketTimeoutMS=3000", "esn_docker");
-        db = MongoDBConnectionFactory.instantiateDB(mongoDBConfiguration, new RecordingMetricFactory());
+        mongoClient = instantiateClient(mongoDBConfiguration);
+        db = mongoClient.getDatabase(mongoDBConfiguration.database());
         MongoDBCollectionFactory.initialize(db);
+    }
+
+    private static MongoClient instantiateClient(MongoDBConfiguration configuration) {
+        MongoClientSettings settings = MongoClientSettings.builder()
+            .applyConnectionString(new ConnectionString(configuration.mongoURL()))
+            .uuidRepresentation(UuidRepresentation.STANDARD)
+            .build();
+
+        return MongoClients.create(settings);
     }
 
     public static MongoDBConfiguration getMongoDBConfiguration() {


### PR DESCRIPTION
WIP
need to polish 

draft result 
```
[INFO] Twake Calendar Side service ........................ SUCCESS [  0.386 s]
[INFO] Twake Calendar :: Side service :: API .............. SUCCESS [  4.445 s]
[INFO] Twake Calendar :: Storage service :: API ........... SUCCESS [ 20.687 s]
[INFO] Twake Calendar :: Storage service :: MongoDB ....... SUCCESS [01:05 min]
[INFO] Twake Calendar :: Side service :: Dav .............. SUCCESS [01:35 min]
[INFO] Twake Calendar :: Side service :: SMTP ............. SUCCESS [ 21.747 s]
[INFO] Twake Calendar :: Side service :: AMQP ............. SUCCESS [06:58 min]
[INFO] Twake Calendar :: Redis ............................ SUCCESS [01:27 min]
[INFO] Twake Calendar :: Side service :: Rest API ......... SUCCESS [  4.886 s]
[INFO] Twake Calendar :: Storage service :: Opensearch .... SUCCESS [02:35 min]
[INFO] Twake Calendar :: Storage service :: LDAP .......... SUCCESS [ 40.647 s]
[INFO] Twake Calendar :: Side service :: Web Admin ........ SUCCESS [02:02 min]
[INFO] Twake Calendar :: Side service :: Scheduling ....... SUCCESS [01:05 min]
[INFO] Twake Calendar :: Utility .......................... SUCCESS [ 19.634 s]
[INFO] Twake Calendar :: SaaS :: RabbitMQ ................. SUCCESS [ 44.206 s]
[INFO] Twake Calendar :: Side service :: App .............. SUCCESS [18:41 min]
```

Some issues encountered during the improvement work:

- Each JVM fork runs its own “shared” Docker Compose stack throughout the test execution.
- Some test classes still need a dedicated Docker Compose stack, for example `ScheduledReconnectionHandlerTest`. We should add support for a dedicated `per_class` mode.
- We need tighter control over resource cleanup in `afterAll`: WebSocket connections, Mongo connections, and RabbitMQ queues.
- Refactor the setup flow for Mock ESN and Mock SMTP, and clean them up properly.
- Jenkins nodes have 32 GB of RAM. I am experimenting with `forkCount > 1` for the `app` and `calendar-amqp` modules to see if we can get better results.