### PR TITLE
fix(webadmin): limit calendar reindex export concurrency

### DIFF
--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/CalendarRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/CalendarRoutes.java
@@ -20,6 +20,7 @@ package com.linagora.calendar.webadmin;
 
 import static com.linagora.calendar.webadmin.CalendarRoutesModule.USER_CALENDAR_TASKS_KEY;
 import static com.linagora.calendar.webadmin.EventArchivalCriteriaRequestParser.extractEventArchivalCriteria;
+import static com.linagora.calendar.webadmin.task.CalendarEventsReindexTask.RunningOptions.DEFAULT_CALENDARS_CONCURRENCY;
 import static com.linagora.calendar.webadmin.task.RunningOptions.DEFAULT_EVENTS_PER_SECOND;
 
 import java.time.Clock;
@@ -57,6 +58,7 @@ import spark.Service;
 
 public class CalendarRoutes implements Routes {
     private static final String EVENTS_PER_SECOND_PARAMETER = "eventsPerSecond";
+    private static final String CALENDARS_CONCURRENCY_PARAMETER = "calendarsConcurrency";
     private static final String TASK_PARAMETER = "task";
 
     public static class CalendarEventsReindexRequestToTask extends TaskFromRequestRegistry.TaskRegistration {
@@ -65,8 +67,10 @@ public class CalendarRoutes implements Routes {
         @Inject
         public CalendarEventsReindexRequestToTask(CalendarEventsReindexService reindexService) {
             super(TASK_NAME, request -> {
-                int usersPerSecond = extractEventsPerSecond(request);
-                return new CalendarEventsReindexTask(reindexService, RunningOptions.of(usersPerSecond));
+                int eventsPerSecond = extractEventsPerSecond(request);
+                int calendarsConcurrency = extractCalendarsConcurrency(request);
+                return new CalendarEventsReindexTask(reindexService,
+                    CalendarEventsReindexTask.RunningOptions.of(eventsPerSecond, calendarsConcurrency));
             });
         }
     }
@@ -171,19 +175,27 @@ public class CalendarRoutes implements Routes {
     }
 
     private static Integer extractEventsPerSecond(Request request) {
+        return extractPositiveIntegerParameter(request, EVENTS_PER_SECOND_PARAMETER, DEFAULT_EVENTS_PER_SECOND);
+    }
+
+    private static Integer extractCalendarsConcurrency(Request request) {
+        return extractPositiveIntegerParameter(request, CALENDARS_CONCURRENCY_PARAMETER, DEFAULT_CALENDARS_CONCURRENCY);
+    }
+
+    private static Integer extractPositiveIntegerParameter(Request request, String parameterName, int defaultValue) {
         try {
-            return Optional.ofNullable(request.queryParams(EVENTS_PER_SECOND_PARAMETER))
+            return Optional.ofNullable(request.queryParams(parameterName))
                 .map(Integer::parseInt)
-                .map(eventPerSecond -> {
-                    Preconditions.checkArgument(eventPerSecond > 0,
-                        "Query parameter '%s' must be strictly positive, got: %d", EVENTS_PER_SECOND_PARAMETER, eventPerSecond);
-                    return eventPerSecond;
+                .map(value -> {
+                    Preconditions.checkArgument(value > 0,
+                        "Query parameter '%s' must be strictly positive, got: %d", parameterName, value);
+                    return value;
                 })
-                .orElse(DEFAULT_EVENTS_PER_SECOND);
+                .orElse(defaultValue);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException(String.format(
                 "Illegal value supplied for query parameter '%s', expecting an integer",
-                EVENTS_PER_SECOND_PARAMETER), e);
+                parameterName), e);
         }
     }
 

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/CalendarEventsReindexService.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/CalendarEventsReindexService.java
@@ -19,7 +19,6 @@
 package com.linagora.calendar.webadmin.service;
 
 import static com.linagora.calendar.webadmin.CalendarRoutes.CalendarEventsReindexRequestToTask.TASK_NAME;
-import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.time.Duration;
 import java.util.List;
@@ -43,6 +42,7 @@ import com.linagora.calendar.storage.event.EventFields;
 import com.linagora.calendar.storage.event.EventParseUtils;
 import com.linagora.calendar.storage.eventsearch.CalendarEvents;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchService;
+import com.linagora.calendar.webadmin.task.CalendarEventsReindexTask;
 
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.component.VEvent;
@@ -114,11 +114,11 @@ public class CalendarEventsReindexService {
         this.calDavClient = calDavClient;
     }
 
-    public Mono<Task.Result> reindex(Context context, int eventsPerSecond) {
+    public Mono<Task.Result> reindex(Context context, CalendarEventsReindexTask.RunningOptions runningOptions) {
         return userDAO.list()
-            .flatMap(user -> collectEvents(context, user), DEFAULT_CONCURRENCY)
+            .concatMap(user -> collectEvents(context, user, runningOptions.calendarsConcurrency()))
             .transform(ReactorUtils.<IndexItem, Task.Result>throttle()
-                .elements(eventsPerSecond)
+                .elements(runningOptions.eventsPerSecond())
                 .per(Duration.ofSeconds(1))
                 .forOperation(indexItem -> reindex(context, indexItem)))
             .reduce(Task.Result.COMPLETED, Task::combine)
@@ -149,11 +149,11 @@ public class CalendarEventsReindexService {
             });
     }
 
-    private Flux<IndexItem> collectEvents(Context context, OpenPaaSUser user) {
+    private Flux<IndexItem> collectEvents(Context context, OpenPaaSUser user, int calendarsConcurrency) {
         return calendarSearchService.deleteAll(AccountId.fromUsername(user.username()))
             .then(Mono.fromRunnable(() -> LOGGER.info("{} task deleted all events of user {}", TASK_NAME.asString(), user.username())))
             .thenMany(calDavClient.findUserCalendars(user.username(), user.id())
-                .flatMap(calendarURL -> collectEvents(context, user, calendarURL)))
+                .flatMap(calendarURL -> collectEvents(context, user, calendarURL), calendarsConcurrency))
             .onErrorResume(e -> {
                 LOGGER.error("Error while doing task {} for user {}", TASK_NAME.asString(), user.username().asString(), e);
                 context.incrementFailedUser();
@@ -163,6 +163,8 @@ public class CalendarEventsReindexService {
 
     private Flux<IndexItem> collectEvents(Context context, OpenPaaSUser user, CalendarURL calendarURL) {
         return calDavClient.export(calendarURL, user.username())
+            .doOnNext(bytes -> LOGGER.debug("{} task exported calendar {} for user {} with {} bytes",
+                TASK_NAME.asString(), calendarURL.serialize(), user.username().asString(), bytes.length))
             .flatMap(bytes -> Mono.fromCallable(() -> CalendarUtil.parseIcs(bytes))
                 .subscribeOn(Schedulers.boundedElastic()))
             .flatMapMany(calendar -> collectEvents(context, user, calendarURL, calendar))

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarEventsReindexTask.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarEventsReindexTask.java
@@ -26,6 +26,7 @@ import org.apache.james.task.Task;
 import org.apache.james.task.TaskExecutionDetails;
 import org.apache.james.task.TaskType;
 
+import com.google.common.base.Preconditions;
 import com.linagora.calendar.webadmin.service.CalendarEventsReindexService;
 
 public class CalendarEventsReindexTask implements Task {
@@ -33,6 +34,25 @@ public class CalendarEventsReindexTask implements Task {
         @Override
         public Instant timestamp() {
             return instant;
+        }
+    }
+
+    public record RunningOptions(int eventsPerSecond,
+                                 int calendarsConcurrency) {
+        public static final int DEFAULT_EVENTS_PER_SECOND = com.linagora.calendar.webadmin.task.RunningOptions.DEFAULT_EVENTS_PER_SECOND;
+        public static final int DEFAULT_CALENDARS_CONCURRENCY = 1;
+
+        public static final RunningOptions DEFAULT = of(
+            DEFAULT_EVENTS_PER_SECOND,
+            DEFAULT_CALENDARS_CONCURRENCY);
+
+        public RunningOptions {
+            Preconditions.checkArgument(eventsPerSecond > 0, "eventsPerSecond must be strictly positive");
+            Preconditions.checkArgument(calendarsConcurrency > 0, "calendarsConcurrency must be strictly positive");
+        }
+
+        public static RunningOptions of(int eventsPerSecond, int calendarsConcurrency) {
+            return new RunningOptions(eventsPerSecond, calendarsConcurrency);
         }
     }
 
@@ -50,7 +70,7 @@ public class CalendarEventsReindexTask implements Task {
 
     @Override
     public Result run() {
-        return reindexService.reindex(context, runningOptions.eventsPerSecond()).block();
+        return reindexService.reindex(context, runningOptions).block();
     }
 
     @Override

--- a/docs/apis/webadmin.md
+++ b/docs/apis/webadmin.md
@@ -200,12 +200,14 @@ Both endpoints will return a webadmin task with the following additional informa
 ### Calendar event reindexing
 
 ```
-POST /calendars?task=reindex?eventsPerSecond=100
+POST /calendars?task=reindex&eventsPerSecond=100&calendarsConcurrency=1
 ```
 
-Will iterate all registered user calendar and reindex their events.
+Will iterate all registered user calendars and reindex their events.
 
-The query parameter `eventsPerSecond` controls the concurrency. Defaults to 100.
+The query parameter `eventsPerSecond` controls the indexing rate. Defaults to 100.
+
+The query parameter `calendarsConcurrency` controls how many calendars can be exported and parsed concurrently for a user. Defaults to 1.
 
 This endpoint returns a webdmin task with the following additional information:
 


### PR DESCRIPTION
Add `calendarsConcurrency` to the calendar event reindex task so CalDAV export and ICS parsing can be throttled separately from indexing rate. Default to one calendar at a time to reduce heap pressure during reindex.

// This PR was created after the app crashed in production due to insufficient Java heap memory while running the calendar events reindex task.