### PR TITLE
Booking links: add optional name and description

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
@@ -270,6 +270,76 @@ class BookingLinkCreateRouteTest {
     }
 
     @Test
+    void shouldPersistBookingLinkWithNameAndDescription() {
+        String publicId = given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "name": "Intro call",
+                    "description": "Book a 30-minute introduction call"
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED)
+            .extract().jsonPath().getString("bookingLinkPublicId");
+
+        BookingLink stored = bookingLinkProbe.findBookingLink(openPaaSUser.username(), new BookingLinkPublicId(UUID.fromString(publicId)));
+
+        assertThat(stored.name()).contains("Intro call");
+        assertThat(stored.description()).contains("Book a 30-minute introduction call");
+    }
+
+    @Test
+    void shouldDefaultNameAndDescriptionToEmptyWhenNotProvided() {
+        String publicId = given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED)
+            .extract().jsonPath().getString("bookingLinkPublicId");
+
+        BookingLink stored = bookingLinkProbe.findBookingLink(openPaaSUser.username(), new BookingLinkPublicId(UUID.fromString(publicId)));
+
+        assertThat(stored.name()).isEmpty();
+        assertThat(stored.description()).isEmpty();
+    }
+
+    @Test
+    void shouldIgnoreBlankNameAndDescription() {
+        String publicId = given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "name": "   ",
+                    "description": ""
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED)
+            .extract().jsonPath().getString("bookingLinkPublicId");
+
+        BookingLink stored = bookingLinkProbe.findBookingLink(openPaaSUser.username(), new BookingLinkPublicId(UUID.fromString(publicId)));
+
+        assertThat(stored.name()).isEmpty();
+        assertThat(stored.description()).isEmpty();
+    }
+
+    @Test
     void shouldReturnDistinctPublicIdsForSuccessiveCreations() {
         String body = """
             {

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
@@ -243,6 +243,33 @@ class BookingLinkGetRouteTest {
     }
 
     @Test
+    void shouldReturn200WithNameAndDescription() {
+        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
+                Optional.empty(), Optional.of("Intro call"), Optional.of("Book a 30-minute introduction call")));
+
+        String response = given()
+        .when()
+            .get("/api/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                    "publicId": "%s",
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "name": "Intro call",
+                    "description": "Book a 30-minute introduction call"
+                }
+                """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));
+    }
+
+    @Test
     void shouldReturn404WhenBookingLinkDoesNotExist() {
         given()
         .when()

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
@@ -164,6 +164,45 @@ class BookingLinkPatchRouteTest {
     }
 
     @Test
+    void shouldPersistUpdatedNameAndDescription() {
+        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        given()
+            .body("""
+                { "name": "Intro call", "description": "Book a 30-minute introduction call" }
+                """)
+        .when()
+            .patch("/api/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        BookingLink updated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
+        assertThat(updated.name()).contains("Intro call");
+        assertThat(updated.description()).contains("Book a 30-minute introduction call");
+    }
+
+    @Test
+    void shouldRemoveNameAndDescriptionWhenSetToNull() {
+        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
+                Optional.empty(), Optional.of("Intro call"), Optional.of("Some description")));
+
+        given()
+            .body("""
+                { "name": null, "description": null }
+                """)
+        .when()
+            .patch("/api/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        BookingLink updated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
+        assertThat(updated.name()).isEmpty();
+        assertThat(updated.description()).isEmpty();
+    }
+
+    @Test
     void shouldPersistUpdatedDurationMinutes() {
         BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
@@ -64,7 +64,9 @@ public class BookingLinkCreateRoute extends CalendarRoute {
     public record CreateBookingLinkRequestDTO(@JsonProperty("calendarUrl") String calendarUrl,
                                               @JsonProperty("durationMinutes") Integer durationMinutes,
                                               @JsonProperty("active") Boolean active,
-                                              @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules) {
+                                              @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules,
+                                              @JsonProperty("name") Optional<String> name,
+                                              @JsonProperty("description") Optional<String> description) {
 
         public static BookingLinkInsertRequest toBookingLinkInsertRequest(CreateBookingLinkRequestDTO request,
                                                                           ZoneId defaultZone,
@@ -79,7 +81,12 @@ public class BookingLinkCreateRoute extends CalendarRoute {
 
             Optional<AvailabilityRules> availabilityRules = getAvailabilityRules(request, defaultZone).or(() -> defaultAvailabilityRules);
 
-            return new BookingLinkInsertRequest(calendarURL, duration, request.active, availabilityRules);
+            return new BookingLinkInsertRequest(calendarURL, duration, request.active, availabilityRules,
+                normalize(request.name), normalize(request.description));
+        }
+
+        private static Optional<String> normalize(Optional<String> value) {
+            return value.map(String::trim).filter(s -> !s.isEmpty());
         }
 
         private static Optional<AvailabilityRules> getAvailabilityRules(CreateBookingLinkRequestDTO request, ZoneId defaultZone) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
@@ -61,11 +61,15 @@ public class BookingLinkPatchRoute extends CalendarRoute {
     private static final String FIELD_DURATION_MINUTES = "durationMinutes";
     private static final String FIELD_ACTIVE = "active";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_DESCRIPTION = "description";
 
     public record PatchDto(@JsonProperty(FIELD_CALENDAR_URL) Optional<String> calendarUrl,
                            @JsonProperty(FIELD_DURATION_MINUTES) Optional<Integer> durationMinutes,
                            @JsonProperty(FIELD_ACTIVE) Optional<Boolean> active,
-                           @JsonProperty(FIELD_AVAILABILITY_RULES) Optional<List<AvailabilityRuleDTO>> availabilityRules) {
+                           @JsonProperty(FIELD_AVAILABILITY_RULES) Optional<List<AvailabilityRuleDTO>> availabilityRules,
+                           @JsonProperty(FIELD_NAME) Optional<String> name,
+                           @JsonProperty(FIELD_DESCRIPTION) Optional<String> description) {
     }
 
     private final BookingLinkDAO bookingLinkDAO;
@@ -124,7 +128,9 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                 parseCalendarUrl(node, dto),
                 parseDuration(node, dto),
                 parseActive(node, dto),
-                parseAvailabilityRules(node, dto, defaultTimeZone));
+                parseAvailabilityRules(node, dto, defaultTimeZone),
+                parseName(node, dto),
+                parseDescription(node, dto));
         } catch (IllegalArgumentException e) {
             throw e;
         } catch (Exception e) {
@@ -181,6 +187,24 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                 Preconditions.checkArgument(!ruleList.isEmpty(), "'availabilityRules' cannot be empty if provided");
                 return new AvailabilityRules(ruleList);
             })
+            .map(ValuePatch::modifyTo)
+            .orElseGet(ValuePatch::remove);
+    }
+
+    private ValuePatch<String> parseName(JsonNode node, PatchDto dto) {
+        if (!node.has(FIELD_NAME)) {
+            return ValuePatch.keep();
+        }
+        return dto.name().map(String::trim).filter(name -> !name.isEmpty())
+            .map(ValuePatch::modifyTo)
+            .orElseGet(ValuePatch::remove);
+    }
+
+    private ValuePatch<String> parseDescription(JsonNode node, PatchDto dto) {
+        if (!node.has(FIELD_DESCRIPTION)) {
+            return ValuePatch.keep();
+        }
+        return dto.description().map(String::trim).filter(description -> !description.isEmpty())
             .map(ValuePatch::modifyTo)
             .orElseGet(ValuePatch::remove);
     }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/BookingLinkDTO.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/BookingLinkDTO.java
@@ -30,7 +30,9 @@ public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
                              @JsonProperty("calendarUrl") String calendarUrl,
                              @JsonProperty("durationMinutes") long durationMinutes,
                              @JsonProperty("active") boolean active,
-                             @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules) {
+                             @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules,
+                             @JsonProperty("name") Optional<String> name,
+                             @JsonProperty("description") Optional<String> description) {
 
     public static BookingLinkDTO from(BookingLink bookingLink) {
         Optional<List<AvailabilityRuleDTO>> ruleDTOs = bookingLink.availabilityRules()
@@ -43,6 +45,8 @@ public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
             bookingLink.calendarUrl().asUri().toString(),
             bookingLink.duration().toMinutes(),
             bookingLink.active(),
-            ruleDTOs);
+            ruleDTOs,
+            bookingLink.name(),
+            bookingLink.description());
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
@@ -88,6 +88,8 @@ public class BookingLinkUserRoutes implements Routes {
     private static final String FIELD_DURATION_MINUTES = "durationMinutes";
     private static final String FIELD_ACTIVE = "active";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_DESCRIPTION = "description";
     private static final String FIELD_PUBLIC_ID = "bookingLinkPublicId";
     private static final ZoneId DEFAULT_ZONE = ZoneId.of("UTC");
 
@@ -220,7 +222,9 @@ public class BookingLinkUserRoutes implements Routes {
                 parseCalendarUrl(node, dto),
                 parseDuration(node, dto),
                 parseActive(node, dto),
-                parseAvailabilityRules(node, dto));
+                parseAvailabilityRules(node, dto),
+                parseName(node, dto),
+                parseDescription(node, dto));
         } catch (IllegalArgumentException e) {
             throw badRequest(e.getMessage(), e);
         } catch (Exception e) {
@@ -267,6 +271,24 @@ public class BookingLinkUserRoutes implements Routes {
                 Preconditions.checkArgument(!ruleList.isEmpty(), "'availabilityRules' cannot be empty if provided");
                 return new AvailabilityRules(ruleList);
             })
