### PR TITLE
[FIX] Stabilize flaky actionLinksShouldWorkForExternalUser test

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
@@ -290,21 +290,19 @@ class EventParticipationRouteTest {
             .get("/smtpMails")
             .jsonPath();
 
-        CALMLY_AWAIT
-            .atMost(Duration.ofSeconds(10))
-            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(1));
-
-        JsonPath smtpMailsResponse = smtpMailsResponseSupplier.get();
-
         AtomicReference<String> actionLink = new AtomicReference<>();
 
-        assertSoftly(Throwing.consumer(softly -> {
-            softly.assertThat(smtpMailsResponse.getString("[0].recipients[0].address")).isEqualTo(externalUser);
-            String message = smtpMailsResponse.getString("[0].message");
-            List<String> actionLinks = extractActionLinks(getHtml(message));
-            softly.assertThat(actionLinks).hasSize(3);
-            actionLink.set(actionLinks.getFirst());
-        }));
+        CALMLY_AWAIT
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted(() -> {
+                JsonPath smtpMailsResponse = smtpMailsResponseSupplier.get();
+                assertThat(smtpMailsResponse.getList("")).hasSize(1);
+                assertThat(smtpMailsResponse.getString("[0].recipients[0].address")).isEqualTo(externalUser);
+                String message = smtpMailsResponse.getString("[0].message");
+                List<String> actionLinks = extractActionLinks(getHtml(message));
+                assertThat(actionLinks).hasSize(3);
+                actionLink.set(actionLinks.getFirst());
+            });
 
         String participationLink = actionLink.get()
             .replace("https://excal.linagora.com/excal/?jwt=",
@@ -338,7 +336,9 @@ class EventParticipationRouteTest {
             "Content-Transfer-Encoding: base64\r?\nContent-Type: text/html; charset=UTF-8\r?\nContent-Language: [^\r\n]+\r?\n\r?\n([A-Za-z0-9+/=\r\n]+)\r?\n---=Part",
             Pattern.DOTALL);
         Matcher matcher = htmlPattern.matcher(message);
-        matcher.find();
+        if (!matcher.find()) {
+            return "";
+        }
         String base64Html = matcher.group(1).replaceAll("\\s+", "");
         return new String(Base64.getDecoder().decode(base64Html), StandardCharsets.UTF_8);
     }


### PR DESCRIPTION
Closes #853

`EventParticipationRouteTest.actionLinksShouldWorkForExternalUser` was flaky on CI, failing with:

```
java.util.NoSuchElementException
	at java.base/java.util.List.getFirst(List.java:823)
	at ...EventParticipationRouteTest.lambda$actionLinksShouldWorkForExternalUser$2(EventParticipationRouteTest.java:306)
```

## Root cause
The test only awaited for the SMTP mail to exist (`hasSize(1)`), then in a soft assertion expected 3 action links and **unconditionally** called `actionLinks.getFirst()`. When the mail body was not yet fully observable, the link list could be empty: the soft assertion merely recorded the `hasSize(3)` failure, but the following `getFirst()` threw a hard `NoSuchElementException` that aborted the test.

## Fix
- Move the recipient check and the action-link extraction inside the `CALMLY_AWAIT` block so they are retried until the mail and its 3 action links are actually available.
- Guard `getHtml` against a not-yet-complete message: return an empty string when the HTML part is not matched yet, so it triggers a retry rather than throwing `IllegalStateException`.

No production code is touched; this is a test-stability change only.
