### PR TITLE
fix(calendar-amqp): Gracefully stop AMQP consumers on application shutdown

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumer.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -100,7 +101,9 @@ public class CalendarDelegatedNotificationConsumer implements Closeable, Startab
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        LOGGER.info("Trying to stop delegated calendar notification consumer");
         if (consumeDisposable != null && !consumeDisposable.isDisposed()) {
             consumeDisposable.dispose();
         }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarListNotificationConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarListNotificationConsumer.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
 import org.apache.james.backends.rabbitmq.QueueArguments;
@@ -163,7 +164,9 @@ public class CalendarListNotificationConsumer implements Closeable, Startable {
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        LOGGER.info("Trying to stop calendar list notification consumer");
         if (consumeDisposable != null && !consumeDisposable.isDisposed()) {
             consumeDisposable.dispose();
         }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmConsumer.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -160,7 +161,9 @@ public class EventAlarmConsumer implements Closeable, Startable {
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        LOGGER.info("Trying to stop event alarm consumer");
         consumeDisposableMap.values().forEach(disposable -> {
             if (!disposable.isDisposed()) {
                 disposable.dispose();

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventCalendarConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventCalendarConsumer.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -147,7 +148,9 @@ public class EventCalendarConsumer implements Closeable, Startable {
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        LOGGER.info("Trying to stop event calendar consumer");
         consumeDisposableMap.values()
             .stream()
             .filter(disposable -> !disposable.isDisposed())

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventCalendarNotificationConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventCalendarNotificationConsumer.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -160,7 +161,9 @@ public class EventCalendarNotificationConsumer implements Closeable, Startable {
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        LOGGER.info("Trying to stop event calendar notification consumer");
         consumeDisposableMap.values().forEach(disposable -> {
             if (!disposable.isDisposed()) {
                 disposable.dispose();

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventEmailConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventEmailConsumer.java
@@ -27,6 +27,7 @@ import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 import java.io.Closeable;
 import java.util.function.Supplier;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.BooleanUtils;
@@ -149,7 +150,9 @@ public class EventEmailConsumer implements Closeable, Startable {
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        LOGGER.info("Trying to stop event email consumer");
         if (consumeDisposable != null && !consumeDisposable.isDisposed()) {
             consumeDisposable.dispose();
         }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventIndexerConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventIndexerConsumer.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -161,7 +162,9 @@ public class EventIndexerConsumer implements Closeable, Startable {
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        LOGGER.info("Trying to stop event indexer consumer");
         consumeDisposableMap.values().forEach(disposable -> {
             if (!disposable.isDisposed()) {
                 disposable.dispose();

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventResourceConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventResourceConsumer.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -155,7 +156,9 @@ public class EventResourceConsumer implements Closeable, Startable {
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        LOGGER.info("Trying to stop event resource consumer");
         consumeDisposableMap.values().forEach(disposable -> {
             if (!disposable.isDisposed()) {
                 disposable.dispose();

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
@@ -163,7 +164,9 @@ public class ItipLocalDeliveryConsumer implements Closeable, Startable {
     }
 
     @Override
+    @PreDestroy
     public void close() {
+        LOGGER.info("Trying to stop iTIP local delivery consumer");
         if (consumeDisposable != null && !consumeDisposable.isDisposed()) {
             consumeDisposable.dispose();
         }


### PR DESCRIPTION
During the investigation of flaky CI tests, we found that several AMQP consumers implement `Closeable`, but their `close()` methods are not called when the application or Docker container is stopped/restarted.

The current lifecycle only invokes methods registered with Guice `@PreDestroy`. Because these consumers were missing `@PreDestroy`, their RabbitMQ subscriptions were not explicitly disposed during shutdown.

This can lead to non-graceful shutdown behavior, and in test/CI scenarios may leave consumers active longer than expected, causing messages to be consumed by stale consumers and making tests flaky.


**Validation**
<img width="2360" height="952" alt="image" src="https://github.com/user-attachments/assets/1c64625c-cffb-43de-8b84-03a94426fd58" />