+            .map(ValuePatch::modifyTo)
+            .orElseGet(ValuePatch::remove);
+    }
+
+    private ValuePatch<String> parseName(JsonNode node, PatchDto dto) {
+        if (!node.has(FIELD_NAME)) {
+            return ValuePatch.keep();
+        }
+        return dto.name().map(String::trim).filter(name -> !name.isEmpty())
+            .map(ValuePatch::modifyTo)
+            .orElseGet(ValuePatch::remove);
+    }
+
+    private ValuePatch<String> parseDescription(JsonNode node, PatchDto dto) {
+        if (!node.has(FIELD_DESCRIPTION)) {
+            return ValuePatch.keep();
+        }
+        return dto.description().map(String::trim).filter(description -> !description.isEmpty())
             .map(ValuePatch::modifyTo)
             .orElseGet(ValuePatch::remove);
     }

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -24,6 +24,8 @@ Public users can use booking links to book events.
 | `durationMinutes`   | integer          | Duration of each bookable slot in minutes (must be positive)                |
 | `active`            | boolean          | Whether the booking link is active                                          |
 | `availabilityRules` | array (optional) | List of availability rule objects (weekly or fixed)                         |
+| `name`              | string (optional)| Display name of the booking link                                            |
+| `description`       | string (optional)| Description of the booking link                                             |
 
 ### Availability rule object
 
