### PR TITLE
ISSUE-800 test(calendar): adapt Sabre tests to async scheduling

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/CalendarDavToWebsocketFlowIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/CalendarDavToWebsocketFlowIntegrationTest.java
@@ -134,7 +134,7 @@ class CalendarDavToWebsocketFlowIntegrationTest {
     }
 
     @Test
-    void bobShouldReceiveWebsocketPushWhenAliceInvitesHim() {
+    void bobShouldReceiveWebsocketPushWhenHaveANewEvent() {
         // GIVEN: Bob opens WebSocket
         String bobTicket = generateTicket(bob);
         BlockingQueue<String> messages = new LinkedBlockingQueue<>();
@@ -154,11 +154,11 @@ class CalendarDavToWebsocketFlowIntegrationTest {
             .isArray()
             .contains(bobCalendarUrl);
 
-        // WHEN: Alice creates ICS event and invites Bob
+        // WHEN: Bob's calendar changes
         String eventUid = "event-" + System.currentTimeMillis();
         String ics = buildEventICS(eventUid, alice.username().asString(), bob.username().asString());
 
-        davTestHelper.upsertCalendar(alice, ics, eventUid);
+        davTestHelper.upsertCalendar(bob, ics, eventUid);
 
         String pushMessage = awaitMessage(messages, msg -> msg.contains("syncToken") && msg.contains(bobCalendarUrl));
 
@@ -185,11 +185,12 @@ class CalendarDavToWebsocketFlowIntegrationTest {
                 "register": ["%s"]
             }
             """.formatted(bobCalendarUrl));
+        awaitMessage(messages, msg -> msg.contains("\"registered\""));
 
-        // WHEN: Alice creates an event
+        // WHEN: Bob's calendar changes
         String eventUid = "event-" + System.currentTimeMillis();
         String ics = buildEventICS(eventUid, alice.username().asString(), bob.username().asString());
-        davTestHelper.upsertCalendar(alice, ics, eventUid);
+        davTestHelper.upsertCalendar(bob, ics, eventUid);
 
         // Bob receives websocket notification (skip unrelated messages)
         String pushMessage = awaitMessage(messages, msg -> msg.contains("syncToken"));

--- a/app/src/test/java/com/linagora/calendar/app/CalendarDavToWebsocketFlowIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/CalendarDavToWebsocketFlowIntegrationTest.java
@@ -52,7 +52,6 @@ import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.CalDavClient.ItipRequest;
 import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.DavTestHelper;
-import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.storage.CalendarURL;
@@ -70,7 +69,7 @@ class CalendarDavToWebsocketFlowIntegrationTest {
 
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavExtension sabreDavExtension = SabreDavExtension.perClass();
 
     @Order(2)
     @RegisterExtension
@@ -257,6 +256,7 @@ class CalendarDavToWebsocketFlowIntegrationTest {
             VERSION:2.0
             PRODID:-//Sabre//Sabre VObject 4.2.2//EN
             CALSCALE:GREGORIAN
+            METHOD:REQUEST
             BEGIN:VEVENT
             UID:{UID}
             DTSTAMP:{DTSTAMP}Z
@@ -264,7 +264,7 @@ class CalendarDavToWebsocketFlowIntegrationTest {
             DTEND;TZID=Asia/Ho_Chi_Minh:{END}
             SUMMARY:WebSocket Flow Test
             ORGANIZER:mailto:{ORGANIZER}
-            ATTENDEE;PARTSTAT=ACCEPTED:mailto:{ATTENDEE}
+            ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{ATTENDEE}
             END:VEVENT
             END:VCALENDAR
             """;

--- a/app/src/test/java/com/linagora/calendar/app/CalendarDavToWebsocketFlowIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/CalendarDavToWebsocketFlowIntegrationTest.java
@@ -49,6 +49,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.CalDavClient.ItipRequest;
 import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
@@ -158,7 +159,7 @@ class CalendarDavToWebsocketFlowIntegrationTest {
         String eventUid = "event-" + System.currentTimeMillis();
         String ics = buildEventICS(eventUid, alice.username().asString(), bob.username().asString());
 
-        davTestHelper.upsertCalendar(bob, ics, eventUid);
+        sendItipRequestToBob(eventUid, ics);
 
         String pushMessage = awaitMessage(messages, msg -> msg.contains("syncToken") && msg.contains(bobCalendarUrl));
 
@@ -190,7 +191,7 @@ class CalendarDavToWebsocketFlowIntegrationTest {
         // WHEN: Bob's calendar changes
         String eventUid = "event-" + System.currentTimeMillis();
         String ics = buildEventICS(eventUid, alice.username().asString(), bob.username().asString());
-        davTestHelper.upsertCalendar(bob, ics, eventUid);
+        sendItipRequestToBob(eventUid, ics);
 
         // Bob receives websocket notification (skip unrelated messages)
         String pushMessage = awaitMessage(messages, msg -> msg.contains("syncToken"));
@@ -231,6 +232,19 @@ class CalendarDavToWebsocketFlowIntegrationTest {
         Map<String, Object> inner = (Map<String, Object>) entry.getValue();
         String syncToken = (String) inner.get("syncToken");
         return Pair.of(CalendarURL.deserialize(Strings.CS.removeStart(calendarUrlString, "/calendars/")), syncToken);
+    }
+
+    private void sendItipRequestToBob(String eventUid, String ics) {
+        Boolean deliveredLocally = calDavClient.sendItip(bob.username(), new ItipRequest(
+                eventUid,
+                alice.username().asString(),
+                bob.username().asString(),
+                ics,
+                "REQUEST",
+                Optional.of(0)))
+            .block();
+
+        assertThat(deliveredLocally).isTrue();
     }
 
     private String buildEventICS(String eventUid, String organizer, String attendee) {

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
@@ -260,7 +260,7 @@ class EventParticipationRouteTest {
                                     ["dtstart", {"tzid": "Asia/Ho_Chi_Minh"}, "date-time", "${json-unit.ignore}"],
                                     ["dtend", {"tzid": "Asia/Ho_Chi_Minh"}, "date-time", "${json-unit.ignore}"],
                                     ["summary", {}, "text", "Twake Calendar - Sprint planning #04"],
-                                    ["organizer", {"cn": "Van Tung TRAN", "schedule-status": "1.1"}, "cal-address", "${json-unit.ignore}"],
+                                    ["organizer", {"cn": "Van Tung TRAN", "schedule-status": "${json-unit.ignore}"}, "cal-address", "${json-unit.ignore}"],
                                     ["attendee", {"cn": "Benoît TELLIER", "partstat": "ACCEPTED"}, "cal-address", "${json-unit.ignore}"]
                                 ],
                                 []
@@ -687,7 +687,7 @@ class EventParticipationRouteTest {
 
     private void upsertCalendarForTest(String eventUid) {
         davTestHelper.upsertCalendar(
-            organizer,
+            attendee,
             generateCalendarData(eventUid, organizer.username().asString(), attendee.username().asString()),
             eventUid);
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCancellationTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCancellationTest.java
@@ -63,12 +63,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import com.github.fge.lambdas.Throwing;
-import com.linagora.calendar.smtp.EventEmailFilter;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.CalDavEventRepository;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.smtp.EventEmailFilter;
 import com.linagora.calendar.storage.AlarmEventDAO;
 import com.linagora.calendar.storage.AlarmEventFactory;
 import com.linagora.calendar.storage.MemoryAlarmEventDAO;
@@ -89,7 +88,7 @@ import reactor.rabbitmq.Sender;
 public class AlarmEventCancellationTest {
 
     @RegisterExtension
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
 
     private static final SettingsBasedResolver settingsResolver = mock(SettingsBasedResolver.class);
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCreateTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCreateTest.java
@@ -74,7 +74,6 @@ import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.CalDavEventRepository;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.AlarmEvent;
 import com.linagora.calendar.storage.AlarmEventDAO;
 import com.linagora.calendar.storage.AlarmEventFactory;
@@ -101,7 +100,8 @@ import reactor.rabbitmq.Sender;
 public class AlarmEventCreateTest {
 
     @RegisterExtension
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
+
     private static final SettingsBasedResolver settingsResolver = mock(SettingsBasedResolver.class);
     private static final EventEmailFilter eventEmailFilter = spy(EventEmailFilter.acceptAll());
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventUpdateTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventUpdateTest.java
@@ -68,7 +68,6 @@ import com.linagora.calendar.dav.CalendarEventModifier;
 import com.linagora.calendar.dav.CalendarEventUpdatePatch;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.AlarmEvent;
 import com.linagora.calendar.storage.AlarmEventDAO;
 import com.linagora.calendar.storage.AlarmEventFactory;
@@ -93,7 +92,7 @@ import reactor.rabbitmq.Sender;
 public class AlarmEventUpdateTest {
 
     @RegisterExtension
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
 
     private static final SettingsBasedResolver settingsResolver = mock(SettingsBasedResolver.class);
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCancelEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCancelEmailConsumerTest.java
@@ -77,7 +77,6 @@ import com.linagora.calendar.api.Participation;
 import com.linagora.calendar.api.ParticipationTokenSigner;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.smtp.MailSender;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
 import com.linagora.calendar.smtp.MockSmtpServerExtension;
@@ -110,7 +109,7 @@ public class EventCancelEmailConsumerTest {
 
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
 
     @RegisterExtension
     @Order(2)

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCounterEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCounterEmailConsumerTest.java
@@ -19,7 +19,6 @@
 package com.linagora.calendar.amqp;
 
 import static com.linagora.calendar.amqp.EventInviteEmailConsumerTest.INTERNAL_USER;
-import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static com.linagora.calendar.storage.configuration.EntryIdentifier.LANGUAGE_IDENTIFIER;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,8 +72,6 @@ import com.linagora.calendar.smtp.EventEmailFilter;
 import com.linagora.calendar.api.EventParticipationActionLinkFactory;
 import com.linagora.calendar.api.Participation;
 import com.linagora.calendar.api.ParticipationTokenSigner;
-import com.linagora.calendar.dav.DavTestHelper;
-import com.linagora.calendar.dav.DavTestHelper.CounterRequest;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.smtp.MailSender;
@@ -96,6 +93,7 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import reactor.core.publisher.Mono;
+import reactor.rabbitmq.OutboundMessage;
 
 public class EventCounterEmailConsumerTest {
     private final ConditionFactory calmlyAwait = Awaitility.with()
@@ -118,7 +116,6 @@ public class EventCounterEmailConsumerTest {
     private static final EventEmailFilter eventEmailFilter = spy(EventEmailFilter.acceptAll());
     private static ReactorRabbitMQChannelPool channelPool;
     private static SimpleConnectionPool connectionPool;
-    private static DavTestHelper davTestHelper;
 
     @BeforeAll
     static void beforeAll(DockerSabreDavSetup dockerSabreDavSetup) throws Exception {
@@ -137,8 +134,6 @@ public class EventCounterEmailConsumerTest {
             new RecordingMetricFactory(),
             new NoopGaugeRegistry());
         channelPool.start();
-
-        davTestHelper = new DavTestHelper(dockerSabreDavSetup.davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
     }
 
     @AfterAll
@@ -232,8 +227,6 @@ public class EventCounterEmailConsumerTest {
     void shouldSendEmailWhenProposeCounterEvent() {
         when(settingsResolver.resolveOrDefault(any(Username.class), any(Username.class)))
             .thenReturn(Mono.just(SettingsBasedResolver.ResolvedSettings.DEFAULT));
-        // Ensure no event exists initially for attendee
-        assertThat(davTestHelper.findFirstEventId(attendee)).isEmpty();
 
         JsonPath smtpMailsResponse = simulateProposeCounterAndWaitForEmail();
         int counterIndex = findCounterMailIndex(smtpMailsResponse);
@@ -290,10 +283,6 @@ public class EventCounterEmailConsumerTest {
             LocalDateTime.now().plusDays(1).plusHours(1),
             false,
             Optional.empty());
-        davTestHelper.upsertCalendar(organizer, initialCalendarData, eventUid);
-
-        // When: Attendee propose counter event
-        String eventDavIdOnAttendee = waitForEventCreation(attendee);
         String counterEvent = generateCalendarData(
             eventUid,
             organizer.username().asString(),
@@ -303,34 +292,46 @@ public class EventCounterEmailConsumerTest {
             true,
             Optional.of("I propose a counter event"));
 
-        CounterRequest  counterRequest = new CounterRequest(
-            counterEvent,
-            attendee.username().asString(),
-            organizer.username().asString(),
-            eventUid,
-            1);
-
-        davTestHelper.postCounter(attendee, eventDavIdOnAttendee, counterRequest).block();
+        publishCounterEmailNotification(counterEvent, initialCalendarData, eventUid);
 
         // Wait for the mail to be received via mock SMTP
         awaitAtMost
             .atMost(Duration.ofSeconds(20))
-            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(2));
+            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
 
         // Then: Received mail
         return  smtpMailsResponseSupplier.get();
     }
 
+    private void publishCounterEmailNotification(String counterEvent, String oldEvent, String eventUid) {
+        String eventPath = "/calendars/%s/%s/%s.ics".formatted(attendee.id().value(), attendee.id().value(), eventUid);
+        String payload = """
+            {
+              "senderEmail": "%s",
+              "recipientEmail": "%s",
+              "method": "COUNTER",
+              "event": "%s",
+              "notify": true,
+              "calendarURI": "%s",
+              "eventPath": "%s",
+              "oldEvent": "%s"
+            }
+            """.formatted(
+            attendee.username().asString(),
+            organizer.username().asString(),
+            counterEvent.replace("\n", "\\r\\n"),
+            attendee.id().value(),
+            eventPath,
+            oldEvent.replace("\n", "\\r\\n"));
+
+        channelPool.getSender()
+            .send(Mono.just(new OutboundMessage(EventEmailConsumer.EXCHANGE_NAME, "", payload.getBytes())))
+            .block();
+    }
+
     private static final Supplier<JsonPath> smtpMailsResponseSupplier = () -> given(mockSMTPRequestSpecification())
         .get("/smtpMails")
         .jsonPath();
-
-    private String waitForEventCreation(OpenPaaSUser user) {
-        awaitAtMost.untilAsserted(() ->
-            assertThat(davTestHelper.findFirstEventId(user)).isPresent());
-
-        return davTestHelper.findFirstEventId(user).get();
-    }
 
     private String generateCalendarData(String eventUid,
                                         String organizerEmail,

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
@@ -64,7 +64,6 @@ import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
 
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -94,7 +93,7 @@ public class EventIndexerConsumerTest {
     private final ConditionFactory awaitAtMost = calmlyAwait.atMost(30, TimeUnit.SECONDS);
 
     @RegisterExtension
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
 
     private static ReactorRabbitMQChannelPool channelPool;
     private static SimpleConnectionPool connectionPool;
@@ -132,23 +131,26 @@ public class EventIndexerConsumerTest {
     private OpenPaaSUser attendee2;
     private CalendarSearchService calendarSearchService;
     private Sender sender;
+    private EventIndexerConsumer eventIndexerConsumer;
 
     @BeforeEach
-    public void setUp(DockerSabreDavSetup dockerSabreDavSetup) {
+    public void setUp() {
         openPaasUser = sabreDavExtension.newTestUser();
         attendee1 = sabreDavExtension.newTestUser();
         attendee2 = sabreDavExtension.newTestUser();
         calendarSearchService = Mockito.spy(new MemoryCalendarSearchService());
 
-        EventIndexerConsumer calendarEventConsumer = new EventIndexerConsumer(channelPool, calendarSearchService,
+        eventIndexerConsumer = new EventIndexerConsumer(channelPool, calendarSearchService,
             QueueArguments.Builder::new, new RecordingMetricFactory());
-        calendarEventConsumer.init();
+        eventIndexerConsumer.init();
 
         sender = channelPool.getSender();
     }
 
     @AfterEach
     void afterEach() {
+        eventIndexerConsumer.close();
+
         Arrays.stream(EventIndexerConsumer.Queue
                 .values())
             .map(EventIndexerConsumer.Queue::queueName)

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventInviteEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventInviteEmailConsumerTest.java
@@ -78,7 +78,6 @@ import com.linagora.calendar.api.Participation;
 import com.linagora.calendar.api.ParticipationTokenSigner;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.smtp.MailSender;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
 import com.linagora.calendar.smtp.MockSmtpServerExtension;
@@ -114,7 +113,7 @@ public class EventInviteEmailConsumerTest {
 
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
 
     @RegisterExtension
     @Order(2)

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
@@ -77,7 +77,6 @@ import com.linagora.calendar.api.Participation;
 import com.linagora.calendar.api.ParticipationTokenSigner;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.smtp.EventEmailFilter;
 import com.linagora.calendar.smtp.MailSender;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
@@ -120,7 +119,7 @@ public class EventPublicAgendaEmailConsumerTest {
 
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
 
     @RegisterExtension
     @Order(2)

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
@@ -86,7 +86,6 @@ import com.linagora.calendar.dav.CalDavEventRepository;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.Fixture;
-import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.smtp.EventEmailFilter;
 import com.linagora.calendar.smtp.MailSender;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
@@ -125,7 +124,7 @@ public class EventReplyEmailConsumerTest {
 
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
 
     @RegisterExtension
     @Order(2)

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
@@ -81,7 +81,6 @@ import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.CalDavEventRepository;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.smtp.MailSender;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
 import com.linagora.calendar.smtp.MockSmtpServerExtension;
@@ -121,7 +120,7 @@ public class EventResourceConsumerTest {
 
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
 
     @RegisterExtension
     @Order(2)
@@ -678,4 +677,3 @@ public class EventResourceConsumerTest {
         channel.basicPublish(exchange, EMPTY_ROUTING_KEY, basicProperties, message.getBytes(StandardCharsets.UTF_8));
     }
 }
-

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventUpdateEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventUpdateEmailConsumerTest.java
@@ -77,7 +77,6 @@ import com.linagora.calendar.api.Participation;
 import com.linagora.calendar.api.ParticipationTokenSigner;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.smtp.MailSender;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
 import com.linagora.calendar.smtp.MockSmtpServerExtension;
@@ -109,7 +108,7 @@ public class EventUpdateEmailConsumerTest {
 
     @RegisterExtension
     @Order(1)
-    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+    static SabreDavWithAsyncSchedulingExtension sabreDavExtension = new SabreDavWithAsyncSchedulingExtension();
 
     @RegisterExtension
     @Order(2)

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/SabreAsyncSchedulingExtension.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/SabreAsyncSchedulingExtension.java
@@ -1,0 +1,124 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import static com.linagora.calendar.amqp.CalendarAmqpModule.DEFAULT_ITIP_EVENT_MESSAGES_PREFETCH_COUNT;
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Objects;
+
+import org.apache.james.backends.rabbitmq.QueueArguments;
+import org.apache.james.backends.rabbitmq.RabbitMQConfiguration;
+import org.apache.james.backends.rabbitmq.RabbitMQConnectionFactory;
+import org.apache.james.backends.rabbitmq.ReactorRabbitMQChannelPool;
+import org.apache.james.backends.rabbitmq.SimpleConnectionPool;
+import org.apache.james.metrics.api.NoopGaugeRegistry;
+import org.apache.james.metrics.tests.RecordingMetricFactory;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBResourceDAO;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+
+import reactor.rabbitmq.QueueSpecification;
+
+public class SabreAsyncSchedulingExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+
+    private final SabreDavExtension sabreDavExtension;
+    private SimpleConnectionPool connectionPool;
+    private ReactorRabbitMQChannelPool channelPool;
+    private ItipLocalDeliveryConsumer itipLocalDeliveryConsumer;
+
+    public SabreAsyncSchedulingExtension(SabreDavExtension sabreDavExtension) {
+        this.sabreDavExtension = Objects.requireNonNull(sabreDavExtension);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        RabbitMQConfiguration rabbitMQConfiguration = sabreDavExtension.dockerSabreDavSetup().rabbitMQConfiguration();
+
+        RabbitMQConnectionFactory connectionFactory = new RabbitMQConnectionFactory(rabbitMQConfiguration);
+        connectionPool = new SimpleConnectionPool(connectionFactory,
+            SimpleConnectionPool.Configuration.builder()
+                .retries(2)
+                .initialDelay(Duration.ofMillis(5)));
+        channelPool = new ReactorRabbitMQChannelPool(connectionPool.getResilientConnection(),
+            ReactorRabbitMQChannelPool.Configuration.builder()
+                .retries(2)
+                .maxBorrowDelay(Duration.ofMillis(250))
+                .maxChannel(10),
+            new RecordingMetricFactory(),
+            new NoopGaugeRegistry());
+        channelPool.start();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        itipLocalDeliveryConsumer = new ItipLocalDeliveryConsumer(channelPool,
+            QueueArguments.Builder::new,
+            new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING),
+            localRecipientResolver(),
+            DEFAULT_ITIP_EVENT_MESSAGES_PREFETCH_COUNT);
+        itipLocalDeliveryConsumer.init();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) {
+        try {
+            if (itipLocalDeliveryConsumer != null) {
+                itipLocalDeliveryConsumer.close();
+            }
+        } finally {
+            deleteItipLocalDeliveryQueues();
+            itipLocalDeliveryConsumer = null;
+        }
+    }
+
+    private void deleteItipLocalDeliveryQueues() {
+        channelPool.getSender().delete(QueueSpecification.queue().name(ItipLocalDeliveryConsumer.QUEUE_NAME)).block();
+        channelPool.getSender().delete(QueueSpecification.queue().name(ItipLocalDeliveryConsumer.DEAD_LETTER_QUEUE)).block();
+    }
+
+    private LocalRecipientResolver localRecipientResolver() {
+        MongoDatabase mongoDB = sabreDavExtension.dockerSabreDavSetup().getMongoDB();
+        MongoDBOpenPaaSDomainDAO domainDAO = new MongoDBOpenPaaSDomainDAO(mongoDB);
+        return new LocalRecipientResolver(new MongoDBOpenPaaSUserDAO(mongoDB, domainDAO),
+            new MongoDBResourceDAO(mongoDB, Clock.systemUTC()),
+            domainDAO);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        if (channelPool != null) {
+            channelPool.close();
+        }
+        if (connectionPool != null) {
+            connectionPool.close();
+        }
+    }
+}

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/SabreDavWithAsyncSchedulingExtension.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/SabreDavWithAsyncSchedulingExtension.java
@@ -1,0 +1,109 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import com.linagora.calendar.dav.DavTestHelper;
+import com.linagora.calendar.dav.DockerSabreDavSetup;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.storage.OpenPaaSUser;
+
+public class SabreDavWithAsyncSchedulingExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, ParameterResolver {
+    private final SabreDavExtension sabreDavExtension;
+    private final SabreAsyncSchedulingExtension asyncSchedulingExtension;
+
+    public SabreDavWithAsyncSchedulingExtension() {
+        this(SabreDavExtension.shared());
+    }
+
+    public SabreDavWithAsyncSchedulingExtension(SabreDavExtension sabreDavExtension) {
+        this.sabreDavExtension = Objects.requireNonNull(sabreDavExtension);
+        this.asyncSchedulingExtension = new SabreAsyncSchedulingExtension(sabreDavExtension);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        sabreDavExtension.beforeAll(extensionContext);
+        asyncSchedulingExtension.beforeAll(extensionContext);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        asyncSchedulingExtension.beforeEach(extensionContext);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        try {
+            asyncSchedulingExtension.afterEach(extensionContext);
+        } finally {
+            sabreDavExtension.afterEach(extensionContext);
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        try {
+            asyncSchedulingExtension.afterAll(extensionContext);
+        } finally {
+            sabreDavExtension.afterAll(extensionContext);
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return sabreDavExtension.supportsParameter(parameterContext, extensionContext);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return sabreDavExtension.resolveParameter(parameterContext, extensionContext);
+    }
+
+    public OpenPaaSUser newTestUser() {
+        return sabreDavExtension.newTestUser();
+    }
+
+    public OpenPaaSUser newTestUser(Optional<String> prefix) {
+        return sabreDavExtension.newTestUser(prefix);
+    }
+
+    public DockerSabreDavSetup dockerSabreDavSetup() {
+        return sabreDavExtension.dockerSabreDavSetup();
+    }
+
+    public void deleteRabbitMQQueues(String... queueNames) {
+        sabreDavExtension.deleteRabbitMQQueues(queueNames);
+    }
+
+    public DavTestHelper davTestHelper() {
+        return sabreDavExtension.davTestHelper();
+    }
+}

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
@@ -24,6 +24,7 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
@@ -1049,7 +1050,7 @@ public class CalDavClientTest {
 
     @Test
     void calendarQueryReportXmlShouldQueryResourceCalendar() {
-        // Given a resource calendar receives an event from an organizer invitation.
+        // Given a resource calendar already contains an event.
         OpenPaaSUser admin = createOpenPaaSUser();
         OpenPaaSDomain domain = new MongoDBOpenPaaSDomainDAO(sabreDavExtension.dockerSabreDavSetup().getMongoDB())
             .retrieve(admin.username().getDomainPart().get())
@@ -1082,13 +1083,12 @@ public class CalDavClientTest {
             END:VCALENDAR
             """.formatted(uid, admin.username().asString(), resourceEmail);
 
-        davTestHelper.upsertCalendar(admin, ics, uid);
-        String resourceEventId = Fixture.awaitAtMost.until(
-            () -> davTestHelper.findFirstEventId(resourceId, domain.id()),
-            Optional::isPresent).get();
+        CalendarURL resourceCalendarURL = CalendarURL.from(resourceId.asOpenPaaSId());
+        URI resourceEventUri = URI.create("/calendars/" + resourceId.value() + "/" + resourceId.value() + "/" + uid + ".ics");
+        davTestHelper.upsertCalendar(domain.id(), resourceEventUri, ics).block();
+        String resourceEventId = uid;
 
         // When querying the resource calendar through the domain technical token.
-        CalendarURL resourceCalendarURL = CalendarURL.from(resourceId.asOpenPaaSId());
         List<CalendarObject> items = testee.calendarQueryReportXml(domain.id(), resourceCalendarURL, CalendarQuery.ofFilters())
             .block()
             .extractCalendarObjects();

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavEventRepositoryTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavEventRepositoryTest.java
@@ -140,7 +140,7 @@ public class CalDavEventRepositoryTest {
                         ["dtstart", { "tzid": "Asia/Ho_Chi_Minh" }, "date-time", "${json-unit.any-string}"],
                         ["dtend", { "tzid": "Asia/Ho_Chi_Minh" }, "date-time", "${json-unit.any-string}"],
                         ["summary", {}, "text", "Twake Calendar - Sprint planning #04"],
-                        ["organizer", { "cn": "Van Tung TRAN", "schedule-status": "1.1" }, "cal-address", "mailto:%s"],
+                        ["organizer", { "cn": "Van Tung TRAN", "schedule-status": "1.0" }, "cal-address", "mailto:%s"],
                         ["attendee", { "cn": "Benoît TELLIER", "partstat": "ACCEPTED" }, "cal-address", "mailto:%s"]
                       ],
                       []
@@ -244,6 +244,7 @@ public class CalDavEventRepositoryTest {
                 BEGIN:VCALENDAR
                 VERSION:2.0
                 PRODID:-//Twake//Recurrence Test//EN
+                CALSCALE:GREGORIAN
                 BEGIN:VEVENT
                 UID:%1$s
                 DTSTAMP:%2$sZ
@@ -276,8 +277,7 @@ public class CalDavEventRepositoryTest {
             dateTime(1, 11, 0),
             dateTime(1, 11, 30));
 
-        davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
-        waitForEventCreation(attendee);
+        davTestHelper.upsertCalendar(attendee, calendarData, eventUid);
 
         CalendarReportJsonResponse result = testee.updatePartStat(
             attendee.username(), attendee.id(), new EventUid(eventUid), PartStat.ACCEPTED).block();
@@ -303,7 +303,7 @@ public class CalDavEventRepositoryTest {
                         ["dtend", { "tzid": "Asia/Ho_Chi_Minh" }, "date-time", "${json-unit.any-string}"],
                         ["rrule", {}, "recur", { "freq": "DAILY", "count": 3 }],
                         ["summary", {}, "text", "Recurring Standup Meeting"],
-                        ["organizer", { "cn": "Van Tung TRAN", "schedule-status": "1.1" }, "cal-address", "mailto:%s"],
+                        ["organizer", { "cn": "Van Tung TRAN", "schedule-status": "1.0" }, "cal-address", "mailto:%s"],
                         ["sequence", {}, "integer", 1],
                         ["attendee", { "cn": "Benoît TELLIER", "partstat": "ACCEPTED" }, "cal-address", "mailto:%s"]
                       ],
@@ -396,27 +396,21 @@ public class CalDavEventRepositoryTest {
 
 
         davTestHelper.upsertCalendar(organizer, icalData, eventUid);
-
-        // Wait until resource calendar sees the event
-        Fixture.awaitAtMost.untilAsserted(() ->
-            assertThat(davTestHelper.findFirstEventId(resourceId, domain.id()))
-                .withFailMessage("Event not created for resource: " + resourceId.value())
-                .isPresent());
+        upsertResourceCalendar(domain.id(), resourceId, icalData, eventUid);
 
         String eventPathId = davTestHelper.findFirstEventId(resourceId, domain.id()).get();
 
         // When: update participation status of the resource to ACCEPTED
         testee.updatePartStat(domain, resourceId, eventPathId, PartStat.ACCEPTED).block();
 
-        // Then: verify that resource attendee in organizer’s calendar has been updated
-
-        URI organizerEventHref = URI.create("/calendars/")
-            .resolve(organizer.id().value() + "/")
-            .resolve(organizer.id().value() + "/")
-            .resolve(eventUid + ".ics");
+        // Then: verify the resource calendar event has been updated.
+        URI resourceEventHref = URI.create("/calendars/")
+            .resolve(resourceId.value() + "/")
+            .resolve(resourceId.value() + "/")
+            .resolve(eventPathId + ".ics");
 
         Fixture.awaitAtMost.untilAsserted(() -> {
-            DavCalendarObject calendarObject = calDavClient.fetchCalendarEvent(organizer.username(), organizerEventHref).block();
+            DavCalendarObject calendarObject = davTestHelper.fetchCalendarEvent(domain.id(), resourceEventHref).block();
             EventFields.Person resourceAttendee = getFirstResource(calendarObject);
             assertThat(resourceAttendee.partStat()).contains(PartStat.ACCEPTED);
         });
@@ -425,13 +419,6 @@ public class CalDavEventRepositoryTest {
     private EventFields.Person getFirstResource(DavCalendarObject calendarObject) {
         VEvent vEvent = (VEvent) calendarObject.calendarData().getComponent(Component.VEVENT).get();
         return EventParseUtils.getResources(vEvent).getFirst();
-    }
-
-    private void waitForEventCreation(OpenPaaSUser user) {
-        Fixture.awaitAtMost.untilAsserted(() ->
-            assertThat(davTestHelper.findFirstEventId(user))
-                .withFailMessage("Event not created for user: " + user.username())
-                .isPresent());
     }
 
     private String generateCalendarData(String eventUid, String organizerEmail, String attendeeEmail,
@@ -493,9 +480,13 @@ public class CalDavEventRepositoryTest {
 
     private void upsertCalendarForTest(String eventUid, PartStat partStat) {
         davTestHelper.upsertCalendar(
-            organizer,
+            attendee,
             generateCalendarData(eventUid, organizer.username().asString(), attendee.username().asString(), partStat),
             eventUid);
-        waitForEventCreation(attendee);
+    }
+
+    private void upsertResourceCalendar(OpenPaaSId domainId, ResourceId resourceId, String calendarData, String eventUid) {
+        URI davCalendarUri = URI.create("/calendars/" + resourceId.value() + "/" + resourceId.value() + "/" + eventUid + ".ics");
+        davTestHelper.upsertCalendar(domainId, davCalendarUri, calendarData).block();
     }
 }

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/DavExchangeNames.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/DavExchangeNames.java
@@ -52,7 +52,7 @@ public class DavExchangeNames {
         "calendar:event:deleted",
         "calendar:event:cancel",
         "calendar:event:request",
-        "calendar:itip:deliver",
+        "calendar:itip:localDelivery",
         "resource:calendar:event:created",
         "resource:calendar:event:accepted",
         "resource:calendar:event:declined");

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/DavTestHelper.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/DavTestHelper.java
@@ -121,6 +121,30 @@ public class DavTestHelper extends DavClient {
             });
     }
 
+    public Mono<Void> upsertCalendar(OpenPaaSId domainId, URI uri, String calendarData) {
+        return httpClientWithTechnicalToken(domainId)
+            .flatMap(client -> client.headers(headers ->
+                    headers.add(HttpHeaderNames.CONTENT_TYPE, "text/plain"))
+                .request(HttpMethod.PUT)
+                .uri(uri.toString())
+                .send(Mono.just(Unpooled.wrappedBuffer(calendarData.getBytes(StandardCharsets.UTF_8))))
+                .responseSingle((response, responseContent) -> {
+                    if (response.status().code() == 201 || response.status().code() == 204) {
+                        return Mono.empty();
+                    }
+                    return responseContent.asString(StandardCharsets.UTF_8)
+                        .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                        .flatMap(responseBody -> Mono.error(new DavClientException("""
+                            Unexpected status code: %d when create/update calendar object '%s'
+                            %s
+                            """.formatted(response.status().code(), uri.toString(), responseBody))));
+                }));
+    }
+
+    public Mono<DavCalendarObject> fetchCalendarEvent(OpenPaaSId domainId, URI calendarEventHref) {
+        return calDavClient.fetchCalendarEvent(httpClientWithTechnicalToken(domainId), calendarEventHref);
+    }
+
     public Mono<Void> postCounter(OpenPaaSUser openPaaSUser, String attendeeEventUid, CounterRequest counterRequest) {
         URI uri = URI.create("/calendars/" + openPaaSUser.id().value() + "/" + openPaaSUser.id().value() + "/" + attendeeEventUid + ".ics");
         return httpClientWithImpersonation(openPaaSUser.username()).headers(headers -> headers

--- a/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
+++ b/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
@@ -43,7 +43,7 @@ services:
 
   sabre_dav:
     hostname: esn_sabre
-    image: linagora/esn-sabre:2.3.1.1
+    image: linagora/esn-sabre:2.3.2
     environment:
       - SABRE_ENV=dev
       - SABRE_MONGO_HOST=mongo

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
@@ -31,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
@@ -270,9 +271,9 @@ public class CalendarRoutesTest {
             END:VCALENDAR
             """.formatted(eventId, openPaaSUser.username().asString(), resourceEmail);
         davTestHelper.upsertCalendar(openPaaSUser, ics, eventId);
-        String resourceEventId = awaitAtMost.until(
-            () -> davTestHelper.findFirstEventId(resourceId, domain.id()),
-            Optional::isPresent).get();
+        URI resourceEventUri = URI.create("/calendars/" + resourceId.value() + "/" + resourceId.value() + "/" + eventId + ".ics");
+        davTestHelper.upsertCalendar(domain.id(), resourceEventUri, ics).block();
+        String resourceEventId = eventId;
 
         String taskId = given()
             .queryParam("task", "reindex")


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/800

## Context

The new `esn-sabre` image no longer supports `synchronize` scheduling mode. A number of side-service tests were relying on this mode to deliver iTIP messages synchronously, which caused failures after the image update.


## Changes

- Add `SabreAsyncSchedulingExtension` to run `ItipLocalDeliveryConsumer` in the background during tests.
- Add `SabreDavWithAsyncSchedulingExtension`, which composes `SabreDavExtension` and `SabreAsyncSchedulingExtension`, to reduce boilerplate in test setup.
- Update tests that actually depend on scheduling behavior to use async scheduling.
- Adjust tests where scheduling is not the behavior under test to avoid unnecessary organizer/attendee flows.






