### PR TITLE
perf(calendar-amqp): Allow EventFieldConverter to deserialize only selected VEVENT properties

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarEventMessage.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarEventMessage.java
@@ -94,7 +94,7 @@ public abstract class CalendarEventMessage {
         }
 
         public List<EventUid> extractEventUid() {
-            return EventFieldConverter.extractVEventProperties(calendarEvent)
+            return EventFieldConverter.extractVEventProperties(calendarEvent, EventProperty.UID_PROPERTY)
                 .stream().flatMap(List::stream)
                 .filter(property -> property instanceof EventProperty.EventUidProperty)
                 .map(property -> ((EventProperty.EventUidProperty) property).getEventUid())

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
@@ -161,7 +161,7 @@ public class EventAlarmHandler {
     }
 
     private EventUid extractEventUid(CalendarAlarmMessageDTO alarmMessageDTO) {
-        return EventFieldConverter.extractVEventProperties(alarmMessageDTO.calendarEvent())
+        return EventFieldConverter.extractVEventProperties(alarmMessageDTO.calendarEvent(), EventProperty.UID_PROPERTY)
             .stream().flatMap(List::stream)
             .filter(property -> property instanceof EventProperty.EventUidProperty)
             .map(property -> ((EventProperty.EventUidProperty) property).getEventUid())

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventFieldConverter.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventFieldConverter.java
@@ -138,6 +138,14 @@ public class EventFieldConverter {
     }
 
     public static List<List<EventProperty>> extractVEventProperties(JsonNode calendarEvent) {
+        return extractVEventProperties(calendarEvent, List.of());
+    }
+
+    public static List<List<EventProperty>> extractVEventProperties(JsonNode calendarEvent, String... propertyNames) {
+        return extractVEventProperties(calendarEvent, List.of(propertyNames));
+    }
+
+    private static List<List<EventProperty>> extractVEventProperties(JsonNode calendarEvent, List<String> propertyNames) {
         if (!calendarEvent.isArray() || calendarEvent.size() < 3 || !"vcalendar".equalsIgnoreCase(calendarEvent.get(0).asText())) {
             throw new CalendarEventDeserializeException("Not a valid vcalendar array structure" + calendarEvent.toPrettyString());
         }
@@ -150,11 +158,18 @@ public class EventFieldConverter {
             .map(component -> {
                 ArrayNode veventProps = (ArrayNode) component.get(1);
                 return StreamSupport.stream(veventProps.spliterator(), false)
+                    .filter(node -> shouldExtractEventProperty(node, propertyNames))
                     .map(EventFieldConverter::deserializeEventProperty)
                     .flatMap(Optional::stream)
                     .collect(Collectors.toList());
             })
             .collect(Collectors.toList());
+    }
+
+    private static boolean shouldExtractEventProperty(JsonNode node, List<String> propertyNames) {
+        return propertyNames.isEmpty()
+            || propertyNames.stream()
+            .anyMatch(propertyName -> isEventProperty(node, propertyName));
     }
 
     private static Optional<EventProperty> deserializeEventProperty(JsonNode node) {


### PR DESCRIPTION
Some flows only need the event UID but previously deserialized every VEVENT property first. 
Filtering before deserialization reduces unnecessary work and avoids touching unrelated malformed fields in UID-only paths.