@@ -62,6 +64,8 @@ Create a new booking link for the authenticated user.
 | `durationMinutes`   | yes      | Slot duration in minutes, must be positive                                                                                                               |
 | `active`            | yes      | Whether the booking link is active                                                                                                                       |
 | `availabilityRules` | no       | List of availability rules. Defaults to business hours from user settings when omitted. Each rule may specify its own `timeZone` (see availability rule object above). |
+| `name`              | no       | Display name of the booking link. Blank values are ignored.                                                                                              |
+| `description`       | no       | Description of the booking link. Blank values are ignored.                                                                                               |
 
 **Sample request**
 ```
@@ -73,6 +77,8 @@ Content-Type: application/json
     "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
     "durationMinutes": 30,
     "active": true,
+    "name": "Intro call",
+    "description": "Book a 30-minute introduction call",
     "availabilityRules": [
         { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Asia/Ho_Chi_Minh" },
         { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "timeZone": "Europe/London" },
@@ -121,6 +127,8 @@ Content-Type: application/json
         "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
         "durationMinutes": 30,
         "active": true,
+        "name": "Intro call",
+        "description": "Book a 30-minute introduction call",
         "availabilityRules": [
             { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "17:00", "timeZone": "Asia/Ho_Chi_Minh" }
         ]
@@ -128,7 +136,7 @@ Content-Type: application/json
 ]
 ```
 
