### PR TITLE
ISSUE-801 Address book admin webadmin interface

### DIFF
--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CardDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CardDavClient.java
@@ -33,10 +33,13 @@ import org.apache.james.core.Username;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Streams;
@@ -83,9 +86,21 @@ public class CardDavClient extends DavClient {
     public record AddressBook(String value, AddressBookType type) {
     }
 
+    public record NewAddressBook(String id, String name, String description) {
+    }
+
+    public record AddressBookSharee(@JsonProperty("dav:href") String davHref,
+                                    @JsonProperty("dav:share-access") int shareAccess) {
+        public AddressBookSharee {
+            Preconditions.checkArgument(StringUtils.isNotBlank(davHref), "'dav:href' must not be blank");
+            Preconditions.checkArgument(shareAccess >= 2 && shareAccess <= 5, "'dav:share-access' must be between 2 and 5");
+        }
+    }
+
     public static final String LIMIT_PARAM = "limit";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CardDavClient.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final String CONTENT_TYPE_VCARD = "application/vcard";
     private static final String CONTENT_TYPE_VCARD_JSON = "application/vcard+json";
@@ -311,8 +326,7 @@ public class CardDavClient extends DavClient {
                     return Mono.empty();
                 }
                 if (response.status().code() == HttpStatus.SC_NOT_IMPLEMENTED) {
-                    LOGGER.info("Could not delete address book {}", addressBookURL.asUri().toASCIIString());
-                    return Mono.empty();
+                    return Mono.error(new SystemAddressBookException(addressBookURL));
                 }
                 return buf.asString(StandardCharsets.UTF_8)
                     .switchIfEmpty(Mono.just(StringUtils.EMPTY))
@@ -338,6 +352,125 @@ public class CardDavClient extends DavClient {
                             .formatted(response.status().code(),
                                 addressBookURL.vcardUri(vcardUid).toASCIIString(),
                                 errorBody))));
