### PR TITLE
Revert "ISSUE-765 fix(search): stop consuming `request` and `cancel` queues"

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
@@ -117,6 +117,8 @@ public class ScheduledReconnectionHandlerTest {
             .containsExactlyInAnyOrder("tcalendar:event:created:search",
                 "tcalendar:event:updated:search",
                 "tcalendar:event:deleted:search",
+                "tcalendar:event:cancel:search",
+                "tcalendar:event:request:search",
                 "tcalendar:event:alarm:created",
                 "tcalendar:event:alarm:updated",
                 "tcalendar:event:alarm:deleted",

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventIndexerConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventIndexerConsumer.java
@@ -74,12 +74,11 @@ public class EventIndexerConsumer implements Closeable, Startable {
     public enum Queue {
         ADD("calendar:event:created", "tcalendar:event:created:search", "tcalendar:event:created:search-dead-letter"),
         UPDATE("calendar:event:updated", "tcalendar:event:updated:search", "tcalendar:event:updated:search-dead-letter"),
-        DELETE("calendar:event:deleted", "tcalendar:event:deleted:search", "tcalendar:event:deleted:search-dead-letter");
-        /* Search indexing intentionally ignores:
-         * - `calendar:event:request`: Sabre 4.7 also emits an equivalent `calendar:event:updated`
-         * - `calendar:event:cancel`: Sabre 4.7 also emits an equivalent `calendar:event:deleted`
-         * - `calendar:event:reply`: eventSearch does not rely on attendee partstat changes
-         */
+        DELETE("calendar:event:deleted", "tcalendar:event:deleted:search", "tcalendar:event:deleted:search-dead-letter"),
+        CANCEL("calendar:event:cancel", "tcalendar:event:cancel:search", "tcalendar:event:cancel:search-dead-letter"),
+        REQUEST("calendar:event:request", "tcalendar:event:request:search", "tcalendar:event:request:search-dead-letter");
+        /* Ignored the `calendar:event:reply`, which is triggered exclusively when an attendee updates their participation status (partstat).
+        Since eventSearch does not rely on partstat, this queue is not required. */
 
         private final String exchangeName;
         private final String queueName;
@@ -163,6 +162,8 @@ public class EventIndexerConsumer implements Closeable, Startable {
         consumeDisposableMap.put(Queue.ADD, doConsumeCalendarEventMessages(Queue.ADD, handlerAdd));
         consumeDisposableMap.put(Queue.UPDATE, doConsumeCalendarEventMessages(Queue.UPDATE, handlerAddOrUpdate));
         consumeDisposableMap.put(Queue.DELETE, doConsumeCalendarEventMessages(Queue.DELETE, handlerDelete));
+        consumeDisposableMap.put(Queue.CANCEL, doConsumeCalendarEventMessages(Queue.CANCEL, handlerDelete));
+        consumeDisposableMap.put(Queue.REQUEST, doConsumeCalendarEventMessages(Queue.REQUEST, handlerAddOrUpdate));
     }
 
     public void restart() {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
@@ -873,8 +873,8 @@ public class EventIndexerConsumerTest {
     class FailureTest {
 
         @ParameterizedTest
-        @ValueSource(strings = {"calendar:event:created", "calendar:event:updated"})
-        void consumeShouldNotCrashOnMalformedMessageOnIndexQueues(String exchangeName) {
+        @ValueSource(strings = {"calendar:event:created", "calendar:event:updated", "calendar:event:request"})
+        void consumeShouldNotCrashOnMalformedMessageOnCreatedAndUpdatedQueues(String exchangeName) {
             channelPool.getSender()
                 .send(Mono.just(new OutboundMessage(exchangeName,
                     EMPTY_ROUTING_KEY,
@@ -889,8 +889,8 @@ public class EventIndexerConsumerTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {"calendar:event:deleted"})
-        void consumeOnMalformedMessageOnDeleteQueue(String exchangeName) {
+        @ValueSource(strings = {"calendar:event:deleted", "calendar:event:cancel"})
+        void consumeOnMalformedMessageOnDeletedAndCancelQueues(String exchangeName) {
             String eventUid = UUID.randomUUID().toString();
             String calendarData = getSampleCalendar(eventUid);
             davTestHelper.upsertCalendar(openPaasUser, calendarData, eventUid);

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -4,29 +4,6 @@ This document describes breaking changes and migration steps required when upgra
 
 ## 2.2.0 (upcoming)
 
-### Removed obsolete search queues
-
-Date: 02/06/2026
-
-The search indexer no longer binds the search queues
-`tcalendar:event:request:search` and `tcalendar:event:cancel:search`
-For Sabre 4.7, equivalent search payloads are already delivered through
-the existing search queues bound to exchange `calendar:event:updated` and `calendar:event:deleted`.
-
-#### Breaking Change
-
-Old deployments may still have these `:search` bindings and queues.
-If left in place, messages will keep accumulating there with no consumer.
-
-#### Required Actions
-
-After all calendar-side-service instances have been upgraded, delete these obsolete search queues:
-
-- `tcalendar:event:request:search`
-- `tcalendar:event:request:search-dead-letter`
-- `tcalendar:event:cancel:search`
-- `tcalendar:event:cancel:search-dead-letter`
-
 ### Added resourceName field to Calendar Event index mapping
 
 Date: 13/05/2026


### PR DESCRIPTION
Reverts linagora/twake-calendar-side-service#770

We missed a case related to subscribed calendars.
If we remove consumption of `request` and `cancel`, subscribed calendars will not be index -> will not be found.

**Example scenario:**
- Bob subscribes to Cedric’s calendar. 
- Alice creates an event and invites Cedric. 
- Bob’s subscribed copy can see the event, 
- but when searching across all calendars, that event will not appear.

AMQP publishes the event for Bob, and it goes through `calendar:event:request`, (not `calendar:event:updated`)