-Field `availabilityRules` is omitted from each entry when not set.
+Fields `availabilityRules`, `name` and `description` are omitted from each entry when not set.
 
 **Error responses**
 
@@ -158,6 +166,8 @@ Content-Type: application/json
     "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
     "durationMinutes": 30,
     "active": true,
+    "name": "Intro call",
+    "description": "Book a 30-minute introduction call",
     "availabilityRules": [
         { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Asia/Ho_Chi_Minh" },
         { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "timeZone": "Europe/London" },
@@ -166,7 +176,7 @@ Content-Type: application/json
 }
 ```
 
-Fields `availabilityRules` are omitted from the response when not set.
+Fields `availabilityRules`, `name` and `description` are omitted from the response when not set.
 
 **Error responses**
 
@@ -193,6 +203,8 @@ All fields are optional. Include only the fields to update.
 | `durationMinutes`   | New slot duration in minutes, must be positive                                                                   |
 | `active`            | New active state                                                                                                 |
 | `availabilityRules` | Replaces all existing rules. Set to `null` to remove all rules. Each rule may specify its own `timeZone`. |
+| `name`              | New display name. Set to `null` or a blank value to remove it.                                                   |
+| `description`       | New description. Set to `null` or a blank value to remove it.                                                    |
 
 **Sample request — update duration and deactivate**
 ```

--- a/docs/apis/webadmin.md
+++ b/docs/apis/webadmin.md
@@ -1138,6 +1138,8 @@ Content-Type: application/json
     "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
     "durationMinutes": 30,
     "active": true,
+    "name": "Intro call",
+    "description": "Book a 30-minute introduction call",
     "availabilityRules": [
       { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "17:00", "timeZone": "UTC" }
     ]
@@ -1145,7 +1147,7 @@ Content-Type: application/json
 ]
 ```
 
-`availabilityRules` is omitted from an entry when not set.
+`availabilityRules`, `name` and `description` are omitted from an entry when not set.
 
 **Status codes**:
 - `200`: the list is returned (possibly empty)
@@ -1171,13 +1173,15 @@ POST /users/{username}/booking-links
   "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
   "durationMinutes": 30,
   "active": true,
+  "name": "Intro call",
+  "description": "Book a 30-minute introduction call",
   "availabilityRules": [
     { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Europe/Paris" }
   ]
 }
 ```
 
-`calendarUrl`, `durationMinutes` and `active` are required. `availabilityRules` is optional.
+`calendarUrl`, `durationMinutes` and `active` are required. `availabilityRules`, `name` and `description` are optional.
 
 ```
 HTTP/1.1 201 Created
@@ -1205,7 +1209,8 @@ PATCH /users/{username}/booking-links/{publicId}
 ```
 
 Only the fields present in the body are updated. At least one field must be provided.