+            });
+    }
+
+    public Mono<byte[]> listUserAddressBooksAsBytes(Username username, OpenPaaSId userId) {
+        String uri = "/addressbooks/%s.json?contactsCount=true&inviteStatus=2&personal=true&shared=true&subscribed=true"
+            .formatted(userId.value());
+        return httpClientWithImpersonation(username)
+            .headers(headers -> headers.add(HttpHeaderNames.ACCEPT, "application/json"))
+            .get()
+            .uri(uri)
+            .responseSingle((response, buf) -> {
+                if (response.status().code() == HttpStatus.SC_OK) {
+                    return buf.asByteArray();
+                }
+                return buf.asString(StandardCharsets.UTF_8)
+                    .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                    .flatMap(errorBody -> Mono.error(new DavClientException(
+                        "Unexpected status code: %d when listing address books for user %s\n%s"
+                            .formatted(response.status().code(), userId.value(), errorBody))));
+            });
+    }
+
+    public Mono<Boolean> addressBookExists(Username username, OpenPaaSId userId, String addressBookId) {
+        String uri = new AddressBookURL(userId, addressBookId).asUri().toASCIIString() + ".json";
+        return httpClientWithImpersonation(username)
+            .headers(headers -> headers.add(HttpHeaderNames.ACCEPT, "application/json"))
+            .get()
+            .uri(uri)
+            .responseSingle((response, buf) -> switch (response.status().code()) {
+                case HttpStatus.SC_OK -> Mono.just(true);
+                case HttpStatus.SC_NOT_FOUND, HttpStatus.SC_UNAUTHORIZED, HttpStatus.SC_FORBIDDEN -> Mono.just(false);
+                default -> buf.asString(StandardCharsets.UTF_8)
+                    .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                    .flatMap(errorBody -> Mono.error(new DavClientException(
+                        "Unexpected status code: %d when checking existence of address book %s/%s\n%s"
+                            .formatted(response.status().code(), userId.value(), addressBookId, errorBody))));
+            });
+    }
+
+    public Mono<Void> createUserAddressBook(Username username, OpenPaaSId userId, NewAddressBook newAddressBook) {
+        String description = newAddressBook.description().isBlank() ? "" : newAddressBook.description();
+        byte[] payload = ("""
+        {
+            "id": "%s",
+            "dav:name": "%s",
+            "carddav:description": "%s",
+            "dav:acl": ["dav:read","dav:write"],
+            "type": "user"
+        }
+        """.formatted(newAddressBook.id(), newAddressBook.name(), description)).getBytes(StandardCharsets.UTF_8);
+
+        return httpClientWithImpersonation(username).headers(headers -> headers
+                .add(HttpHeaderNames.CONTENT_TYPE, "application/json")
+                .add(HttpHeaderNames.ACCEPT, "application/json"))
+            .post()
+            .uri("/addressbooks/%s.json".formatted(userId.value()))
+            .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(payload)))
+            .responseSingle((response, buf) -> {
+                if (response.status().code() == HttpStatus.SC_CREATED) {
+                    return Mono.empty();
+                }
+                return buf.asString(StandardCharsets.UTF_8)
+                    .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                    .flatMap(errorBody -> Mono.error(new DavClientException(
+                        "Unexpected status code: %d when creating address book for user %s\n%s"
+                            .formatted(response.status().code(), userId.value(), errorBody))));
+            });
+    }
+
+    public Mono<Void> updateAddressBookPublicRight(Username username, AddressBookURL addressBookURL, boolean publish) {
+        String uri = addressBookURL.asUri().toASCIIString() + ".json";
+        byte[] payload = publish
+            ? "{\"dav:publish-addressbook\":{\"privilege\":\"{DAV:}read\"}}".getBytes(StandardCharsets.UTF_8)
+            : "{\"dav:unpublish-addressbook\":true}".getBytes(StandardCharsets.UTF_8);
+
+        return httpClientWithImpersonation(username)
+            .headers(headers -> headers
+                .add(HttpHeaderNames.CONTENT_TYPE, "application/json")
+                .add(HttpHeaderNames.ACCEPT, "application/json"))
+            .post()
+            .uri(uri)
+            .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(payload)))
+            .responseSingle((response, buf) -> switch (response.status().code()) {
+                case HttpStatus.SC_OK, HttpStatus.SC_NO_CONTENT -> Mono.empty();
+                default -> buf.asString(StandardCharsets.UTF_8)
+                    .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                    .flatMap(errorBody -> Mono.error(new DavClientException(
+                        "Unexpected status code: %d when updating public right of address book %s\n%s"
+                            .formatted(response.status().code(), uri, errorBody))));
+            });
+    }
+
+    public Mono<Void> updateAddressBookShares(Username username, AddressBookURL addressBookURL,
+                                              List<AddressBookSharee> sharees) {
+        String uri = addressBookURL.asUri().toASCIIString() + ".json";
+        byte[] payload;
+        try {
+            ObjectNode body = OBJECT_MAPPER.createObjectNode()
+                .set("dav:share-resource", OBJECT_MAPPER.createObjectNode()
+                    .set("dav:sharee", OBJECT_MAPPER.valueToTree(sharees)));
+            payload = OBJECT_MAPPER.writeValueAsBytes(body);
+        } catch (JsonProcessingException e) {
+            return Mono.error(new DavClientException("Failed to serialize address book sharing request", e));
+        }
+
+        return httpClientWithImpersonation(username)
+            .headers(headers -> headers
+                .add(HttpHeaderNames.CONTENT_TYPE, "application/json")
+                .add(HttpHeaderNames.ACCEPT, "application/json"))
+            .post()
+            .uri(uri)
+            .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(payload)))
+            .responseSingle((response, buf) -> switch (response.status().code()) {
+                case HttpStatus.SC_OK, HttpStatus.SC_NO_CONTENT -> Mono.empty();
+                default -> buf.asString(StandardCharsets.UTF_8)
+                    .switchIfEmpty(Mono.just(StringUtils.EMPTY))
+                    .flatMap(errorBody -> Mono.error(new DavClientException(
+                        "Unexpected status code: %d when updating shares of address book %s\n%s"
+                            .formatted(response.status().code(), uri, errorBody))));
             });
     }
 

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/SystemAddressBookException.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/SystemAddressBookException.java
@@ -1,0 +1,27 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav;
+
+import com.linagora.calendar.storage.AddressBookURL;
+
+public class SystemAddressBookException extends DavClientException {
+    public SystemAddressBookException(AddressBookURL addressBookURL) {
+        super("Cannot delete system address book: " + addressBookURL.asUri().toASCIIString());
+    }
+}

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/CalendarRoutesModule.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/CalendarRoutesModule.java
@@ -56,6 +56,7 @@ public class CalendarRoutesModule extends AbstractModule {
         routesMultibinder.addBinding().to(DomainRegisteredUsersRoutes.class);
         routesMultibinder.addBinding().to(DomainSettingsRoutes.class);
         routesMultibinder.addBinding().to(UserCalendarRoutes.class);
+        routesMultibinder.addBinding().to(UserAddressBookRoutes.class);
         routesMultibinder.addBinding().to(BookingLinkUserRoutes.class);
 
         bind(MemoryTaskManager.class).in(Scopes.SINGLETON);

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/UserAddressBookRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/UserAddressBookRoutes.java
@@ -43,7 +43,6 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.dav.CardDavClient;
 import com.linagora.calendar.dav.DavClientException;
-import com.linagora.calendar.dav.SystemAddressBookException;
 import com.linagora.calendar.storage.AddressBookURL;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
@@ -138,25 +137,29 @@ public class UserAddressBookRoutes implements Routes {
 
     private String deleteAddressBook(Request request, Response response) {
         OpenPaaSUser user = retrieveUser(request);
-        AddressBookURL addressBookURL = retrieveExistingAddressBook(request, user);
+        String addressBookId = request.params(ADDRESSBOOK_ID_PARAM);
 
-        try {
-            cardDavClient.deleteUserAddressBook(user.username(), addressBookURL).block();
-        } catch (SystemAddressBookException e) {
+        CardDavClient.AddressBook addressBook = wrapDavErrors(() ->
+            cardDavClient.listUserAddressBookIds(user.username(), user.id())
+                .filter(book -> book.value().equals(addressBookId))
+                .next()
+                .blockOptional()
+                .orElseThrow(() -> ErrorResponder.builder()
+                    .statusCode(HttpStatus.NOT_FOUND_404)
+                    .type(ErrorResponder.ErrorType.NOT_FOUND)
+                    .message("Address book does not exist")
+                    .haltError()));
+
+        if (addressBook.type() == CardDavClient.AddressBookType.SYSTEM) {
             throw ErrorResponder.builder()
                 .statusCode(HttpStatus.BAD_REQUEST_400)
                 .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
                 .message("Cannot delete system address book")
-                .cause(e)
-                .haltError();
-        } catch (DavClientException e) {
-            throw ErrorResponder.builder()
-                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
-                .type(ErrorResponder.ErrorType.SERVER_ERROR)
-                .message("Error while calling the DAV server")
-                .cause(e)
                 .haltError();
         }
+
+        wrapDavErrors(() -> cardDavClient.deleteUserAddressBook(user.username(),
+            new AddressBookURL(user.id(), addressBookId)).block());
 
         response.status(HttpStatus.NO_CONTENT_204);
         return Constants.EMPTY_BODY;

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/UserAddressBookRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/UserAddressBookRoutes.java
@@ -1,0 +1,304 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.webadmin;
+
+import static org.apache.james.webadmin.Constants.SEPARATOR;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import jakarta.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.james.core.Username;
+import org.apache.james.webadmin.Constants;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.base.Preconditions;
+import com.linagora.calendar.dav.CardDavClient;
+import com.linagora.calendar.dav.DavClientException;
+import com.linagora.calendar.dav.SystemAddressBookException;
+import com.linagora.calendar.storage.AddressBookURL;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+
+import spark.HaltException;
+import spark.Request;
+import spark.Response;
+import spark.Service;
+
+/**
+ * Administrative management of user address books. Calls are proxied to the Sabre
+ * DAV server, impersonating the targeted user.
+ */
+public class UserAddressBookRoutes implements Routes {
+
+    public static final String BASE_PATH = "/users";
+
+    private static final String USERNAME_PARAM = ":username";
+    private static final String ADDRESSBOOK_ID_PARAM = ":addressBookId";
+    private static final String ADDRESSBOOKS_PATH = BASE_PATH + SEPARATOR + USERNAME_PARAM + SEPARATOR + "addressbooks";
+    private static final String ADDRESSBOOK_PATH = ADDRESSBOOKS_PATH + SEPARATOR + ADDRESSBOOK_ID_PARAM;
+    private static final String PUBLIC_RIGHT_PATH = ADDRESSBOOK_PATH + SEPARATOR + "publicRight";
+    private static final String INVITEE_PATH = ADDRESSBOOK_PATH + SEPARATOR + "invitee";
+
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_NAME = "dav:name";
+    private static final String FIELD_DESCRIPTION = "carddav:description";
+    private static final String FIELD_PUBLIC_RIGHT = "public_right";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
+
+    public record AddressBookCreationRequest(@JsonProperty(FIELD_ID) Optional<String> id,
+                                             @JsonProperty(value = FIELD_NAME, required = true) String name,
+                                             @JsonProperty(FIELD_DESCRIPTION) Optional<String> description) {
+        public AddressBookCreationRequest {
+            Preconditions.checkArgument(StringUtils.isNotBlank(name), "Field '%s' is required", FIELD_NAME);
+        }
+    }
+
+    private final OpenPaaSUserDAO userDAO;
+    private final CardDavClient cardDavClient;
+
+    @Inject
+    public UserAddressBookRoutes(OpenPaaSUserDAO userDAO, CardDavClient cardDavClient) {
+        this.userDAO = userDAO;
+        this.cardDavClient = cardDavClient;
+    }
+
+    @Override
+    public String getBasePath() {
+        return BASE_PATH;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(ADDRESSBOOKS_PATH, this::listAddressBooks);
+        service.post(ADDRESSBOOKS_PATH, this::createAddressBook);
+        service.delete(ADDRESSBOOK_PATH, this::deleteAddressBook);
+        service.post(PUBLIC_RIGHT_PATH, this::updatePublicRight);
+        service.post(INVITEE_PATH, this::updateInvitees);
+    }
+
+    private String listAddressBooks(Request request, Response response) {
+        OpenPaaSUser user = retrieveUser(request);
+
+        byte[] sabreResponse = wrapDavErrors(() -> cardDavClient
+            .listUserAddressBooksAsBytes(user.username(), user.id())
+            .block());
+
+        response.status(HttpStatus.OK_200);
+        response.type(Constants.JSON_CONTENT_TYPE);
+        return new String(sabreResponse, StandardCharsets.UTF_8);
+    }
+
+    private String createAddressBook(Request request, Response response) {
+        OpenPaaSUser user = retrieveUser(request);
+        AddressBookCreationRequest creationRequest = parseBody(request, AddressBookCreationRequest.class);
+
+        String addressBookId = creationRequest.id()
+            .map(StringUtils::trimToNull)
+            .orElseGet(() -> UUID.randomUUID().toString());
+
+        wrapDavErrors(() -> cardDavClient.createUserAddressBook(user.username(), user.id(),
+            new CardDavClient.NewAddressBook(addressBookId, creationRequest.name(), creationRequest.description().orElse(""))).block());
+
+        response.status(HttpStatus.CREATED_201);
+        response.type(Constants.JSON_CONTENT_TYPE);
+        return OBJECT_MAPPER.createObjectNode()
+            .put(FIELD_ID, addressBookId)
+            .toString();
+    }
+
+    private String deleteAddressBook(Request request, Response response) {
+        OpenPaaSUser user = retrieveUser(request);
+        AddressBookURL addressBookURL = retrieveExistingAddressBook(request, user);
+
+        try {
+            cardDavClient.deleteUserAddressBook(user.username(), addressBookURL).block();
+        } catch (SystemAddressBookException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Cannot delete system address book")
+                .cause(e)
+                .haltError();
+        } catch (DavClientException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
+                .type(ErrorResponder.ErrorType.SERVER_ERROR)
+                .message("Error while calling the DAV server")
+                .cause(e)
+                .haltError();
+        }
+
+        response.status(HttpStatus.NO_CONTENT_204);
+        return Constants.EMPTY_BODY;
+    }
+
+    private String updatePublicRight(Request request, Response response) {
+        OpenPaaSUser user = retrieveUser(request);
+        boolean publish = parsePublicRight(request);
+        AddressBookURL addressBookURL = retrieveExistingAddressBook(request, user);
+
+        wrapDavErrors(() -> cardDavClient.updateAddressBookPublicRight(user.username(), addressBookURL, publish).block());
+
+        response.status(HttpStatus.NO_CONTENT_204);
+        return Constants.EMPTY_BODY;
+    }
+
+    private String updateInvitees(Request request, Response response) {
+        OpenPaaSUser user = retrieveUser(request);
+        List<CardDavClient.AddressBookSharee> sharees = parseSharees(request);
+        AddressBookURL addressBookURL = retrieveExistingAddressBook(request, user);
+
+        wrapDavErrors(() -> cardDavClient.updateAddressBookShares(user.username(), addressBookURL, sharees).block());
+
+        response.status(HttpStatus.NO_CONTENT_204);
+        return Constants.EMPTY_BODY;
+    }
+
+    private OpenPaaSUser retrieveUser(Request request) {
+        String rawUsername = request.params(USERNAME_PARAM);
+        try {
+            Username username = Username.of(rawUsername);
+            return userDAO.retrieve(username)
+                .blockOptional()
+                .orElseThrow(() -> ErrorResponder.builder()
+                    .statusCode(HttpStatus.NOT_FOUND_404)
+                    .type(ErrorResponder.ErrorType.NOT_FOUND)
+                    .message("User does not exist")
+                    .haltError());
+        } catch (IllegalArgumentException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid username: %s", rawUsername)
+                .cause(e)
+                .haltError();
+        }
+    }
+
+    private AddressBookURL retrieveExistingAddressBook(Request request, OpenPaaSUser user) {
+        String addressBookId = request.params(ADDRESSBOOK_ID_PARAM);
+        boolean exists = wrapDavErrors(() -> cardDavClient.addressBookExists(user.username(), user.id(), addressBookId).block());
+        if (!exists) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .message("Address book does not exist")
+                .haltError();
+        }
+        return new AddressBookURL(user.id(), addressBookId);
+    }
+
+    private boolean parsePublicRight(Request request) {
+        JsonNode body = parseBody(request);
+        JsonNode publicRightNode = body.path(FIELD_PUBLIC_RIGHT);
+        if (!publicRightNode.isTextual()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Field '%s' is required".formatted(FIELD_PUBLIC_RIGHT))
+                .haltError();
+        }
+        String publicRight = publicRightNode.asText();
+        return switch (publicRight) {
+            case "" -> false;
+            case "{DAV:}read" -> true;
+            default -> throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Invalid '%s' value: '%s'. Supported values are: '' and '{DAV:}read'".formatted(FIELD_PUBLIC_RIGHT, publicRight))
+                .haltError();
+        };
+    }
+
+    private List<CardDavClient.AddressBookSharee> parseSharees(Request request) {
+        JsonNode body = parseBody(request);
+        JsonNode shareesNode = body.path("dav:sharee");
+        if (!shareesNode.isArray()) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message("Field 'dav:sharee' must be a JSON array")
+                .haltError();
+        }
+        try {
+            return OBJECT_MAPPER.readerForListOf(CardDavClient.AddressBookSharee.class).readValue(shareesNode);
+        } catch (Exception e) {
+            throw invalidBody(e);
+        }
+    }
+
+    private JsonNode parseBody(Request request) {
+        try {
+            JsonNode body = OBJECT_MAPPER.readTree(request.bodyAsBytes());
+            if (body == null || !body.isObject()) {
+                throw new IllegalArgumentException("Request body must be a JSON object");
+            }
+            return body;
+        } catch (Exception e) {
+            throw invalidBody(e);
+        }
+    }
+
+    private <T> T parseBody(Request request, Class<T> type) {
+        try {
+            return OBJECT_MAPPER.readValue(request.bodyAsBytes(), type);
+        } catch (Exception e) {
+            throw invalidBody(e);
+        }
+    }
+
+    private HaltException invalidBody(Exception e) {
+        String detail = Optional.ofNullable(ExceptionUtils.getRootCause(e))
+            .map(Throwable::getMessage)
+            .orElse(e.getMessage());
+        return ErrorResponder.builder()
+            .statusCode(HttpStatus.BAD_REQUEST_400)
+            .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+            .message("Invalid request body: %s".formatted(detail))
+            .cause(e)
+            .haltError();
+    }
+
+    private <T> T wrapDavErrors(Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (DavClientException e) {
+            throw ErrorResponder.builder()
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
+                .type(ErrorResponder.ErrorType.SERVER_ERROR)
+                .message("Error while calling the DAV server")
+                .cause(e)
+                .haltError();
+        }
+    }
+}

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/UserAddressBookRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/UserAddressBookRoutesTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.not;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import javax.net.ssl.SSLException;
 
@@ -36,6 +37,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linagora.calendar.dav.CardDavClient;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
@@ -178,26 +183,22 @@ public class UserAddressBookRoutesTest {
             .doesNotContain("/addressbooks/%s/%s.json".formatted(user.id().value(), addressBookId));
     }
 
-    @Test
-    void deleteAddressBookShouldReturn404WhenAddressBookDoesNotExist() {
+    @ParameterizedTest
+    @MethodSource("deleteAddressBookErrorCases")
+    void deleteAddressBookShouldReturnErrorForInvalidCases(String addressBookId, int statusCode, String type, String message) {
         given()
         .when()
-            .delete("/users/{username}/addressbooks/{addressBookId}", user.username().asString(), UUID.randomUUID().toString())
+            .delete("/users/{username}/addressbooks/{addressBookId}", user.username().asString(), addressBookId)
         .then()
-            .statusCode(404)
-            .body("type", is("notFound"))
-            .body("message", is("Address book does not exist"));
+            .statusCode(statusCode)
+            .body("type", is(type))
+            .body("message", is(message));
     }
 
-    @Test
-    void deleteAddressBookShouldReturn400WhenDeletingSystemAddressBook() {
-        given()
-        .when()
-            .delete("/users/{username}/addressbooks/{addressBookId}", user.username().asString(), "contacts")
-        .then()
-            .statusCode(400)
-            .body("type", is("InvalidArgument"))
-            .body("message", is("Cannot delete system address book"));
+    static Stream<Arguments> deleteAddressBookErrorCases() {
+        return Stream.of(
+            Arguments.of("00000000-0000-0000-0000-000000000000", 404, "notFound", "Address book does not exist"),
+            Arguments.of("contacts", 400, "InvalidArgument", "Cannot delete system address book"));
     }
 
     @Test
@@ -300,27 +301,16 @@ public class UserAddressBookRoutesTest {
             .body("type", is("notFound"));
     }
 
-    @Test
-    void inviteeShouldFailWhenShareeFieldIsMissing() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "{}",
+        "{\"dav:sharee\":[{\"dav:href\":\"mailto:anyone@linagora.com\",\"dav:share-access\":99}]}"
+    })
+    void inviteeShouldFailWhenPayloadIsInvalid(String body) {
         String addressBookId = createAddressBook(user, "Address book");
 
         given()
-            .body("{}")
-        .when()
-            .post("/users/{username}/addressbooks/{addressBookId}/invitee", user.username().asString(), addressBookId)
-        .then()
-            .statusCode(400)
-            .body("type", is("InvalidArgument"));
-    }
-
-    @Test
-    void inviteeShouldFailWhenShareAccessIsInvalid() {
-        String addressBookId = createAddressBook(user, "Address book");
-
-        given()
-            .body("""
-                {"dav:sharee":[{"dav:href":"mailto:%s","dav:share-access":99}]}
-                """.formatted(otherUser.username().asString()))
+            .body(body)
         .when()
             .post("/users/{username}/addressbooks/{addressBookId}/invitee", user.username().asString(), addressBookId)
         .then()

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/UserAddressBookRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/UserAddressBookRoutesTest.java
@@ -230,32 +230,22 @@ public class UserAddressBookRoutesTest {
             .statusCode(204);
     }
 
-    @Test
-    void publicRightShouldRejectUnsupportedValue() {
-        String addressBookId = createAddressBook(user, "Address book");
-
+    @ParameterizedTest
+    @MethodSource("publicRightErrorCases")
+    void publicRightShouldReturnErrorForInvalidCases(String body, int statusCode, String type) {
         given()
-            .body("""
-                {"public_right":"{DAV:}write"}
-                """)
-        .when()
-            .post("/users/{username}/addressbooks/{addressBookId}/publicRight", user.username().asString(), addressBookId)
-        .then()
-            .statusCode(400)
-            .body("type", is("InvalidArgument"));
-    }
-
-    @Test
-    void publicRightShouldReturn404WhenAddressBookDoesNotExist() {
-        given()
-            .body("""
-                {"public_right":"{DAV:}read"}
-                """)
+            .body(body)
         .when()
             .post("/users/{username}/addressbooks/{addressBookId}/publicRight", user.username().asString(), UUID.randomUUID().toString())
         .then()
-            .statusCode(404)
-            .body("type", is("notFound"));
+            .statusCode(statusCode)
+            .body("type", is(type));
+    }
+
+    static Stream<Arguments> publicRightErrorCases() {
+        return Stream.of(
+            Arguments.of("{\"public_right\":\"{DAV:}write\"}", 400, "InvalidArgument"),
+            Arguments.of("{\"public_right\":\"{DAV:}read\"}", 404, "notFound"));
     }
 
     @Test

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/UserAddressBookRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/UserAddressBookRoutesTest.java
@@ -1,0 +1,360 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.webadmin;
+
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.List;
+import java.util.UUID;
+
+import javax.net.ssl.SSLException;
+
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.WebAdminUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.calendar.dav.CardDavClient;
+import com.linagora.calendar.dav.DockerSabreDavSetup;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.storage.AddressBookURL;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+
+public class UserAddressBookRoutesTest {
+
+    @RegisterExtension
+    static SabreDavExtension sabreDavExtension = new SabreDavExtension(DockerSabreDavSetup.SINGLETON);
+
+    private WebAdminServer webAdminServer;
+    private OpenPaaSUserDAO userDAO;
+    private CardDavClient cardDavClient;
+
+    private OpenPaaSUser user;
+    private OpenPaaSUser otherUser;
+
+    @BeforeEach
+    void setUp() throws SSLException {
+        MongoDatabase mongoDB = sabreDavExtension.dockerSabreDavSetup().getMongoDB();
+        MongoDBOpenPaaSDomainDAO domainDAO = new MongoDBOpenPaaSDomainDAO(mongoDB);
+        userDAO = new MongoDBOpenPaaSUserDAO(mongoDB, domainDAO);
+        cardDavClient = new CardDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+
+        user = sabreDavExtension.newTestUser();
+        otherUser = sabreDavExtension.newTestUser();
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(new UserAddressBookRoutes(userDAO, cardDavClient))
+            .start();
+
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
+            .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+    }
+
+    @Test
+    void listAddressBooksShouldReturnDefaultAddressBooks() {
+        List<String> hrefs = listAddressBookHrefs(user);
+
+        assertThat(hrefs)
+            .contains("/addressbooks/%s/contacts.json".formatted(user.id().value()));
+    }
+
+    @Test
+    void listAddressBooksShouldReturn404WhenUserDoesNotExist() {
+        given()
+        .when()
+            .get("/users/ghost@linagora.com/addressbooks")
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is("User does not exist"));
+    }
+
+    @Test
+    void createAddressBookShouldCreateAddressBookInDav() {
+        String addressBookId = UUID.randomUUID().toString();
+
+        given()
+            .body("""
+                {"id":"%s","dav:name":"My Contacts","carddav:description":"Personal contacts"}
+                """.formatted(addressBookId))
+        .when()
+            .post("/users/{username}/addressbooks", user.username().asString())
+        .then()
+            .statusCode(201)
+            .body("id", is(addressBookId));
+
+        assertThat(listAddressBookHrefs(user))
+            .contains("/addressbooks/%s/%s.json".formatted(user.id().value(), addressBookId));
+    }
+
+    @Test
+    void createAddressBookShouldGenerateIdWhenAbsent() {
+        String addressBookId = given()
+            .body("""
+                {"dav:name":"Generated id book"}
+                """)
+        .when()
+            .post("/users/{username}/addressbooks", user.username().asString())
+        .then()
+            .statusCode(201)
+            .body("id", not(emptyString()))
+            .extract()
+            .jsonPath()
+            .getString("id");
+
+        assertThat(listAddressBookHrefs(user))
+            .contains("/addressbooks/%s/%s.json".formatted(user.id().value(), addressBookId));
+    }
+
+    @Test
+    void createAddressBookShouldFailWhenNameIsMissing() {
+        given()
+            .body("{}")
+        .when()
+            .post("/users/{username}/addressbooks", user.username().asString())
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"));
+    }
+
+    @Test
+    void createAddressBookShouldReturn404WhenUserDoesNotExist() {
+        given()
+            .body("""
+                {"dav:name":"My Contacts"}
+                """)
+        .when()
+            .post("/users/ghost@linagora.com/addressbooks")
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"));
+    }
+
+    @Test
+    void deleteAddressBookShouldDeleteAddressBook() {
+        String addressBookId = createAddressBook(user, "To be deleted");
+
+        given()
+        .when()
+            .delete("/users/{username}/addressbooks/{addressBookId}", user.username().asString(), addressBookId)
+        .then()
+            .statusCode(204);
+
+        assertThat(listAddressBookHrefs(user))
+            .doesNotContain("/addressbooks/%s/%s.json".formatted(user.id().value(), addressBookId));
+    }
+
+    @Test
+    void deleteAddressBookShouldReturn404WhenAddressBookDoesNotExist() {
+        given()
+        .when()
+            .delete("/users/{username}/addressbooks/{addressBookId}", user.username().asString(), UUID.randomUUID().toString())
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is("Address book does not exist"));
+    }
+
+    @Test
+    void deleteAddressBookShouldReturn400WhenDeletingSystemAddressBook() {
+        given()
+        .when()
+            .delete("/users/{username}/addressbooks/{addressBookId}", user.username().asString(), "contacts")
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Cannot delete system address book"));
+    }
+
+    @Test
+    void publicRightShouldPublishAddressBook() {
+        String addressBookId = createAddressBook(user, "Soon to be public");
+
+        given()
+            .body("""
+                {"public_right":"{DAV:}read"}
+                """)
+        .when()
+            .post("/users/{username}/addressbooks/{addressBookId}/publicRight", user.username().asString(), addressBookId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    void publicRightShouldUnpublishAddressBook() {
+        String addressBookId = createAddressBook(user, "Public then private");
+        cardDavClient.updateAddressBookPublicRight(user.username(), new AddressBookURL(user.id(), addressBookId), true).block();
+
+        given()
+            .body("""
+                {"public_right":""}
+                """)
+        .when()
+            .post("/users/{username}/addressbooks/{addressBookId}/publicRight", user.username().asString(), addressBookId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    void publicRightShouldRejectUnsupportedValue() {
+        String addressBookId = createAddressBook(user, "Address book");
+
+        given()
+            .body("""
+                {"public_right":"{DAV:}write"}
+                """)
+        .when()
+            .post("/users/{username}/addressbooks/{addressBookId}/publicRight", user.username().asString(), addressBookId)
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"));
+    }
+
+    @Test
+    void publicRightShouldReturn404WhenAddressBookDoesNotExist() {
+        given()
+            .body("""
+                {"public_right":"{DAV:}read"}
+                """)
+        .when()
+            .post("/users/{username}/addressbooks/{addressBookId}/publicRight", user.username().asString(), UUID.randomUUID().toString())
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"));
+    }
+
+    @Test
+    void inviteeShouldGrantDelegation() {
+        String addressBookId = createAddressBook(user, "Shared address book");
+
+        given()
+            .body("""
+                {"dav:sharee":[{"dav:href":"mailto:%s","dav:share-access":3}]}
+                """.formatted(otherUser.username().asString()))
+        .when()
+            .post("/users/{username}/addressbooks/{addressBookId}/invitee", user.username().asString(), addressBookId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    void inviteeShouldRevokeDelegation() {
+        String addressBookId = createAddressBook(user, "Shared address book");
+        cardDavClient.updateAddressBookShares(user.username(), new AddressBookURL(user.id(), addressBookId),
+            List.of(new CardDavClient.AddressBookSharee("mailto:" + otherUser.username().asString(), 3))).block();
+
+        given()
+            .body("""
+                {"dav:sharee":[{"dav:href":"mailto:%s","dav:share-access":5}]}
+                """.formatted(otherUser.username().asString()))
+        .when()
+            .post("/users/{username}/addressbooks/{addressBookId}/invitee", user.username().asString(), addressBookId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    void inviteeShouldReturn404WhenAddressBookDoesNotExist() {
+        given()
+            .body("""
+                {"dav:sharee":[]}
+                """)
+        .when()
+            .post("/users/{username}/addressbooks/{addressBookId}/invitee", user.username().asString(), UUID.randomUUID().toString())
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"));
+    }
+
+    @Test
+    void inviteeShouldFailWhenShareeFieldIsMissing() {
+        String addressBookId = createAddressBook(user, "Address book");
+
+        given()
+            .body("{}")
+        .when()
+            .post("/users/{username}/addressbooks/{addressBookId}/invitee", user.username().asString(), addressBookId)
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"));
+    }
+
+    @Test
+    void inviteeShouldFailWhenShareAccessIsInvalid() {
+        String addressBookId = createAddressBook(user, "Address book");
+
+        given()
+            .body("""
+                {"dav:sharee":[{"dav:href":"mailto:%s","dav:share-access":99}]}
+                """.formatted(otherUser.username().asString()))
+        .when()
+            .post("/users/{username}/addressbooks/{addressBookId}/invitee", user.username().asString(), addressBookId)
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"));
+    }
+
+    private String createAddressBook(OpenPaaSUser owner, String name) {
+        return given()
+            .body("""
+                {"dav:name":"%s"}
+                """.formatted(name))
+        .when()
+            .post("/users/{username}/addressbooks", owner.username().asString())
+        .then()
+            .statusCode(201)
+            .extract()
+            .jsonPath()
+            .getString("id");
+    }
+
+    private List<String> listAddressBookHrefs(OpenPaaSUser targetUser) {
+        String body = given()
+        .when()
+            .get("/users/{username}/addressbooks", targetUser.username().asString())
+        .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+
+        List<String> hrefs = JsonPath.from(body).getList("_embedded.'dav:addressbook'._links.self.href");
+        if (hrefs == null) {
+            return List.of();
+        }
+        return hrefs;
+    }
+}

--- a/docs/apis/webadmin.md
+++ b/docs/apis/webadmin.md
@@ -976,6 +976,134 @@ the sharing for the given user.
 - `400`: missing `share` field, `dav:href` is not a `mailto:` URI, or a `set` entry carries no right
 - `404`: the user or the calendar does not exist
 
+## User address book management routes
+
+Administrative management of user address books. These routes proxy the Sabre DAV server,
+impersonating the targeted user. The user is identified by their email address; the associated
+technical user id is resolved automatically.
+
+All routes return:
+- `400`: the username is invalid or the request body is malformed
+- `404`: the user is not registered (`User does not exist`)
+
+### Listing the address books of a user
+
+```
+GET /users/{username}/addressbooks
+```
+
+Example:
+
+```
+GET /users/btellier@linagora.com/addressbooks
+```
+
+Returns the DAV server response verbatim, including the default `contacts` address book and any custom ones.
+
+```json
+{
+  "_links": {"self": {"href": "/addressbooks/5f50a663bdaffe002629099c.json"}},
+  "_embedded": {
+    "dav:addressbook": [
+      {
+        "_links": {"self": {"href": "/addressbooks/5f50a663bdaffe002629099c/contacts.json"}},
+        "dav:name": "My contacts",
+        "carddav:description": ""
+      }
+    ]
+  }
+}
+```
+
+**Status codes**:
+- `200`: the address book list is returned
+
+### Creating an address book
+
+```
+POST /users/{username}/addressbooks
+{
+  "id": "0e26ee47-cc4b-4aaa-8447-12588fdb11f1",
+  "dav:name": "My Contacts",
+  "carddav:description": "Personal contacts"
+}
+```
+
+Supported fields:
+- `id` (optional): the collection identifier of the address book to create. Generated (random UUID) when absent.
+- `dav:name` (required): display name of the address book
+- `carddav:description` (optional): description of the address book
+
+Returns the identifier of the created address book:
+
+```json
+{"id": "0e26ee47-cc4b-4aaa-8447-12588fdb11f1"}
+```
+
+**Status codes**:
+- `201`: the address book was created
+- `400`: `dav:name` is missing or the request body is malformed
+- `404`: the user does not exist
+
+### Deleting an address book
+
+```
+DELETE /users/{username}/addressbooks/{addressBookId}
+```
+
+Example:
+
+```
+DELETE /users/btellier@linagora.com/addressbooks/0e26ee47-cc4b-4aaa-8447-12588fdb11f1
+```
+
+**Status codes**:
+- `204`: the address book was deleted
+- `400`: attempting to delete a system address book (e.g. `contacts`)
+- `404`: the user or the address book does not exist
+
+### Changing the public visibility of an address book
+
+```
+POST /users/{username}/addressbooks/{addressBookId}/publicRight
+{
+  "public_right": "{DAV:}read"
+}
+```
+
+Supported `public_right` values:
+- `"{DAV:}read"`: anyone authenticated can read the address book (public)
+- `""`: removes public rights (private)
+
+**Status codes**:
+- `204`: the public visibility was updated
+- `400`: missing or unsupported `public_right` value
+- `404`: the user or the address book does not exist
+
+### Adding / removing invitees (sharing)
+
+```
+POST /users/{username}/addressbooks/{addressBookId}/invitee
+{
+  "dav:sharee": [
+    {"dav:href": "mailto:alice@linagora.com", "dav:share-access": 3},
+    {"dav:href": "mailto:bob@linagora.com", "dav:share-access": 5}
+  ]
+}
+```
+
+Each entry in `dav:sharee` sets the access level for the given user. The `dav:share-access` field
+accepts integer values between 2 and 5 matching the WebDAV sharing spec:
+- `2`: read access
+- `3`: read-write access
+- `4`: administration access
+- `5`: no access (revokes sharing)
+
+**Status codes**:
+- `204`: the sharees were updated
+- `400`: missing or malformed `dav:sharee` array, or an invalid `dav:share-access` value
+- `404`: the user or the address book does not exist
+
 ## User booking link routes
 
 These routes let an administrator manage the [booking links](bookingLink.md) of a given user.


### PR DESCRIPTION
## Summary

- Adds a webadmin HTTP interface for managing user address books (CardDAV), mirroring `UserCalendarRoutes`
- Exposes list, create, delete, publicRight, and invitee endpoints via Sabre CardDAV
- Introduces `SystemAddressBookException` so deleting a system address book returns 400 instead of silently succeeding

## Endpoints

```
GET    /users/{username}/addressbooks
POST   /users/{username}/addressbooks
DELETE /users/{username}/addressbooks/{addressBookId}
POST   /users/{username}/addressbooks/{addressBookId}/publicRight
POST   /users/{username}/addressbooks/{addressBookId}/invitee
```

## Changes

- `CardDavClient`: adds `listUserAddressBooksAsBytes`, `addressBookExists`, `createUserAddressBook(NewAddressBook)`, `updateAddressBookPublicRight`, `updateAddressBookShares`; `deleteUserAddressBook` now raises `SystemAddressBookException` on 501
- `SystemAddressBookException`: new `DavClientException` subclass for system book deletion attempts
- `UserAddressBookRoutes`: new webadmin routes class (all 5 endpoints)
- `CalendarRoutesModule`: registers `UserAddressBookRoutes`
- `UserAddressBookRoutesTest`: integration test against Docker Sabre

## Test plan

- [ ] List returns default address books
- [ ] Create with explicit id and auto-generated id
- [ ] Create fails with 400 when `dav:name` is missing
- [ ] Delete removes the address book
- [ ] Delete returns 404 for unknown address book
- [ ] Delete returns 400 for system address book
- [ ] publicRight publishes/unpublishes with `{DAV:}read` / `""`
- [ ] invitee grants and revokes delegation

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
