### PR TITLE
chore - update docker sample - fix nginx config

### DIFF
--- a/app/docker-sample/docker-compose.yml
+++ b/app/docker-sample/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 services:
   tcalendar-frontend:
     image: linagora/twake-calendar-web:branch-master
-    container_name: twake_calendar_frontend
+    container_name: calendar-ng.linagora.local
     networks:
       - tcalendar
     ports:
@@ -163,6 +163,9 @@ services:
   web-proxy:
     image: nginx:alpine
     hostname: nginx.local
+    command: >
+      /bin/sh -c 'until getent hosts tcalendar-frontend >/dev/null;
+      do sleep 1; done; exec nginx -g "daemon off;"'
     ports:
       - "443:443"
     volumes:

--- a/app/docker-sample/nginx/nginx.conf
+++ b/app/docker-sample/nginx/nginx.conf
@@ -81,12 +81,12 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
-        proxy_set_header Host localhost:3000;
+        proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto https;
         proxy_cache_bypass $http_upgrade;
 
-        proxy_pass http://host.docker.internal:3000;
+        proxy_pass http://tcalendar-frontend:80;
     }
 }
 


### PR DESCRIPTION
- Replace `proxy_pass http://host.docker.internal:3000` with `proxy_pass http://tcalendar-frontend:80` for support some linux