-Set `availabilityRules` to `null` to remove all rules.
+Set `availabilityRules` to `null` to remove all rules. Set `name` or `description` to `null`
+or a blank value to remove them.
 
 **Status codes**:
 - `204`: the booking link was updated

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLink.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLink.java
@@ -34,6 +34,8 @@ public record BookingLink(Username username,
                           Duration duration,
                           boolean active,
                           Optional<AvailabilityRules> availabilityRules,
+                          Optional<String> name,
+                          Optional<String> description,
                           Instant createdAt,
                           Instant updatedAt) {
 
@@ -44,6 +46,8 @@ public record BookingLink(Username username,
         Preconditions.checkNotNull(duration, "'eventDuration' must not be null");
         Preconditions.checkArgument(!duration.isNegative() && !duration.isZero(), "'eventDuration' must be positive");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
+        Preconditions.checkNotNull(name, "'name' must not be null");
+        Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkNotNull(createdAt, "'createdAt' must not be null");
     }
 
@@ -59,6 +63,8 @@ public record BookingLink(Username username,
             .duration(duration)
             .active(active)
             .availabilityRules(availabilityRules)
+            .name(name)
+            .description(description)
             .createdAt(createdAt)
             .updatedAt(updatedAt);
     }
@@ -70,6 +76,8 @@ public record BookingLink(Username username,
         private Duration duration;
         private boolean active;
         private Optional<AvailabilityRules> availabilityRules = Optional.empty();
+        private Optional<String> name = Optional.empty();
+        private Optional<String> description = Optional.empty();
         private Instant createdAt;
         private Instant updatedAt;
 
@@ -103,6 +111,16 @@ public record BookingLink(Username username,
             return this;
         }
 
+        public Builder name(Optional<String> name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder description(Optional<String> description) {
+            this.description = description;
+            return this;
+        }
+
         public Builder createdAt(Instant createdAt) {
             this.createdAt = createdAt;
             return this;
@@ -114,7 +132,7 @@ public record BookingLink(Username username,
         }
 
         public BookingLink build() {
-            return new BookingLink(username, publicId, calendarUrl, duration, active, availabilityRules, createdAt, updatedAt);
+            return new BookingLink(username, publicId, calendarUrl, duration, active, availabilityRules, name, description, createdAt, updatedAt);
         }
     }
 

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
@@ -28,7 +28,9 @@ import com.linagora.calendar.storage.CalendarURL;
 public record BookingLinkInsertRequest(CalendarURL calendarUrl,
                                        Duration eventDuration,
                                        boolean active,
-                                       Optional<AvailabilityRules> availabilityRules) {
+                                       Optional<AvailabilityRules> availabilityRules,
+                                       Optional<String> name,
+                                       Optional<String> description) {
     public static final boolean ACTIVE = true;
 
     public BookingLinkInsertRequest {
@@ -36,6 +38,15 @@ public record BookingLinkInsertRequest(CalendarURL calendarUrl,
         Preconditions.checkNotNull(eventDuration, "'eventDuration' must not be null");
         Preconditions.checkArgument(!eventDuration.isNegative() && !eventDuration.isZero(), "'eventDuration' must be positive");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
+        Preconditions.checkNotNull(name, "'name' must not be null");
+        Preconditions.checkNotNull(description, "'description' must not be null");
+    }
+
+    public BookingLinkInsertRequest(CalendarURL calendarUrl,
+                                    Duration eventDuration,
+                                    boolean active,
+                                    Optional<AvailabilityRules> availabilityRules) {
+        this(calendarUrl, eventDuration, active, availabilityRules, Optional.empty(), Optional.empty());
     }
 
     public BookingLinkInsertRequest(CalendarURL calendarUrl,

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkPatchRequest.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkPatchRequest.java
@@ -29,12 +29,16 @@ import com.linagora.calendar.storage.CalendarURL;
 public record BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
                                       ValuePatch<Duration> duration,
                                       ValuePatch<Boolean> active,
-                                      ValuePatch<AvailabilityRules> availabilityRules) {
+                                      ValuePatch<AvailabilityRules> availabilityRules,
+                                      ValuePatch<String> name,
+                                      ValuePatch<String> description) {
     public BookingLinkPatchRequest {
         Preconditions.checkNotNull(calendarUrl, "'calendarUrl' must not be null");
         Preconditions.checkNotNull(duration, "'eventDuration' must not be null");
         Preconditions.checkNotNull(active, "'active' must not be null");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
+        Preconditions.checkNotNull(name, "'name' must not be null");
+        Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkArgument(!calendarUrl.isRemoved(), "'calendarUrl' can not be removed");
         Preconditions.checkArgument(!duration.isRemoved(), "'eventDuration' can not be removed");
         Preconditions.checkArgument(!active.isRemoved(), "'active' can not be removed");
@@ -46,6 +50,15 @@ public record BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
         Preconditions.checkArgument(!calendarUrl.isKept()
             || !duration.isKept()
             || !active.isKept()
-            || !availabilityRules.isKept(), "At least one updatable field is required");
+            || !availabilityRules.isKept()
+            || !name.isKept()
+            || !description.isKept(), "At least one updatable field is required");
+    }
+
+    public BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
+                                   ValuePatch<Duration> duration,
+                                   ValuePatch<Boolean> active,
+                                   ValuePatch<AvailabilityRules> availabilityRules) {
+        this(calendarUrl, duration, active, availabilityRules, ValuePatch.keep(), ValuePatch.keep());
     }
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
@@ -57,6 +57,8 @@ public class MemoryBookingLinkDAO implements BookingLinkDAO {
                 .duration(request.eventDuration())
                 .active(request.active())
                 .availabilityRules(request.availabilityRules())
+                .name(request.name())
+                .description(request.description())
                 .createdAt(now)
                 .updatedAt(now)
                 .build();
@@ -92,6 +94,8 @@ public class MemoryBookingLinkDAO implements BookingLinkDAO {
                 builder.duration(request.duration().getOrElse(existing.duration()));
                 builder.active(request.active().getOrElse(existing.active()));
                 builder.availabilityRules(request.availabilityRules().notKeptOrElse(existing.availabilityRules()));
+                builder.name(request.name().notKeptOrElse(existing.name()));
+                builder.description(request.description().notKeptOrElse(existing.description()));
                 return builder.updatedAt(now).build();
             });
 

--- a/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
@@ -279,6 +279,64 @@ public interface BookingLinkDAOContract {
     }
 
     @Test
+    default void insertShouldPersistNameAndDescription() {
+        BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE,
+            Optional.of(AVAILABILITY_RULES), Optional.of("Intro call"), Optional.of("Book a 30-minute intro call"));
+
+        BookingLink created = testee().insert(USER_1, request).block();
+
+        assertThat(created.name()).contains("Intro call");
+        assertThat(created.description()).contains("Book a 30-minute intro call");
+
+        BookingLink found = testee().findByPublicId(USER_1, created.publicId()).block();
+        assertThat(found).isEqualTo(created);
+    }
+
+    @Test
+    default void insertShouldDefaultNameAndDescriptionToEmpty() {
+        BookingLink created = testee().insert(USER_1, INSERT_REQUEST).block();
+
+        assertThat(created.name()).isEmpty();
+        assertThat(created.description()).isEmpty();
+    }
+
+    @Test
+    default void updateShouldApplyNameAndDescription() {
+        BookingLink inserted = testee().insert(USER_1, INSERT_REQUEST).block();
+        BookingLinkPatchRequest patchRequest = new BookingLinkPatchRequest(
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.modifyTo("Updated name"),
+            ValuePatch.modifyTo("Updated description"));
+
+        BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
+
+        assertThat(updated.name()).contains("Updated name");
+        assertThat(updated.description()).contains("Updated description");
+    }
+
+    @Test
+    default void updateShouldAllowRemovingNameAndDescription() {
+        BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE,
+            Optional.of(AVAILABILITY_RULES), Optional.of("Intro call"), Optional.of("Some description"));
+        BookingLink inserted = testee().insert(USER_1, request).block();
+        BookingLinkPatchRequest patchRequest = new BookingLinkPatchRequest(
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.remove(),
+            ValuePatch.remove());
+
+        BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
+
+        assertThat(updated.name()).isEmpty();
+        assertThat(updated.description()).isEmpty();
+    }
+
+    @Test
     default void resetPublicIdShouldFailWhenPublicIdDoesNotExist() {
         assertThatThrownBy(() -> testee().resetPublicId(USER_1, new BookingLinkPublicId(UUID.randomUUID())).block())
             .isInstanceOf(BookingLinkNotFoundException.class);

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
@@ -111,6 +111,8 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
                 .duration(request.eventDuration())
                 .active(request.active())
                 .availabilityRules(request.availabilityRules())
+                .name(request.name())
+                .description(request.description())
                 .createdAt(now)
                 .updatedAt(now)
                 .build();

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
@@ -70,6 +70,8 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
     private static final String FIELD_DURATION_SECONDS = "durationSeconds";
     private static final String FIELD_ACTIVE = "active";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_DESCRIPTION = "description";
     private static final String FIELD_CREATED_AT = "createdAt";
     private static final String FIELD_UPDATED_AT = "updatedAt";
 
@@ -203,6 +205,16 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
         } else if (request.availabilityRules().isRemoved()) {
             unsetFields.append(FIELD_AVAILABILITY_RULES, "");
         }
+        if (request.name().isModified()) {
+            setFields.append(FIELD_NAME, request.name().get());
+        } else if (request.name().isRemoved()) {
+            unsetFields.append(FIELD_NAME, "");
+        }
+        if (request.description().isModified()) {
+            setFields.append(FIELD_DESCRIPTION, request.description().get());
+        } else if (request.description().isRemoved()) {
+            unsetFields.append(FIELD_DESCRIPTION, "");
+        }
 
         Document updateBson = new Document("$set", setFields);
         if (!unsetFields.isEmpty()) {
@@ -224,6 +236,8 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
 
         bookingLink.availabilityRules().ifPresent(rules ->
             doc.append(FIELD_AVAILABILITY_RULES, serializeRules(rules)));
+        bookingLink.name().ifPresent(name -> doc.append(FIELD_NAME, name));
+        bookingLink.description().ifPresent(description -> doc.append(FIELD_DESCRIPTION, description));
 
         return doc;
     }
@@ -261,6 +275,8 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
         Optional<AvailabilityRules> availabilityRules = Optional.ofNullable(doc.getList(FIELD_AVAILABILITY_RULES, Document.class))
             .filter(rules -> !rules.isEmpty())
             .map(rules -> new AvailabilityRules(rules.stream().map(this::deserializeRule).toList()));
+        Optional<String> name = Optional.ofNullable(doc.getString(FIELD_NAME));
+        Optional<String> description = Optional.ofNullable(doc.getString(FIELD_DESCRIPTION));
 
         return BookingLink.builder()
             .username(username)
@@ -269,6 +285,8 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
             .duration(duration)
             .active(active)
             .availabilityRules(availabilityRules)
+            .name(name)
+            .description(description)
             .createdAt(createdAt)
             .updatedAt(updatedAt)
             .build();


### PR DESCRIPTION
Closes #860

Booking links now carry two optional string fields: `name` and `description`.

## Changes
- **Model**: `BookingLink`, `BookingLinkInsertRequest` and `BookingLinkPatchRequest` carry the new optional fields. Convenience constructors keep the previous signatures so existing call sites are unaffected.
- **Mongo storage**: serializes/deserializes `name` and `description`, with retro-compatibility — existing documents without these fields are read as empty (and a patch can unset them).
- **REST API** (`/api/booking-links` create/patch/get/list): accepts and exposes the new fields. Blank values are ignored on creation; a patch removes a field when it is set to `null` or a blank value.
- **WebAdmin API** (`/users/{username}/booking-links`): mirrors the same behavior.
- **Docs**: updated `docs/apis/bookingLink.md` and `docs/apis/webadmin.md`.

## Tests
- Extended `BookingLinkDAOContract` (insert/persist, default empty, update, removal) — passing against the Memory DAO and applicable to Mongo.
- Added REST route tests for create (persist / default empty / blank ignored), get (response exposure) and patch (update / null removal).
