### PR TITLE
ISSUE-743 fix(calendar-amqp): skip malformed attendee properties when deserialize

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventFieldConverter.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventFieldConverter.java
@@ -28,6 +28,8 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apache.commons.lang3.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -50,6 +52,8 @@ import com.linagora.calendar.storage.event.EventFields;
 import com.linagora.calendar.storage.eventsearch.CalendarEvents;
 
 public class EventFieldConverter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventFieldConverter.class);
+
     private static final ObjectMapper MAPPER = new ObjectMapper()
         .registerModule(new SimpleModule().addDeserializer(EventProperty.class, new EventPropertyDeserializer()));
 
@@ -147,17 +151,29 @@ public class EventFieldConverter {
                 ArrayNode veventProps = (ArrayNode) component.get(1);
                 return StreamSupport.stream(veventProps.spliterator(), false)
                     .map(EventFieldConverter::deserializeEventProperty)
+                    .flatMap(Optional::stream)
                     .collect(Collectors.toList());
             })
             .collect(Collectors.toList());
     }
 
-    private static EventProperty deserializeEventProperty(JsonNode node) {
+    private static Optional<EventProperty> deserializeEventProperty(JsonNode node) {
         try {
-            return MAPPER.treeToValue(node, EventProperty.class);
-        } catch (JsonProcessingException e) {
+            return Optional.of(MAPPER.treeToValue(node, EventProperty.class));
+        } catch (JsonProcessingException | RuntimeException e) {
+            if (isEventProperty(node, EventProperty.ATTENDEE_PROPERTY)) {
+                LOGGER.warn("Skipping invalid attendee event property: {}", node, e);
+                return Optional.empty();
+            }
             throw new CalendarEventDeserializeException("Cannot deserialize EventProperty" + node.toPrettyString(), e);
         }
+    }
+
+    private static boolean isEventProperty(JsonNode node, String propertyName) {
+        return node.isArray()
+            && !node.isEmpty()
+            && node.get(0).isTextual()
+            && propertyName.equalsIgnoreCase(node.get(0).asText());
     }
 
     public static class EventPropertyDeserializer extends JsonDeserializer<EventProperty> {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventFieldConverterTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventFieldConverterTest.java
@@ -1588,4 +1588,78 @@ public class EventFieldConverterTest {
 
         assertThat(eventFieldsActual).isEqualTo(eventFieldsExpected);
     }
+
+    @Test
+    void fromCreatedMessageShouldKeepEventFieldsWhenOnlyAttendeesAreMalformed() throws AddressException {
+        String json = """
+            {
+                "eventPath": "/calendars/6801fcef72cc50005a04e5fb/6801fcef72cc50005a04e5fb/malformed-attendee-event.ics",
+                "event": [
+                    "vcalendar",
+                    [["version", {}, "text", "2.0"]],
+                    [[
+                        "vevent",
+                        [
+                            ["uid", {}, "text", "malformed-attendee-event"],
+                            ["dtstart", {"tzid": "Asia/Saigon"}, "date-time", "2025-04-19T11:00:00"],
+                            ["dtend", {"tzid": "Asia/Saigon"}, "date-time", "2025-04-19T11:30:00"],
+                            ["summary", {}, "text", "Malformed attendee event"],
+                            ["organizer", {"cn": "John1 Doe1"}, "cal-address", "mailto:user1@open-paas.org"],
+                            ["attendee", {"cutype": "INDIVIDUAL", "cn": "Radia OUBRAHAM"}, "cal-address", "mailto:Radia%20OUBRAHAM%20%3Croubraham@example.ltd%3E"],
+                            ["dtstamp", {}, "date-time", "2025-04-18T07:47:48Z"]
+                        ],
+                        []
+                    ]]
+                ],
+                "import": false
+            }""";
+
+        CalendarEventMessage createdMessage = CalendarEventMessage.CreatedOrUpdated.deserialize(json.getBytes(StandardCharsets.UTF_8));
+
+        Set<EventFields> eventProperties = EventFieldConverter.from(createdMessage).events();
+
+        assertThat(eventProperties).hasSize(1);
+        EventFields eventFieldsActual = eventProperties.iterator().next();
+        EventFields.Person expectedOrganizer = EventFields.Person.of("John1 Doe1", "user1@open-paas.org");
+        assertSoftly(softly -> {
+            softly.assertThat(eventFieldsActual.uid()).isEqualTo(new EventUid("malformed-attendee-event"));
+            softly.assertThat(eventFieldsActual.summary()).isEqualTo("Malformed attendee event");
+            softly.assertThat(eventFieldsActual.start()).isEqualTo(Instant.parse("2025-04-19T04:00:00Z"));
+            softly.assertThat(eventFieldsActual.end()).isEqualTo(Instant.parse("2025-04-19T04:30:00Z"));
+            softly.assertThat(eventFieldsActual.dtStamp()).isEqualTo(Instant.parse("2025-04-18T07:47:48Z"));
+            softly.assertThat(eventFieldsActual.organizer()).isEqualTo(expectedOrganizer);
+            softly.assertThat(eventFieldsActual.attendees()).isEmpty();
+        });
+    }
+
+    @Test
+    void fromDeletedMessageShouldExtractUidWhenAttendeeIsMalformed() {
+        String json = """
+            {
+                "eventPath": "/calendars/6801fcef72cc50005a04e5fb/6801fcef72cc50005a04e5fb/malformed-attendee-event.ics",
+                "event": [
+                    "vcalendar",
+                    [["version", {}, "text", "2.0"]],
+                    [[
+                        "vevent",
+                        [
+                            ["uid", {}, "text", "malformed-attendee-event"],
+                            ["dtstart", {"tzid": "Asia/Saigon"}, "date-time", "2025-04-19T11:00:00"],
+                            ["dtend", {"tzid": "Asia/Saigon"}, "date-time", "2025-04-19T11:30:00"],
+                            ["summary", {}, "text", "Malformed attendee event"],
+                            ["organizer", {"cn": "John1 Doe1"}, "cal-address", "mailto:user1@open-paas.org"],
+                            ["attendee", {"cutype": "INDIVIDUAL", "cn": "Radia OUBRAHAM"}, "cal-address", "mailto:Radia%20OUBRAHAM%20%3Croubraham@example.ltd%3E"],
+                            ["dtstamp", {}, "date-time", "2025-04-18T07:47:48Z"]
+                        ],
+                        []
+                    ]]
+                ],
+                "import": false
+            }""";
+
+        CalendarEventMessage.Deleted deletedMessage = CalendarEventMessage.Deleted.deserialize(json.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(deletedMessage.extractEventUid())
+            .containsExactly(new EventUid("malformed-attendee-event"));
+    }
 }


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/743

Malformed ATTENDEE fields now log a warning and are ignored during VEVENT property extraction instead of failing the full conversion.