### PR TITLE
ISSUE-757 - Fix deserialize DefaultCalendarPublicVisibility

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarAmqpModule.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarAmqpModule.java
@@ -212,8 +212,8 @@ public class CalendarAmqpModule extends AbstractModule {
     @Named("defaultCalendarPublicVisibility")
     DefaultCalendarPublicVisibility provideDefaultCalendarPublicVisibilityEnabled(PropertiesProvider propertiesProvider) throws ConfigurationException, FileNotFoundException {
         Configuration config = propertiesProvider.getConfiguration("configuration");
-        return Optional.ofNullable(config.getString("default.calendar.public.visibility"))
-            .map(DefaultCalendarPublicVisibility::valueOf)
+        return Optional.ofNullable(config.getString("default.calendar.public.visibility", null))
+            .map(DefaultCalendarPublicVisibility::deserialize)
             .orElse(DefaultCalendarPublicVisibility.PRIVATE);
     }
 


### PR DESCRIPTION
Resolved Guice error occurring during server startup.

```
09:06:40.672 [ERROR] c.l.c.a.TwakeCalendarGuiceServer - Fatal error while starting Twake Calendar side server
2026-06-01T09:06:40.729577304Z java.lang.IllegalArgumentException: No enum constant com.linagora.calendar.storage.DefaultCalendarPublicVisibility.read
2026-06-01T09:06:40.729578888Z 	at java.base/java.lang.Enum.valueOf(Unknown Source)
2026-06-01T09:06:40.729581638Z 	at com.linagora.calendar.storage.DefaultCalendarPublicVisibility.valueOf(DefaultCalendarPublicVisibility.java:21)
2026-06-01T09:06:40.729582513Z 	at java.base/java.util.Optional.map(Unknown Source)
2026-06-01T09:06:40.729583179Z 	at com.linagora.calendar.amqp.CalendarAmqpModule.provideDefaultCalendarPublicVisibilityEnabled(CalendarAmqpModule.java:216)
```