### PR TITLE
ISSUE-799 Support indexing resource calendar events for shared calendar search

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteSharedCalendarTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteSharedCalendarTest.java
@@ -41,7 +41,6 @@ import org.apache.james.utils.GuiceProbe;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -364,15 +363,15 @@ class OpensearchDavCalendarSearchRouteSharedCalendarTest {
             .body("_embedded.events", empty()));
     }
 
-    @Disabled("TODO https://github.com/linagora/twake-calendar-side-service/issues/799")
     @Test
     void searchShouldReturnResourceCalendarEventWhenRequesterIsResourceAdministrator(TwakeCalendarGuiceServer server) {
         // Given Bob has DAV read/write rights on a resource calendar R/R containing an indexed event.
         Resource resource = server.getProbe(ResourceProbe.class)
-            .save(bob, "search admin resource " + UUID.randomUUID(), "projector", List.of(bob.id()));
+            .save(alice, "search admin resource " + UUID.randomUUID(), "projector", List.of());
         CalendarURL resourceCalendar = CalendarURL.from(resource.id().asOpenPaaSId());
         EventUid eventUid = new EventUid("event-resource-admin-" + UUID.randomUUID());
         String summary = "resource admin searchable event " + UUID.randomUUID();
+        calDavClient.grantReadWriteRights(resource.domain(), resource.id(), List.of(bob.username())).block();
         davTestHelper.upsertCalendar(alice, generateCalendarData(eventUid, summary, alice, resource), eventUid);
         String resourceEventId = awaitAtMost.until(
             () -> davTestHelper.findFirstEventId(resource.id(), resource.domain()),
@@ -393,7 +392,6 @@ class OpensearchDavCalendarSearchRouteSharedCalendarTest {
             .body("_embedded.events.data.calendarId", contains(resourceCalendar.calendarId().value())));
     }
 
-    @Disabled("TODO https://github.com/linagora/twake-calendar-side-service/issues/799")
     @Test
     void searchShouldReturnSubscribedResourceCalendarEventWhenRequestedCalendarIsSubscribeMirror(TwakeCalendarGuiceServer server) {
         // Given Bob subscribes to a resource calendar R/R containing an indexed event.

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarEventMessage.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarEventMessage.java
@@ -38,22 +38,18 @@ public abstract class CalendarEventMessage {
 
     static {
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        MAPPER.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false);
     }
 
     protected final String eventPath;
     protected final JsonNode calendarEvent;
     protected final boolean isImport;
-    private final String resourceId;
 
     public CalendarEventMessage(String eventPath,
                                 JsonNode calendarEvent,
-                                boolean isImport,
-                                String resourceId) {
+                                boolean isImport) {
         this.eventPath = eventPath;
         this.calendarEvent = calendarEvent;
         this.isImport = isImport;
-        this.resourceId = resourceId;
     }
 
     public CalendarURL extractCalendarURL() {
@@ -62,10 +58,6 @@ public abstract class CalendarEventMessage {
 
     public CalendarEvents extractCalendarEvents() {
         return EventFieldConverter.from(this);
-    }
-
-    public boolean isResourceEvent() {
-        return resourceId != null;
     }
 
     protected static <T extends CalendarEventMessage> T deserialize(byte[] json, Class<T> clazz) {
@@ -85,9 +77,8 @@ public abstract class CalendarEventMessage {
 
         public CreatedOrUpdated(@JsonProperty("eventPath") String eventPath,
                                 @JsonProperty("event") JsonNode calendarEvent,
-                                @JsonProperty("import") boolean isImport,
-                                @JsonProperty("resourceId") String resourceId) {
-            super(eventPath, calendarEvent, isImport, resourceId);
+                                @JsonProperty("import") boolean isImport) {
+            super(eventPath, calendarEvent, isImport);
         }
     }
 
@@ -98,9 +89,8 @@ public abstract class CalendarEventMessage {
 
         public Deleted(@JsonProperty("eventPath") String eventPath,
                        @JsonProperty("event") JsonNode calendarEvent,
-                       @JsonProperty("import") boolean isImport,
-                       @JsonProperty("resourceId") String resourceId) {
-            super(eventPath, calendarEvent, isImport, resourceId);
+                       @JsonProperty("import") boolean isImport) {
+            super(eventPath, calendarEvent, isImport);
         }
 
         public List<EventUid> extractEventUid() {

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventIndexerConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventIndexerConsumer.java
@@ -178,9 +178,6 @@ public class EventIndexerConsumer implements Closeable, Startable {
     private final CalendarEventHandler handlerAdd = new CalendarEventHandler() {
         @Override
         public Mono<?> handle(CalendarEventMessage calendarEventMessage) {
-            if (shouldSkipIndexing(calendarEventMessage)) {
-                return Mono.empty();
-            }
             return Mono.fromCallable(calendarEventMessage::extractCalendarEvents)
                 .flatMap(calendarSearchService::index)
                 .then();
@@ -196,9 +193,6 @@ public class EventIndexerConsumer implements Closeable, Startable {
 
         @Override
         public Mono<?> handle(CalendarEventMessage calendarEventMessage) {
-            if (shouldSkipIndexing(calendarEventMessage)) {
-                return Mono.empty();
-            }
             return Mono.fromCallable(calendarEventMessage::extractCalendarEvents)
                 .flatMap(this::indexEvents)
                 .then();
@@ -239,9 +233,6 @@ public class EventIndexerConsumer implements Closeable, Startable {
     private final CalendarEventHandler handlerDelete = new CalendarEventHandler() {
         @Override
         public Mono<?> handle(CalendarEventMessage calendarEventMessage) {
-            if (shouldSkipIndexing(calendarEventMessage)) {
-                return Mono.empty();
-            }
             return Flux.fromIterable(((CalendarEventMessage.Deleted) calendarEventMessage).extractEventUid())
                 .flatMap(eventUid -> calendarSearchService.delete(calendarEventMessage.extractCalendarURL(), eventUid)
                     .onErrorResume(error -> {
@@ -271,12 +262,6 @@ public class EventIndexerConsumer implements Closeable, Startable {
         return Flux.using(receiverProvider::createReceiver,
             receiver -> receiver.consumeManualAck(queue, new ConsumeOptions().qos(DEFAULT_CONCURRENCY)),
             Receiver::close);
-    }
-
-    private boolean shouldSkipIndexing(CalendarEventMessage message) {
-        // Resource calendar messages does not expose `event`.
-        // Keep them out of the regular indexer until resource indexing supports that payload.
-        return message.isResourceEvent();
     }
 
     private Mono<?> messageConsume(AcknowledgableDelivery ackDelivery, Mono<CalendarEventMessage> messagePublisher, CalendarEventHandler calendarEventHandler) {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -696,7 +695,6 @@ public class EventIndexerConsumerTest {
             .isEqualTo(videoconferenceUrl);
     }
 
-    @Disabled("TODO https://github.com/linagora/twake-calendar-side-service/issues/799")
     @Test
     void shouldHandleResourceEvent(DockerSabreDavSetup dockerSabreDavSetup) {
         OpenPaaSUser bob = openPaasUser;

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
@@ -99,6 +99,7 @@ import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.ResourceInsertRequest;
 import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
+import com.linagora.calendar.storage.eventsearch.EventUid;
 import com.linagora.calendar.storage.model.ResourceAdministrator;
 import com.linagora.calendar.storage.model.ResourceId;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
@@ -265,13 +266,8 @@ public class EventReplyEmailConsumerTest {
         davTestHelper.upsertCalendar(organizer, initialCalendarData, eventUid);
 
         // When: Attendee replies to the event (e.g. accepts the invitation)
-        String eventDavIdOnAttendee = waitForEventCreation(attendee);
-        String replyCalendarData = generateCalendarData(
-            eventUid,
-            organizer.username().asString(),
-            attendee.username().asString(),
-            new PartStat(partStatValue));
-        davTestHelper.upsertCalendar(attendee, replyCalendarData, eventDavIdOnAttendee);
+        waitForEventCreation(attendee);
+        updateAttendeePartStat(eventUid, new PartStat(partStatValue));
 
         // Wait for the mail to be received via mock SMTP
         awaitAtMost
@@ -355,10 +351,8 @@ public class EventReplyEmailConsumerTest {
 
         davTestHelper.upsertCalendar(organizer, sampleCalendarData, eventUid);
 
-        String eventDavIdOnAttendee = waitForEventCreation(attendee);
-        String replyCalendarData = sampleCalendarData.replace(PartStat.NEEDS_ACTION.getValue(), PartStat.ACCEPTED.getValue());
-
-        davTestHelper.upsertCalendar(attendee, replyCalendarData, eventDavIdOnAttendee);
+        waitForEventCreation(attendee);
+        updateAttendeePartStat(eventUid, PartStat.ACCEPTED);
 
         awaitAtMost
             .atMost(Duration.ofSeconds(20))
@@ -420,18 +414,13 @@ public class EventReplyEmailConsumerTest {
             attendee.username().asString(),
             PartStat.NEEDS_ACTION);
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
-        String eventDavIdOnAttendee = waitForEventCreation(attendee);
+        waitForEventCreation(attendee);
 
         // Mock exception
         when(eventEmailFilter.shouldProcess(any(MailAddress.class)))
             .thenThrow(new RuntimeException("Temporary exception"));
 
-        String replyDataFirst = generateCalendarData(
-            eventUid,
-            organizer.username().asString(),
-            attendee.username().asString(),
-            PartStat.ACCEPTED);
-        davTestHelper.upsertCalendar(attendee, replyDataFirst, eventDavIdOnAttendee);
+        updateAttendeePartStat(eventUid, PartStat.ACCEPTED);
 
         Thread.sleep(1000); // Wait for the exception to be processed
 
@@ -440,12 +429,7 @@ public class EventReplyEmailConsumerTest {
         when(eventEmailFilter.shouldProcess(any(MailAddress.class)))
             .thenReturn(true);
 
-        String replyDataSecond = generateCalendarData(
-            eventUid,
-            organizer.username().asString(),
-            attendee.username().asString(),
-            PartStat.DECLINED);
-        davTestHelper.upsertCalendar(attendee, replyDataSecond, eventDavIdOnAttendee);
+        updateAttendeePartStat(eventUid, PartStat.DECLINED);
 
         awaitAtMost
             .atMost(Duration.ofSeconds(20))
@@ -472,13 +456,8 @@ public class EventReplyEmailConsumerTest {
         davTestHelper.upsertCalendar(organizer, initialCalendarData, eventUid);
 
         // When: Attendee replies to the event
-        String eventDavIdOnAttendee = waitForEventCreation(attendee);
-        String replyCalendarData = generateCalendarData(
-            eventUid,
-            organizer.username().asString(),
-            attendee.username().asString(),
-            PartStat.ACCEPTED);
-        davTestHelper.upsertCalendar(attendee, replyCalendarData, eventDavIdOnAttendee);
+        waitForEventCreation(attendee);
+        updateAttendeePartStat(eventUid, PartStat.ACCEPTED);
 
         Thread.sleep(1000); // Wait for the message to be processed
         assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty();
@@ -564,13 +543,8 @@ public class EventReplyEmailConsumerTest {
             attendee.username().asString(),
             PartStat.NEEDS_ACTION);
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
-        String eventDavIdOnAttendee = waitForEventCreation(attendee);
-        String replyData = generateCalendarData(
-            eventUid,
-            organizer.username().asString(),
-            attendee.username().asString(),
-            PartStat.ACCEPTED);
-        davTestHelper.upsertCalendar(attendee, replyData, eventDavIdOnAttendee);
+        waitForEventCreation(attendee);
+        updateAttendeePartStat(eventUid, PartStat.ACCEPTED);
 
         awaitAtMost
             .atMost(Duration.ofSeconds(20))
@@ -582,6 +556,16 @@ public class EventReplyEmailConsumerTest {
     private static final Supplier<JsonPath> smtpMailsResponseSupplier = () -> given(mockSMTPRequestSpecification())
         .get("/smtpMails")
         .jsonPath();
+
+    private void updateAttendeePartStat(String eventUid, PartStat partStat) {
+        try {
+            calDavEventRepository()
+                .updatePartStat(attendee.username(), attendee.id(), new EventUid(eventUid), partStat)
+                .block();
+        } catch (SSLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     private String waitForEventCreation(OpenPaaSUser user) {
         awaitAtMost.untilAsserted(() ->

--- a/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
+++ b/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
@@ -43,7 +43,7 @@ services:
 
   sabre_dav:
     hostname: esn_sabre
-    image: linagora/esn-sabre:2.2.1
+    image: linagora/esn-sabre:2.3.1.1
     environment:
       - SABRE_ENV=dev
       - SABRE_MONGO_HOST=mongo


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/799

The AMQP message payload for resource calendars already works with the `esn-sabre:2.3.1.1` image.

It looks like 
- https://github.com/linagora/esn-sabre/pull/384/
already fixed this, so we do not need any additional code changes.