### PR TITLE
ISSUE-775 update(alarm): filter email VALARM recipients

### DIFF
--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/AlarmInstantFactoryTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/AlarmInstantFactoryTest.java
@@ -168,6 +168,244 @@ public class AlarmInstantFactoryTest {
     }
 
     @Test
+    void shouldSkipInvalidEmailAlarmRecipient() {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            UID:invalid-email-alarm-recipient
+            DTSTART:20250829T100000Z
+            SUMMARY:Meeting
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:jane@example.com
+            BEGIN:VALARM
+            ACTION:EMAIL
+            ATTENDEE:urn:uuid:not-a-mail-address
+            ATTENDEE:mailto:jane@example.com
+            TRIGGER:-PT15M
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+        AlarmInstantFactory testee = testee(Instant.parse("2025-07-28T00:00:00Z"));
+
+        // When an email VALARM mixes an invalid recipient with a valid one
+        Optional<AlarmInstant> result = testee.computeNextAlarmInstant(calendar, Username.of("jane@example.com"));
+
+        // Then the invalid recipient is skipped without preventing the valid alarm recipient
+        assertThat(result)
+            .describedAs("Invalid email VALARM recipients should be ignored")
+            .isPresent()
+            .contains(new AlarmInstant(Instant.parse("2025-08-29T09:45:00Z"),
+                Instant.parse("2025-08-29T10:00:00Z"),
+                Optional.empty(),
+                List.of(asMailAddress("jane@example.com")),
+                AlarmAction.EMAIL));
+    }
+
+    @Test
+    void shouldPickCurrentUserSpecificEmailVALARMAmongMultipleVALARMs() {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            UID:organizer-specific-email-alarm
+            DTSTART:20250829T100000Z
+            SUMMARY:Meeting
+            ORGANIZER:mailto:organizer@example.com
+            ATTENDEE;ROLE=CHAIR;PARTSTAT=ACCEPTED:mailto:organizer@example.com
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:attendee@example.com
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:other-attendee@example.com
+            BEGIN:VALARM
+            ACTION:EMAIL
+            DESCRIPTION:This is an event reminder
+            SUMMARY:Alarm notification
+            ATTENDEE:mailto:attendee@example.com
+            ATTENDEE:mailto:other-attendee@example.com
+            TRIGGER:-P0DT0H10M0S
+            END:VALARM
+            BEGIN:VALARM
+            ACTION:EMAIL
+            DESCRIPTION:This is an event reminder
+            SUMMARY:Alarm notification
+            ATTENDEE:mailto:organizer@example.com
+            TRIGGER:-P0DT0H05M0S
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+        AlarmInstantFactory testee = testee(Instant.parse("2025-07-28T00:00:00Z"));
+
+        // When current user and other attendees are targeted by different email VALARM components
+        Optional<AlarmInstant> result = testee.computeNextAlarmInstant(calendar, Username.of("organizer@example.com"));
+
+        // Then the current user calendar keeps only the email VALARM component targeting current user
+        assertThat(result)
+            .describedAs("Current user should keep only the email VALARM component targeting current user")
+            .isPresent()
+            .get()
+            .satisfies(alarmInstant -> {
+                assertThat(alarmInstant.alarmTime()).isEqualTo(Instant.parse("2025-08-29T09:55:00Z"));
+                assertThat(alarmInstant.recipients()).isEqualTo(List.of(asMailAddress("organizer@example.com")));
+            });
+    }
+
+    @Test
+    void shouldKeepOnlyCurrentUserWhenSingleEmailVALARMTargetsMultipleAttendees() {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            UID:single-email-alarm-multiple-attendees
+            DTSTART:20250829T100000Z
+            SUMMARY:Meeting
+            ORGANIZER:mailto:organizer@example.com
+            ATTENDEE;ROLE=CHAIR;PARTSTAT=ACCEPTED:mailto:organizer@example.com
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:attendee@example.com
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:other-attendee@example.com
+            BEGIN:VALARM
+            ACTION:EMAIL
+            DESCRIPTION:This is an event reminder
+            SUMMARY:Alarm notification
+            ATTENDEE:mailto:organizer@example.com
+            ATTENDEE:mailto:attendee@example.com
+            ATTENDEE:mailto:other-attendee@example.com
+            TRIGGER:-P0DT0H10M0S
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+        AlarmInstantFactory testee = testee(Instant.parse("2025-07-28T00:00:00Z"));
+
+        // When a single email VALARM targets current user and other event attendees
+        Optional<AlarmInstant> result = testee.computeNextAlarmInstant(calendar, Username.of("organizer@example.com"));
+
+        // Then the current user calendar keeps only the recipient matching current user
+        assertThat(result)
+            .describedAs("Current user should keep only their own recipient from a multi-attendee email VALARM")
+            .isPresent()
+            .get()
+            .satisfies(alarmInstant -> {
+                assertThat(alarmInstant.alarmTime()).isEqualTo(Instant.parse("2025-08-29T09:50:00Z"));
+                assertThat(alarmInstant.recipients()).isEqualTo(List.of(asMailAddress("organizer@example.com")));
+            });
+    }
+
+    @Test
+    void shouldNotComputeAlarmWhenEmailAlarmTargetsOnlyOtherEventAttendee() {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            UID:organizer-attendee-alarm
+            DTSTART:20250829T100000Z
+            SUMMARY:Meeting
+            ORGANIZER:mailto:organizer@example.com
+            ATTENDEE;ROLE=CHAIR;PARTSTAT=ACCEPTED:mailto:organizer@example.com
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:attendee@example.com
+            BEGIN:VALARM
+            ACTION:EMAIL
+            ATTENDEE:mailto:attendee@example.com
+            TRIGGER:-PT15M
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+        AlarmInstantFactory testee = testee(Instant.parse("2025-07-28T00:00:00Z"));
+
+        // When email VALARM targets only another event attendee
+        Optional<AlarmInstant> result = testee.computeNextAlarmInstant(calendar, Username.of("organizer@example.com"));
+
+        // Then recipient filtering removes this alarm from the current user calendar
+        assertThat(result)
+            .describedAs("Current user alarm should not keep email VALARM recipients targeting only another event attendee")
+            .isEmpty();
+    }
+
+    @Test
+    void shouldComputeAlarmForAliasRecipient() {
+        // Given email VALARM targets alias@example.com, which is not an event attendee but another personal email of the organizer
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            UID:organizer-alias-alarm
+            DTSTART:20250829T100000Z
+            SUMMARY:Meeting
+            ORGANIZER:mailto:organizer@example.com
+            ATTENDEE;ROLE=CHAIR;PARTSTAT=ACCEPTED:mailto:organizer@example.com
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:attendee@example.com
+            BEGIN:VALARM
+            ACTION:EMAIL
+            ATTENDEE:mailto:alias@example.com
+            TRIGGER:-PT15M
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+        AlarmInstantFactory testee = testee(Instant.parse("2025-07-28T00:00:00Z"));
+
+        // When
+        Optional<AlarmInstant> result = testee.computeNextAlarmInstant(calendar, Username.of("organizer@example.com"));
+
+        // Then the current user calendar computes the alias recipient alarm
+        assertThat(result)
+            .describedAs("Current user calendar must schedule VALARM recipients that are not event attendees, such as an alias")
+            .isPresent()
+            .get()
+            .extracting(AlarmInstant::recipients)
+            .isEqualTo(List.of(asMailAddress("alias@example.com")));
+    }
+
+    @Test
+    void shouldKeepAliasAndCurrentUserWhenFilteringMixedEmailAlarmRecipients() {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            UID:organizer-attendee-alias-alarm
+            DTSTART:20250829T100000Z
+            SUMMARY:Meeting
+            ORGANIZER:mailto:organizer@example.com
+            ATTENDEE;ROLE=CHAIR;PARTSTAT=ACCEPTED:mailto:organizer@example.com
+            ATTENDEE;PARTSTAT=ACCEPTED:mailto:attendee@example.com
+            BEGIN:VALARM
+            ACTION:EMAIL
+            ATTENDEE:mailto:organizer@example.com
+            ATTENDEE:mailto:attendee@example.com
+            ATTENDEE:mailto:alias@example.com
+            TRIGGER:-PT15M
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+        AlarmInstantFactory testee = testee(Instant.parse("2025-07-28T00:00:00Z"));
+
+        // Given current user, another event attendee, and alias are listed in the same email VALARM
+        Optional<AlarmInstant> result = testee.computeNextAlarmInstant(calendar, Username.of("organizer@example.com"));
+
+        // Then AlarmInstantFactory filters out the other event attendee and keeps current user plus alias
+        assertThat(result)
+            .describedAs("Current user alarm should keep current user and alias recipients only")
+            .isPresent()
+            .get()
+            .extracting(AlarmInstant::recipients)
+            .isEqualTo(List.of(asMailAddress("organizer@example.com"),
+                asMailAddress("alias@example.com")));
+    }
+
+    @Test
     void shouldPickEarliestValidAlarmAmongMultiple() {
         String ics = """
             BEGIN:VCALENDAR

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/AlarmInstantFactory.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/AlarmInstantFactory.java
@@ -36,11 +36,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import jakarta.mail.internet.AddressException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -60,6 +59,7 @@ import net.fortuna.ical4j.model.Recur;
 import net.fortuna.ical4j.model.component.VAlarm;
 import net.fortuna.ical4j.model.component.VEvent;
 import net.fortuna.ical4j.model.parameter.PartStat;
+import net.fortuna.ical4j.model.property.Attendee;
 import net.fortuna.ical4j.model.property.ExDate;
 import net.fortuna.ical4j.model.property.RRule;
 import net.fortuna.ical4j.model.property.RecurrenceId;
@@ -75,6 +75,10 @@ public interface AlarmInstantFactory {
             Preconditions.checkArgument(alarmTime != null, "alarmTime must not be null");
             Preconditions.checkArgument(eventStartTime != null, "eventStartTime must not be null");
             Preconditions.checkArgument(action != null, "action must not be null");
+        }
+
+        public AlarmInstant withRecipients(List<MailAddress> recipients) {
+            return new AlarmInstant(alarmTime, eventStartTime, recurrenceId, recipients, action);
         }
     }
 
@@ -103,15 +107,33 @@ public interface AlarmInstantFactory {
 
         @Override
         public Optional<AlarmInstant> computeNextAlarmInstant(Calendar calendar, Username username, Optional<Instant> sinceInstant) {
-            Instant sinceInstantValue = sinceInstant
-                .orElse(clock.instant());
+            Instant sinceInstantValue = sinceInstant.orElse(clock.instant());
+            MailAddress userMailAddress = Throwing.supplier(username::asMailAddress).get();
             return listUpcomingAcceptedVEvents(calendar, username).stream()
                 .filter(event -> !EventParseUtils.isCancelled(event))
-                .flatMap(event -> computeAlarmInstants(event).stream())
+                .flatMap(event -> computeAlarmInstants(event).stream()
+                    .map(alarmInstant -> filterRecipientsForUser(event, alarmInstant, userMailAddress))
+                    .flatMap(Optional::stream))
                 .filter(alarmInstant -> alarmInstant.alarmTime().isAfter(sinceInstantValue))
-                .filter(Throwing.predicate(alarmInstant -> alarmInstant.recipients().isEmpty()
-                    || alarmInstant.recipients().contains(username.asMailAddress())))
                 .min(EARLIEST_FIRST_ALARM_COMPARATOR);
+        }
+
+        private Optional<AlarmInstant> filterRecipientsForUser(VEvent event, AlarmInstant alarmInstant, MailAddress userMailAddress) {
+            if (alarmInstant.recipients().isEmpty()) {
+                return Optional.of(alarmInstant);
+            }
+
+            Set<MailAddress> otherEventAttendeeMailAddresses = EventParseUtils.getAttendees(event).stream()
+                .map(EventFields.Person::email)
+                .filter(attendee -> !attendee.equals(userMailAddress))
+                .collect(Collectors.toSet());
+
+            return Optional.of(alarmInstant.recipients().stream()
+                    .filter(Predicate.not(otherEventAttendeeMailAddresses::contains))
+                    .distinct()
+                    .toList())
+                .filter(Predicate.not(List::isEmpty))
+                .map(alarmInstant::withRecipients);
         }
 
         private List<AlarmInstant> computeAlarmInstants(VEvent event) {
@@ -137,13 +159,17 @@ public interface AlarmInstantFactory {
 
         private List<MailAddress> extractRecipients(VAlarm vAlarm) {
             return vAlarm.getProperties(ATTENDEE).stream()
-                .map(property -> Strings.CS.replace(property.getValue(), "mailto:", ""))
-                .filter(StringUtils::isNotBlank)
-                .map(mailAddressValue -> {
+                .flatMap(property -> {
                     try {
-                        return new MailAddress(mailAddressValue);
-                    } catch (AddressException e) {
-                        throw new IllegalArgumentException("Invalid email address in ATTENDEE property: " + mailAddressValue, e);
+                        return Optional.ofNullable(((Attendee) property).getCalAddress())
+                            .map(Object::toString)
+                            .map(value -> Strings.CI.removeStart(value, "mailto:"))
+                            .filter(StringUtils::isNotEmpty)
+                            .map(Throwing.function(MailAddress::new))
+                            .stream();
+                    } catch (Exception e) {
+                        LOGGER.warn("Invalid email address in VALARM ATTENDEE property: {}. Skipping", property, e);
+                        return Optional.<MailAddress>empty().stream();
                     }
                 })
                 .toList();


### PR DESCRIPTION
- Support multiple EMAIL VALARM components with multiple attendee addresses.
- Filter recipients to avoid triggering duplicate email notifications for the same attendee from both organizer and replicated attendee ICS copies.

ref: https://github.com/linagora/twake-calendar-side-service/issues/775