### PR TITLE
ISSUE-87 Searching delegated events: resolve calendar search sources from DAV list

### DIFF
--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
@@ -187,6 +187,10 @@ public class CalDavClient extends DavClient {
             .flatMapIterable(response -> response.calendars().keySet());
     }
 
+    public Mono<CalendarListResponse> findUserCalendarList(OpenPaaSUser user) {
+        return findUserCalendars(user.username(), user.id(), DEFAULT_FIND_USER_CALENDARS_PARAMS);
+    }
+
     public Mono<CalendarListResponse> findUserCalendars(Username userRequest, OpenPaaSId userId, Map<String, String> queryParams) {
         Preconditions.checkArgument(userRequest != null, "userRequest must not be null");
         Preconditions.checkArgument(userId != null, "userId must not be null");

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalendarSearchSourceResolver.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalendarSearchSourceResolver.java
@@ -39,6 +39,7 @@ import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 
+import it.unimi.dsi.fastutil.Pair;
 import reactor.core.publisher.Mono;
 
 public class CalendarSearchSourceResolver {
@@ -66,15 +67,15 @@ public class CalendarSearchSourceResolver {
         this.calDavClient = calDavClient;
     }
 
-    public Mono<List<CalendarURL>> resolve(OpenPaaSUser requester, List<CalendarURL> requestedCalendars) {
+    public Mono<Map<CalendarURL, CalendarURL>> resolve(OpenPaaSUser requester, List<CalendarURL> requestedCalendars) {
         Preconditions.checkNotNull(requester, "requester must not be null");
         Preconditions.checkNotNull(requestedCalendars, "requestedCalendars must not be null");
 
         if (requestedCalendars.isEmpty()) {
-            return Mono.just(List.of());
+            return Mono.just(Map.of());
         }
         if (isSingleRequesterDefaultCalendar(requester.id(), requestedCalendars)) {
-            return Mono.just(requestedCalendars);
+            return Mono.just(Map.of(requestedCalendars.getFirst(), requestedCalendars.getFirst()));
         }
         return calDavClient.findUserCalendarList(requester)
             .map(this::extractCalendarListEntries)
@@ -86,8 +87,8 @@ public class CalendarSearchSourceResolver {
             && requestedCalendars.contains(CalendarURL.from(requesterId));
     }
 
-    private List<CalendarURL> resolveSearchSourceCalendarURLs(List<CalendarURL> requestedCalendars,
-                                                              List<CalendarListEntry> calendarListEntries) {
+    private Map<CalendarURL, CalendarURL> resolveSearchSourceCalendarURLs(List<CalendarURL> requestedCalendars,
+                                                                          List<CalendarListEntry> calendarListEntries) {
 
         Map<CalendarURL, CalendarURL> searchSourceByCalendarListURL = calendarListEntries.stream()
             .collect(Collectors.toMap(CalendarListEntry::calendarListURL, CalendarListEntry::searchSourceCalendarURL,
@@ -96,10 +97,9 @@ public class CalendarSearchSourceResolver {
         Set<CalendarURL> allowedSearchSourceCalendarURLs = Set.copyOf(searchSourceByCalendarListURL.values());
 
         return requestedCalendars.stream()
-            .map(requestedCalendar -> searchSourceByCalendarListURL.getOrDefault(requestedCalendar, requestedCalendar))
-            .filter(allowedSearchSourceCalendarURLs::contains)
-            .distinct()
-            .toList();
+            .map(requestedCalendar -> Pair.of(requestedCalendar, searchSourceByCalendarListURL.getOrDefault(requestedCalendar, requestedCalendar)))
+            .filter(pair -> allowedSearchSourceCalendarURLs.contains(pair.right()))
+            .collect(Collectors.toMap(Pair::left, Pair::right, (firstSearchSource, _) -> firstSearchSource));
     }
 
     private List<CalendarListEntry> extractCalendarListEntries(CalendarListResponse calendarListResponse) {

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalendarSearchSourceResolver.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalendarSearchSourceResolver.java
@@ -1,0 +1,129 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import com.linagora.calendar.dav.dto.CalendarListResponse;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.OpenPaaSUser;
+
+import reactor.core.publisher.Mono;
+
+public class CalendarSearchSourceResolver {
+    private static final String JSON_EXTENSION = ".json";
+
+    private static final Function<JsonNode, Optional<CalendarURL>> SUBSCRIBED_CALENDAR_SOURCE_URL = metadata ->
+        Optional.ofNullable(metadata.path("calendarserver:source")
+                .path("_links")
+                .path("self")
+                .path("href").asText(null))
+            .filter(StringUtils::isNotBlank)
+            .map(URI::create)
+            .map(CalendarSearchSourceResolver::toCalendarURL);
+
+    private static final Function<JsonNode, Optional<CalendarURL>> DELEGATED_CALENDAR_SOURCE_URL = metadata ->
+        Optional.ofNullable(metadata.path("calendarserver:delegatedsource").asText(null))
+            .filter(StringUtils::isNotBlank)
+            .map(URI::create)
+            .map(CalendarSearchSourceResolver::toCalendarURL);
+
+    private final CalDavClient calDavClient;
+
+    @Inject
+    public CalendarSearchSourceResolver(CalDavClient calDavClient) {
+        this.calDavClient = calDavClient;
+    }
+
+    public Mono<List<CalendarURL>> resolve(OpenPaaSUser requester, List<CalendarURL> requestedCalendars) {
+        Preconditions.checkNotNull(requester, "requester must not be null");
+        Preconditions.checkNotNull(requestedCalendars, "requestedCalendars must not be null");
+
+        if (requestedCalendars.isEmpty()) {
+            return Mono.just(List.of());
+        }
+        if (isSingleRequesterDefaultCalendar(requester.id(), requestedCalendars)) {
+            return Mono.just(requestedCalendars);
+        }
+        return calDavClient.findUserCalendarList(requester)
+            .map(this::extractCalendarListEntries)
+            .map(calendarListEntries -> resolveSearchSourceCalendarURLs(requestedCalendars, calendarListEntries));
+    }
+
+    private boolean isSingleRequesterDefaultCalendar(OpenPaaSId requesterId, List<CalendarURL> requestedCalendars) {
+        return requestedCalendars.size() == 1
+            && requestedCalendars.contains(CalendarURL.from(requesterId));
+    }
+
+    private List<CalendarURL> resolveSearchSourceCalendarURLs(List<CalendarURL> requestedCalendars,
+                                                              List<CalendarListEntry> calendarListEntries) {
+
+        Map<CalendarURL, CalendarURL> searchSourceByCalendarListURL = calendarListEntries.stream()
+            .collect(Collectors.toMap(CalendarListEntry::calendarListURL, CalendarListEntry::searchSourceCalendarURL,
+                (first, _) -> first, LinkedHashMap::new));
+
+        Set<CalendarURL> allowedSearchSourceCalendarURLs = Set.copyOf(searchSourceByCalendarListURL.values());
+
+        return requestedCalendars.stream()
+            .map(requestedCalendar -> searchSourceByCalendarListURL.getOrDefault(requestedCalendar, requestedCalendar))
+            .filter(allowedSearchSourceCalendarURLs::contains)
+            .distinct()
+            .toList();
+    }
+
+    private List<CalendarListEntry> extractCalendarListEntries(CalendarListResponse calendarListResponse) {
+        return calendarListResponse.calendars()
+            .entrySet()
+            .stream()
+            .map(calendarListEntry -> new CalendarListEntry(
+                calendarListEntry.getKey(),
+                SUBSCRIBED_CALENDAR_SOURCE_URL.apply(calendarListEntry.getValue()),
+                DELEGATED_CALENDAR_SOURCE_URL.apply(calendarListEntry.getValue())))
+            .toList();
+    }
+
+    private static CalendarURL toCalendarURL(URI sourceHref) {
+        return CalendarURL.parse(Strings.CS.removeEnd(sourceHref.getPath(), JSON_EXTENSION));
+    }
+
+    private record CalendarListEntry(CalendarURL calendarListURL,
+                                     Optional<CalendarURL> subscribedSourceCalendarURL,
+                                     Optional<CalendarURL> delegatedSourceCalendarURL) {
+        private CalendarURL searchSourceCalendarURL() {
+            return subscribedSourceCalendarURL
+                .or(() -> delegatedSourceCalendarURL)
+                .orElse(calendarListURL);
+        }
+    }
+}

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSearchSourceResolverTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSearchSourceResolverTest.java
@@ -191,8 +191,8 @@ class CalendarSearchSourceResolverTest {
 
         // Then all readable calendars are kept and the not readable calendar is filtered.
         assertThat(result)
-            .describedAs("Resolver should keep all readable calendars in request order and filter unreadable calendars")
-            .containsExactly(
+            .describedAs("Resolver should keep all readable calendars and filter unreadable calendars")
+            .containsOnly(
                 entry(ownCalendar, ownCalendar),
                 entry(subscribedSourceCalendar, subscribedSourceCalendar),
                 entry(delegatedSourceCalendar, delegatedSourceCalendar));

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSearchSourceResolverTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSearchSourceResolverTest.java
@@ -55,6 +55,8 @@ class CalendarSearchSourceResolverTest {
     private CalDavClient calDavClient;
     private MongoDBResourceDAO resourceDAO;
     private CalendarSearchSourceResolver testee;
+    private OpenPaaSUser requester;
+    private OpenPaaSUser sourceUser;
 
     @BeforeAll
     static void setUp() throws SSLException {
@@ -66,14 +68,14 @@ class CalendarSearchSourceResolverTest {
         calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
         resourceDAO = new MongoDBResourceDAO(sabreDavExtension.dockerSabreDavSetup().getMongoDB(), Clock.systemUTC());
         testee = new CalendarSearchSourceResolver(calDavClient);
+        requester = sabreDavExtension.newTestUser();
+        sourceUser = sabreDavExtension.newTestUser();
     }
 
     @Test
     void resolveShouldFilterCalendarWithoutReadAccess() {
         // Given one readable calendar and one not readable calendar.
-        OpenPaaSUser requester = sabreDavExtension.newTestUser();
-        OpenPaaSUser other = sabreDavExtension.newTestUser();
-        CalendarURL notReadableCalendar = createCalendar(other, "not-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
+        CalendarURL notReadableCalendar = createCalendar(sourceUser, "not-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
         CalendarURL readableCalendar = CalendarURL.from(requester.id());
 
         // When resolving the search sources.
@@ -88,24 +90,11 @@ class CalendarSearchSourceResolverTest {
     @Test
     void resolveShouldTranslateSubscribedMirrorCalendarToSourceCalendar() {
         // Given subscribed mirror A/B points to source D/E.
-        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
-        OpenPaaSUser subscriber = sabreDavExtension.newTestUser();
-
-        String sourceCalendarId = "source-" + UUID.randomUUID();
-        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.READ);
-
-        String subscribedCalendarId = "subscribed-" + UUID.randomUUID();
-        CalendarURL requestedCalendar = davTestHelper.subscribeToSharedCalendar(subscriber, SubscribedCalendarRequest.builder()
-            .id(subscribedCalendarId)
-            .sourceUserId(sourceUser.id().value())
-            .sourceCalendarId(sourceCalendarId)
-            .name("Subscribed source")
-            .color("#123456")
-            .readOnly(true)
-            .build());
+        CalendarURL sourceCalendar = createSubscribedSourceCalendar();
+        CalendarURL requestedCalendar = findMirrorCalendar(requester);
 
         // When resolving A/B.
-        List<CalendarURL> result = testee.resolve(subscriber, List.of(requestedCalendar)).block();
+        List<CalendarURL> result = testee.resolve(requester, List.of(requestedCalendar)).block();
 
         // Then D/E is returned.
         assertThat(result)
@@ -116,23 +105,10 @@ class CalendarSearchSourceResolverTest {
     @Test
     void resolveShouldKeepSubscribedSourceCalendarWhenRequestedDirectly() {
         // Given subscriber has a mirror A/B for source D/E.
-        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
-        OpenPaaSUser subscriber = sabreDavExtension.newTestUser();
-
-        String sourceCalendarId = "source-" + UUID.randomUUID();
-        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.READ);
-
-        davTestHelper.subscribeToSharedCalendar(subscriber, SubscribedCalendarRequest.builder()
-            .id("subscribed-" + UUID.randomUUID())
-            .sourceUserId(sourceUser.id().value())
-            .sourceCalendarId(sourceCalendarId)
-            .name("Subscribed source")
-            .color("#123456")
-            .readOnly(true)
-            .build());
+        CalendarURL sourceCalendar = createSubscribedSourceCalendar();
 
         // When resolving D/E directly.
-        List<CalendarURL> result = testee.resolve(subscriber, List.of(sourceCalendar)).block();
+        List<CalendarURL> result = testee.resolve(requester, List.of(sourceCalendar)).block();
 
         // Then D/E is kept.
         assertThat(result)
@@ -143,19 +119,11 @@ class CalendarSearchSourceResolverTest {
     @Test
     void resolveShouldTranslateDelegatedMirrorCalendarToSourceCalendar() {
         // Given delegated mirror A/B points to source D/E.
-        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
-        OpenPaaSUser delegate = sabreDavExtension.newTestUser();
-        String sourceCalendarId = "delegated-" + UUID.randomUUID();
-        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.HIDE_ALL_EVENT);
-        davTestHelper.grantDelegation(sourceUser, sourceCalendar, delegate, "dav:read");
-        CalendarURL requestedCalendar = calDavClient.findUserCalendars(delegate.username(), delegate.id())
-            .filter(calendarURL -> !calendarURL.equals(CalendarURL.from(delegate.id())))
-            .next()
-            .blockOptional()
-            .orElseThrow(() -> new AssertionError("No mirror calendar found"));
+        CalendarURL sourceCalendar = createDelegatedSourceCalendar(requester, PublicRight.HIDE_ALL_EVENT);
+        CalendarURL requestedCalendar = findMirrorCalendar(requester);
 
         // When resolving A/B.
-        List<CalendarURL> result = testee.resolve(delegate, List.of(requestedCalendar)).block();
+        List<CalendarURL> result = testee.resolve(requester, List.of(requestedCalendar)).block();
 
         // Then D/E is returned.
         assertThat(result)
@@ -166,14 +134,10 @@ class CalendarSearchSourceResolverTest {
     @Test
     void resolveShouldKeepDelegatedSourceCalendarWhenRequestedDirectly() {
         // Given source D/E is directly readable and also has a delegated mirror.
-        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
-        OpenPaaSUser delegate = sabreDavExtension.newTestUser();
-        String sourceCalendarId = "delegated-" + UUID.randomUUID();
-        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.READ);
-        davTestHelper.grantDelegation(sourceUser, sourceCalendar, delegate, "dav:read");
+        CalendarURL sourceCalendar = createDelegatedSourceCalendar(requester, PublicRight.READ);
 
         // When resolving D/E.
-        List<CalendarURL> result = testee.resolve(delegate, List.of(sourceCalendar)).block();
+        List<CalendarURL> result = testee.resolve(requester, List.of(sourceCalendar)).block();
 
         // Then D/E is kept.
         assertThat(result)
@@ -184,17 +148,9 @@ class CalendarSearchSourceResolverTest {
     @Test
     void resolveShouldFilterDelegatedMirrorCalendarWhenRequesterIsNotDelegate() {
         // Given delegated mirror A/B belongs to a different delegate.
-        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
         OpenPaaSUser delegate = sabreDavExtension.newTestUser();
-        OpenPaaSUser requester = sabreDavExtension.newTestUser();
-        String sourceCalendarId = "delegated-" + UUID.randomUUID();
-        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.HIDE_ALL_EVENT);
-        davTestHelper.grantDelegation(sourceUser, sourceCalendar, delegate, "dav:read");
-        CalendarURL delegatedMirrorCalendar = calDavClient.findUserCalendars(delegate.username(), delegate.id())
-            .filter(calendarURL -> !calendarURL.equals(CalendarURL.from(delegate.id())))
-            .next()
-            .blockOptional()
-            .orElseThrow(() -> new AssertionError("No mirror calendar found"));
+        createDelegatedSourceCalendar(delegate, PublicRight.HIDE_ALL_EVENT);
+        CalendarURL delegatedMirrorCalendar = findMirrorCalendar(delegate);
 
         // When another user resolves A/B.
         List<CalendarURL> result = testee.resolve(requester, List.of(delegatedMirrorCalendar)).block();
@@ -208,26 +164,24 @@ class CalendarSearchSourceResolverTest {
     @Test
     void resolveShouldKeepMultipleReadableCalendarsAndFilterUnreadableCalendars() {
         // Given several readable calendars and one not readable calendar.
-        OpenPaaSUser requester = sabreDavExtension.newTestUser();
-        OpenPaaSUser user1 = sabreDavExtension.newTestUser();
-        OpenPaaSUser user2 = sabreDavExtension.newTestUser();
-        OpenPaaSUser user3 = sabreDavExtension.newTestUser();
+        OpenPaaSUser delegatedSourceUser = sabreDavExtension.newTestUser();
+        OpenPaaSUser unreadableUser = sabreDavExtension.newTestUser();
 
         CalendarURL ownCalendar = CalendarURL.from(requester.id());
-        CalendarURL subscribedSourceCalendar = createCalendar(user1, "subscribed-readable-" + UUID.randomUUID(), PublicRight.READ);
+        CalendarURL subscribedSourceCalendar = createCalendar(sourceUser, "subscribed-readable-" + UUID.randomUUID(), PublicRight.READ);
         davTestHelper.subscribeToSharedCalendar(requester, SubscribedCalendarRequest.builder()
             .id("subscribed-" + UUID.randomUUID())
-            .sourceUserId(user1.id().value())
+            .sourceUserId(sourceUser.id().value())
             .sourceCalendarId(subscribedSourceCalendar.calendarId().value())
             .name("Subscribed readable source")
             .color("#123456")
             .readOnly(true)
             .build());
 
-        CalendarURL delegatedSourceCalendar = createCalendar(user2, "delegated-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
-        davTestHelper.grantDelegation(user2, delegatedSourceCalendar, requester, "dav:read");
+        CalendarURL delegatedSourceCalendar = createCalendar(delegatedSourceUser, "delegated-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
+        davTestHelper.grantDelegation(delegatedSourceUser, delegatedSourceCalendar, requester, "dav:read");
 
-        CalendarURL notReadableCalendar = createCalendar(user3, "not-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
+        CalendarURL notReadableCalendar = createCalendar(unreadableUser, "not-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
 
         // When resolving all requested calendars.
         List<CalendarURL> result = testee.resolve(requester,
@@ -242,7 +196,6 @@ class CalendarSearchSourceResolverTest {
     @Test
     void resolveShouldKeepResourceCalendarWhenRequesterIsResourceAdministrator() {
         // Given requester is administrator of resource calendar R/R.
-        OpenPaaSUser requester = sabreDavExtension.newTestUser();
         OpenPaaSDomain domain = sabreDavExtension.dockerSabreDavSetup()
             .getOpenPaaSProvisioningService()
             .getDomain()
@@ -263,13 +216,11 @@ class CalendarSearchSourceResolverTest {
     @Test
     void resolveShouldTranslateSubscribedResourceCalendarToResourceCalendar() {
         // Given requester subscribed to resource calendar R/R.
-        OpenPaaSUser requester = sabreDavExtension.newTestUser();
-        OpenPaaSUser resourceCreator = sabreDavExtension.newTestUser();
         OpenPaaSDomain domain = sabreDavExtension.dockerSabreDavSetup()
             .getOpenPaaSProvisioningService()
             .getDomain()
             .block();
-        ResourceId resourceId = createResource(domain, resourceCreator, List.of());
+        ResourceId resourceId = createResource(domain, sourceUser, List.of());
         CalendarURL resourceCalendar = CalendarURL.from(resourceId.asOpenPaaSId());
         CalendarURL subscribedCalendar = davTestHelper.subscribeToSharedCalendar(requester, SubscribedCalendarRequest.builder()
             .id("subscribed-resource-" + UUID.randomUUID())
@@ -292,7 +243,6 @@ class CalendarSearchSourceResolverTest {
     @Test
     void resolveShouldFilterResourceCalendarFromAnotherDomain() {
         // Given resource calendar R/R belongs to another domain.
-        OpenPaaSUser requester = sabreDavExtension.newTestUser();
         OpenPaaSDomain foreignDomain = sabreDavExtension.dockerSabreDavSetup()
             .getOpenPaaSProvisioningService()
             .createDomainIfAbsent(Domain.of("resource-" + UUID.randomUUID() + ".tld"))
@@ -324,6 +274,35 @@ class CalendarSearchSourceResolverTest {
         CalendarURL calendarURL = new CalendarURL(calendarUser.id(), new OpenPaaSId(calendarId));
         calDavClient.updateCalendarAcl(calendarUser.username(), calendarURL, publicRight).block();
         return calendarURL;
+    }
+
+    private CalendarURL createSubscribedSourceCalendar() {
+        CalendarURL sourceCalendar = createCalendar(sourceUser, "source-" + UUID.randomUUID(), PublicRight.READ);
+        davTestHelper.subscribeToSharedCalendar(requester, SubscribedCalendarRequest.builder()
+            .id("subscribed-" + UUID.randomUUID())
+            .sourceUserId(sourceUser.id().value())
+            .sourceCalendarId(sourceCalendar.calendarId().value())
+            .name("Subscribed source")
+            .color("#123456")
+            .readOnly(true)
+            .build());
+
+        return sourceCalendar;
+    }
+
+    private CalendarURL createDelegatedSourceCalendar(OpenPaaSUser delegate, PublicRight sourcePublicRight) {
+        CalendarURL sourceCalendar = createCalendar(sourceUser, "delegated-" + UUID.randomUUID(), sourcePublicRight);
+        davTestHelper.grantDelegation(sourceUser, sourceCalendar, delegate, "dav:read");
+
+        return sourceCalendar;
+    }
+
+    private CalendarURL findMirrorCalendar(OpenPaaSUser user) {
+        return calDavClient.findUserCalendars(user.username(), user.id())
+            .filter(calendarURL -> !calendarURL.equals(CalendarURL.from(user.id())))
+            .next()
+            .blockOptional()
+            .orElseThrow(() -> new AssertionError("No mirror calendar found"));
     }
 
     private ResourceId createResource(OpenPaaSDomain domain, OpenPaaSUser creator, List<OpenPaaSUser> administrators) {

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSearchSourceResolverTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSearchSourceResolverTest.java
@@ -1,0 +1,342 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav;
+
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.UUID;
+
+import javax.net.ssl.SSLException;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.calendar.dav.CalDavClient.NewCalendar;
+import com.linagora.calendar.dav.CalDavClient.PublicRight;
+import com.linagora.calendar.dav.dto.SubscribedCalendarRequest;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSDomain;
+import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.ResourceInsertRequest;
+import com.linagora.calendar.storage.model.ResourceAdministrator;
+import com.linagora.calendar.storage.model.ResourceId;
+import com.linagora.calendar.storage.mongodb.MongoDBResourceDAO;
+
+class CalendarSearchSourceResolverTest {
+    @RegisterExtension
+    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+
+    private static DavTestHelper davTestHelper;
+
+    private CalDavClient calDavClient;
+    private MongoDBResourceDAO resourceDAO;
+    private CalendarSearchSourceResolver testee;
+
+    @BeforeAll
+    static void setUp() throws SSLException {
+        davTestHelper = new DavTestHelper(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+    }
+
+    @BeforeEach
+    void setupEach() throws SSLException {
+        calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        resourceDAO = new MongoDBResourceDAO(sabreDavExtension.dockerSabreDavSetup().getMongoDB(), Clock.systemUTC());
+        testee = new CalendarSearchSourceResolver(calDavClient);
+    }
+
+    @Test
+    void resolveShouldFilterCalendarWithoutReadAccess() {
+        // Given one readable calendar and one not readable calendar.
+        OpenPaaSUser requester = sabreDavExtension.newTestUser();
+        OpenPaaSUser other = sabreDavExtension.newTestUser();
+        CalendarURL notReadableCalendar = createCalendar(other, "not-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
+        CalendarURL readableCalendar = CalendarURL.from(requester.id());
+
+        // When resolving the search sources.
+        List<CalendarURL> result = testee.resolve(requester, List.of(readableCalendar, notReadableCalendar)).block();
+
+        // Then the not readable calendar is filtered out.
+        assertThat(result)
+            .describedAs("Resolver should keep calendars readable by requester and filter calendars without read access")
+            .containsExactly(readableCalendar);
+    }
+
+    @Test
+    void resolveShouldTranslateSubscribedMirrorCalendarToSourceCalendar() {
+        // Given subscribed mirror A/B points to source D/E.
+        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
+        OpenPaaSUser subscriber = sabreDavExtension.newTestUser();
+
+        String sourceCalendarId = "source-" + UUID.randomUUID();
+        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.READ);
+
+        String subscribedCalendarId = "subscribed-" + UUID.randomUUID();
+        CalendarURL requestedCalendar = davTestHelper.subscribeToSharedCalendar(subscriber, SubscribedCalendarRequest.builder()
+            .id(subscribedCalendarId)
+            .sourceUserId(sourceUser.id().value())
+            .sourceCalendarId(sourceCalendarId)
+            .name("Subscribed source")
+            .color("#123456")
+            .readOnly(true)
+            .build());
+
+        // When resolving A/B.
+        List<CalendarURL> result = testee.resolve(subscriber, List.of(requestedCalendar)).block();
+
+        // Then D/E is returned.
+        assertThat(result)
+            .describedAs("Resolver should translate a subscribed mirror calendar to its source calendar")
+            .containsExactly(sourceCalendar);
+    }
+
+    @Test
+    void resolveShouldKeepSubscribedSourceCalendarWhenRequestedDirectly() {
+        // Given subscriber has a mirror A/B for source D/E.
+        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
+        OpenPaaSUser subscriber = sabreDavExtension.newTestUser();
+
+        String sourceCalendarId = "source-" + UUID.randomUUID();
+        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.READ);
+
+        davTestHelper.subscribeToSharedCalendar(subscriber, SubscribedCalendarRequest.builder()
+            .id("subscribed-" + UUID.randomUUID())
+            .sourceUserId(sourceUser.id().value())
+            .sourceCalendarId(sourceCalendarId)
+            .name("Subscribed source")
+            .color("#123456")
+            .readOnly(true)
+            .build());
+
+        // When resolving D/E directly.
+        List<CalendarURL> result = testee.resolve(subscriber, List.of(sourceCalendar)).block();
+
+        // Then D/E is kept.
+        assertThat(result)
+            .describedAs("Resolver should keep the source calendar when it is requested directly")
+            .containsExactly(sourceCalendar);
+    }
+
+    @Test
+    void resolveShouldTranslateDelegatedMirrorCalendarToSourceCalendar() {
+        // Given delegated mirror A/B points to source D/E.
+        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
+        OpenPaaSUser delegate = sabreDavExtension.newTestUser();
+        String sourceCalendarId = "delegated-" + UUID.randomUUID();
+        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.HIDE_ALL_EVENT);
+        davTestHelper.grantDelegation(sourceUser, sourceCalendar, delegate, "dav:read");
+        CalendarURL requestedCalendar = calDavClient.findUserCalendars(delegate.username(), delegate.id())
+            .filter(calendarURL -> !calendarURL.equals(CalendarURL.from(delegate.id())))
+            .next()
+            .blockOptional()
+            .orElseThrow(() -> new AssertionError("No mirror calendar found"));
+
+        // When resolving A/B.
+        List<CalendarURL> result = testee.resolve(delegate, List.of(requestedCalendar)).block();
+
+        // Then D/E is returned.
+        assertThat(result)
+            .describedAs("Resolver should translate a delegated mirror calendar to its source calendar")
+            .containsExactly(sourceCalendar);
+    }
+
+    @Test
+    void resolveShouldKeepDelegatedSourceCalendarWhenRequestedDirectly() {
+        // Given source D/E is directly readable and also has a delegated mirror.
+        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
+        OpenPaaSUser delegate = sabreDavExtension.newTestUser();
+        String sourceCalendarId = "delegated-" + UUID.randomUUID();
+        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.READ);
+        davTestHelper.grantDelegation(sourceUser, sourceCalendar, delegate, "dav:read");
+
+        // When resolving D/E.
+        List<CalendarURL> result = testee.resolve(delegate, List.of(sourceCalendar)).block();
+
+        // Then D/E is kept.
+        assertThat(result)
+            .describedAs("Resolver should keep a directly readable delegated source calendar when requested directly")
+            .containsExactly(sourceCalendar);
+    }
+
+    @Test
+    void resolveShouldFilterDelegatedMirrorCalendarWhenRequesterIsNotDelegate() {
+        // Given delegated mirror A/B belongs to a different delegate.
+        OpenPaaSUser sourceUser = sabreDavExtension.newTestUser();
+        OpenPaaSUser delegate = sabreDavExtension.newTestUser();
+        OpenPaaSUser requester = sabreDavExtension.newTestUser();
+        String sourceCalendarId = "delegated-" + UUID.randomUUID();
+        CalendarURL sourceCalendar = createCalendar(sourceUser, sourceCalendarId, PublicRight.HIDE_ALL_EVENT);
+        davTestHelper.grantDelegation(sourceUser, sourceCalendar, delegate, "dav:read");
+        CalendarURL delegatedMirrorCalendar = calDavClient.findUserCalendars(delegate.username(), delegate.id())
+            .filter(calendarURL -> !calendarURL.equals(CalendarURL.from(delegate.id())))
+            .next()
+            .blockOptional()
+            .orElseThrow(() -> new AssertionError("No mirror calendar found"));
+
+        // When another user resolves A/B.
+        List<CalendarURL> result = testee.resolve(requester, List.of(delegatedMirrorCalendar)).block();
+
+        // Then the delegated mirror is filtered.
+        assertThat(result)
+            .describedAs("Resolver should filter a delegated mirror calendar when requester is not the delegate")
+            .isEmpty();
+    }
+
+    @Test
+    void resolveShouldKeepMultipleReadableCalendarsAndFilterUnreadableCalendars() {
+        // Given several readable calendars and one not readable calendar.
+        OpenPaaSUser requester = sabreDavExtension.newTestUser();
+        OpenPaaSUser user1 = sabreDavExtension.newTestUser();
+        OpenPaaSUser user2 = sabreDavExtension.newTestUser();
+        OpenPaaSUser user3 = sabreDavExtension.newTestUser();
+
+        CalendarURL ownCalendar = CalendarURL.from(requester.id());
+        CalendarURL subscribedSourceCalendar = createCalendar(user1, "subscribed-readable-" + UUID.randomUUID(), PublicRight.READ);
+        davTestHelper.subscribeToSharedCalendar(requester, SubscribedCalendarRequest.builder()
+            .id("subscribed-" + UUID.randomUUID())
+            .sourceUserId(user1.id().value())
+            .sourceCalendarId(subscribedSourceCalendar.calendarId().value())
+            .name("Subscribed readable source")
+            .color("#123456")
+            .readOnly(true)
+            .build());
+
+        CalendarURL delegatedSourceCalendar = createCalendar(user2, "delegated-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
+        davTestHelper.grantDelegation(user2, delegatedSourceCalendar, requester, "dav:read");
+
+        CalendarURL notReadableCalendar = createCalendar(user3, "not-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
+
+        // When resolving all requested calendars.
+        List<CalendarURL> result = testee.resolve(requester,
+            List.of(ownCalendar, subscribedSourceCalendar, notReadableCalendar, delegatedSourceCalendar)).block();
+
+        // Then all readable calendars are kept and the not readable calendar is filtered.
+        assertThat(result)
+            .describedAs("Resolver should keep all readable calendars in request order and filter unreadable calendars")
+            .containsExactly(ownCalendar, subscribedSourceCalendar, delegatedSourceCalendar);
+    }
+
+    @Test
+    void resolveShouldKeepResourceCalendarWhenRequesterIsResourceAdministrator() {
+        // Given requester is administrator of resource calendar R/R.
+        OpenPaaSUser requester = sabreDavExtension.newTestUser();
+        OpenPaaSDomain domain = sabreDavExtension.dockerSabreDavSetup()
+            .getOpenPaaSProvisioningService()
+            .getDomain()
+            .block();
+        ResourceId resourceId = createResource(domain, requester, List.of(requester));
+        CalendarURL resourceCalendar = CalendarURL.from(resourceId.asOpenPaaSId());
+        calDavClient.grantReadWriteRights(domain.id(), resourceId, List.of(requester.username())).block();
+
+        // When resolving R/R.
+        List<CalendarURL> result = testee.resolve(requester, List.of(resourceCalendar)).block();
+
+        // Then R/R is kept.
+        assertThat(result)
+            .describedAs("Resolver should keep a resource calendar readable by its administrator")
+            .containsExactly(resourceCalendar);
+    }
+
+    @Test
+    void resolveShouldTranslateSubscribedResourceCalendarToResourceCalendar() {
+        // Given requester subscribed to resource calendar R/R.
+        OpenPaaSUser requester = sabreDavExtension.newTestUser();
+        OpenPaaSUser resourceCreator = sabreDavExtension.newTestUser();
+        OpenPaaSDomain domain = sabreDavExtension.dockerSabreDavSetup()
+            .getOpenPaaSProvisioningService()
+            .getDomain()
+            .block();
+        ResourceId resourceId = createResource(domain, resourceCreator, List.of());
+        CalendarURL resourceCalendar = CalendarURL.from(resourceId.asOpenPaaSId());
+        CalendarURL subscribedCalendar = davTestHelper.subscribeToSharedCalendar(requester, SubscribedCalendarRequest.builder()
+            .id("subscribed-resource-" + UUID.randomUUID())
+            .sourceUserId(resourceId.value())
+            .sourceCalendarId(resourceId.value())
+            .name("Subscribed resource")
+            .color("#123456")
+            .readOnly(true)
+            .build());
+
+        // When resolving subscribed mirror A/B.
+        List<CalendarURL> result = testee.resolve(requester, List.of(subscribedCalendar)).block();
+
+        // Then R/R is returned.
+        assertThat(result)
+            .describedAs("Resolver should translate a subscribed resource calendar to its source resource calendar")
+            .containsExactly(resourceCalendar);
+    }
+
+    @Test
+    void resolveShouldFilterResourceCalendarFromAnotherDomain() {
+        // Given resource calendar R/R belongs to another domain.
+        OpenPaaSUser requester = sabreDavExtension.newTestUser();
+        OpenPaaSDomain foreignDomain = sabreDavExtension.dockerSabreDavSetup()
+            .getOpenPaaSProvisioningService()
+            .createDomainIfAbsent(Domain.of("resource-" + UUID.randomUUID() + ".tld"))
+            .block();
+        OpenPaaSUser foreignAdmin = sabreDavExtension.dockerSabreDavSetup()
+            .getOpenPaaSProvisioningService()
+            .createUser(Username.fromLocalPartWithDomain("user-" + UUID.randomUUID(), foreignDomain.domain()))
+            .block();
+        ResourceId resourceId = createResource(foreignDomain, foreignAdmin, List.of(foreignAdmin));
+        CalendarURL resourceCalendar = CalendarURL.from(resourceId.asOpenPaaSId());
+        calDavClient.grantReadWriteRights(foreignDomain.id(), resourceId, List.of(foreignAdmin.username())).block();
+
+        // When resolving R/R as a requester from another domain.
+        List<CalendarURL> result = testee.resolve(requester, List.of(resourceCalendar)).block();
+
+        // Then the resource calendar is filtered.
+        assertThat(result)
+            .describedAs("Resolver should filter resource calendars from another domain")
+            .isEmpty();
+    }
+
+    private CalendarURL createCalendar(OpenPaaSUser calendarUser, String calendarId, PublicRight publicRight) {
+        calDavClient.createNewCalendar(calendarUser.username(), calendarUser.id(), new NewCalendar(
+            calendarId,
+            "Calendar " + calendarId,
+            "#123456",
+            "Calendar search scope test")).block();
+
+        CalendarURL calendarURL = new CalendarURL(calendarUser.id(), new OpenPaaSId(calendarId));
+        calDavClient.updateCalendarAcl(calendarUser.username(), calendarURL, publicRight).block();
+        return calendarURL;
+    }
+
+    private ResourceId createResource(OpenPaaSDomain domain, OpenPaaSUser creator, List<OpenPaaSUser> administrators) {
+        ResourceInsertRequest insertRequest = new ResourceInsertRequest(
+            administrators.stream()
+                .map(administrator -> new ResourceAdministrator(administrator.id(), "user"))
+                .toList(),
+            creator.id(),
+            "Resource calendar search source resolver test",
+            domain.id(),
+            "projector",
+            "Resource " + UUID.randomUUID());
+
+        return resourceDAO.insert(insertRequest).block();
+    }
+}

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSearchSourceResolverTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSearchSourceResolverTest.java
@@ -18,11 +18,13 @@
 
 package com.linagora.calendar.dav;
 
+import static java.util.Map.entry;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Clock;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.net.ssl.SSLException;
@@ -79,12 +81,12 @@ class CalendarSearchSourceResolverTest {
         CalendarURL readableCalendar = CalendarURL.from(requester.id());
 
         // When resolving the search sources.
-        List<CalendarURL> result = testee.resolve(requester, List.of(readableCalendar, notReadableCalendar)).block();
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester, List.of(readableCalendar, notReadableCalendar)).block();
 
         // Then the not readable calendar is filtered out.
         assertThat(result)
             .describedAs("Resolver should keep calendars readable by requester and filter calendars without read access")
-            .containsExactly(readableCalendar);
+            .containsExactly(entry(readableCalendar, readableCalendar));
     }
 
     @Test
@@ -94,12 +96,12 @@ class CalendarSearchSourceResolverTest {
         CalendarURL requestedCalendar = findMirrorCalendar(requester);
 
         // When resolving A/B.
-        List<CalendarURL> result = testee.resolve(requester, List.of(requestedCalendar)).block();
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester, List.of(requestedCalendar)).block();
 
         // Then D/E is returned.
         assertThat(result)
             .describedAs("Resolver should translate a subscribed mirror calendar to its source calendar")
-            .containsExactly(sourceCalendar);
+            .containsExactly(entry(requestedCalendar, sourceCalendar));
     }
 
     @Test
@@ -108,12 +110,12 @@ class CalendarSearchSourceResolverTest {
         CalendarURL sourceCalendar = createSubscribedSourceCalendar();
 
         // When resolving D/E directly.
-        List<CalendarURL> result = testee.resolve(requester, List.of(sourceCalendar)).block();
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester, List.of(sourceCalendar)).block();
 
         // Then D/E is kept.
         assertThat(result)
             .describedAs("Resolver should keep the source calendar when it is requested directly")
-            .containsExactly(sourceCalendar);
+            .containsExactly(entry(sourceCalendar, sourceCalendar));
     }
 
     @Test
@@ -123,12 +125,12 @@ class CalendarSearchSourceResolverTest {
         CalendarURL requestedCalendar = findMirrorCalendar(requester);
 
         // When resolving A/B.
-        List<CalendarURL> result = testee.resolve(requester, List.of(requestedCalendar)).block();
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester, List.of(requestedCalendar)).block();
 
         // Then D/E is returned.
         assertThat(result)
             .describedAs("Resolver should translate a delegated mirror calendar to its source calendar")
-            .containsExactly(sourceCalendar);
+            .containsExactly(entry(requestedCalendar, sourceCalendar));
     }
 
     @Test
@@ -137,12 +139,12 @@ class CalendarSearchSourceResolverTest {
         CalendarURL sourceCalendar = createDelegatedSourceCalendar(requester, PublicRight.READ);
 
         // When resolving D/E.
-        List<CalendarURL> result = testee.resolve(requester, List.of(sourceCalendar)).block();
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester, List.of(sourceCalendar)).block();
 
         // Then D/E is kept.
         assertThat(result)
             .describedAs("Resolver should keep a directly readable delegated source calendar when requested directly")
-            .containsExactly(sourceCalendar);
+            .containsExactly(entry(sourceCalendar, sourceCalendar));
     }
 
     @Test
@@ -153,7 +155,7 @@ class CalendarSearchSourceResolverTest {
         CalendarURL delegatedMirrorCalendar = findMirrorCalendar(delegate);
 
         // When another user resolves A/B.
-        List<CalendarURL> result = testee.resolve(requester, List.of(delegatedMirrorCalendar)).block();
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester, List.of(delegatedMirrorCalendar)).block();
 
         // Then the delegated mirror is filtered.
         assertThat(result)
@@ -184,13 +186,16 @@ class CalendarSearchSourceResolverTest {
         CalendarURL notReadableCalendar = createCalendar(unreadableUser, "not-readable-" + UUID.randomUUID(), PublicRight.HIDE_ALL_EVENT);
 
         // When resolving all requested calendars.
-        List<CalendarURL> result = testee.resolve(requester,
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester,
             List.of(ownCalendar, subscribedSourceCalendar, notReadableCalendar, delegatedSourceCalendar)).block();
 
         // Then all readable calendars are kept and the not readable calendar is filtered.
         assertThat(result)
             .describedAs("Resolver should keep all readable calendars in request order and filter unreadable calendars")
-            .containsExactly(ownCalendar, subscribedSourceCalendar, delegatedSourceCalendar);
+            .containsExactly(
+                entry(ownCalendar, ownCalendar),
+                entry(subscribedSourceCalendar, subscribedSourceCalendar),
+                entry(delegatedSourceCalendar, delegatedSourceCalendar));
     }
 
     @Test
@@ -205,12 +210,12 @@ class CalendarSearchSourceResolverTest {
         calDavClient.grantReadWriteRights(domain.id(), resourceId, List.of(requester.username())).block();
 
         // When resolving R/R.
-        List<CalendarURL> result = testee.resolve(requester, List.of(resourceCalendar)).block();
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester, List.of(resourceCalendar)).block();
 
         // Then R/R is kept.
         assertThat(result)
             .describedAs("Resolver should keep a resource calendar readable by its administrator")
-            .containsExactly(resourceCalendar);
+            .containsExactly(entry(resourceCalendar, resourceCalendar));
     }
 
     @Test
@@ -232,12 +237,12 @@ class CalendarSearchSourceResolverTest {
             .build());
 
         // When resolving subscribed mirror A/B.
-        List<CalendarURL> result = testee.resolve(requester, List.of(subscribedCalendar)).block();
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester, List.of(subscribedCalendar)).block();
 
         // Then R/R is returned.
         assertThat(result)
             .describedAs("Resolver should translate a subscribed resource calendar to its source resource calendar")
-            .containsExactly(resourceCalendar);
+            .containsExactly(entry(subscribedCalendar, resourceCalendar));
     }
 
     @Test
@@ -256,7 +261,7 @@ class CalendarSearchSourceResolverTest {
         calDavClient.grantReadWriteRights(foreignDomain.id(), resourceId, List.of(foreignAdmin.username())).block();
 
         // When resolving R/R as a requester from another domain.
-        List<CalendarURL> result = testee.resolve(requester, List.of(resourceCalendar)).block();
+        Map<CalendarURL, CalendarURL> result = testee.resolve(requester, List.of(resourceCalendar)).block();
 
         // Then the resource calendar is filtered.
         assertThat(result)

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/DavTestHelper.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/DavTestHelper.java
@@ -257,7 +257,7 @@ public class DavTestHelper extends DavClient {
             }).block();
     }
 
-    public void subscribeToSharedCalendar(OpenPaaSUser user, SubscribedCalendarRequest subscribedCalendarRequest) {
+    public CalendarURL subscribeToSharedCalendar(OpenPaaSUser user, SubscribedCalendarRequest subscribedCalendarRequest) {
         String uri = CalendarURL.CALENDAR_URL_PATH_PREFIX + "/" + user.id().value() + ".json";
 
         httpClientWithImpersonation(user.username())
@@ -278,6 +278,8 @@ public class DavTestHelper extends DavClient {
                         %s
                         """.formatted(response.status().code(), uri, errorBody))));
             }).block();
+
+        return new CalendarURL(user.id(), new OpenPaaSId(subscribedCalendarRequest.id()));
     }
 
 

--- a/calendar-redis/src/main/java/org/apache/james/events/CalendarRedisEventBus.java
+++ b/calendar-redis/src/main/java/org/apache/james/events/CalendarRedisEventBus.java
@@ -96,7 +96,7 @@ public class CalendarRedisEventBus implements EventBus, Startable {
         if (!isRunning && !isStopping) {
             LocalListenerRegistry localListenerRegistry = new LocalListenerRegistry();
             localKeyListenerExecutor = new LocalKeyListenerExecutor(localListenerRegistry, listenerExecutor);
-            redisKeyEventDispatcher = new RedisKeyEventDispatcher(eventBusId, eventSerializer, redisPublisher, redisSetReactiveCommands, redisEventBusConfiguration);
+            redisKeyEventDispatcher = new RedisKeyEventDispatcher(eventBusId, namingStrategy, eventSerializer, redisPublisher, redisSetReactiveCommands, redisEventBusConfiguration);
             keyRegistrationHandler = new RedisKeyRegistrationHandler(namingStrategy, eventBusId, eventSerializer, routingKeyConverter,
                 localListenerRegistry, listenerExecutor, retryBackoff, metricFactory, redisEventBusClientFactory, redisSetReactiveCommands, redisEventBusConfiguration);
             keyRegistrationHandler.start();


### PR DESCRIPTION
related https://github.com/linagora/twake-calendar-side-service/issues/87

This PR adds a calendar search source resolver for translating client-requested calendar URLs into the actual calendar sources to search. 
It uses the requester calendar list from SabreDAV as the source of truth, so unreadable calendars are filtered and subscribed/delegated mirrors resolve to their source calendars.

## Notes
- The resolver filters unreadable calendars instead of throwing.
- Search is only supported for calendars that are subscribed, delegated, or personal calendars.