### PR TITLE
Booking links: add optional name and description

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
@@ -169,6 +169,8 @@ class BookingLinkCreateRouteTest {
         assertThat(stored.calendarUrl()).isEqualTo(CalendarURL.from(openPaaSUser.id()));
         assertThat(stored.duration()).isEqualTo(Duration.ofMinutes(30));
         assertThat(stored.active()).isTrue();
+        assertThat(stored.name()).isEmpty();
+        assertThat(stored.description()).isEmpty();
 
         // Default availability rules should be set when not provided, based on the default business hours and timezone
         assertThat(stored.availabilityRules()).isEqualTo(Optional.of(AvailabilityRules.of(
@@ -178,6 +180,30 @@ class BookingLinkCreateRouteTest {
             new WeeklyAvailabilityRule(DayOfWeek.THURSDAY, businessStart, businessEnd, europeParis),
             new WeeklyAvailabilityRule(DayOfWeek.FRIDAY, businessStart, businessEnd, europeParis)
         )));
+    }
+
+    @Test
+    void shouldPersistBookingLinkWithNameAndDescription() {
+        String publicId = given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "name": "30-min intro call",
+                    "description": "Book a quick introduction call"
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED)
+            .extract().jsonPath().getString("bookingLinkPublicId");
+
+        BookingLink stored = bookingLinkProbe.findBookingLink(openPaaSUser.username(), new BookingLinkPublicId(UUID.fromString(publicId)));
+
+        assertThat(stored.name()).contains("30-min intro call");
+        assertThat(stored.description()).contains("Book a quick introduction call");
     }
 
     @Test

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
@@ -64,6 +64,8 @@ public class BookingLinkCreateRoute extends CalendarRoute {
     public record CreateBookingLinkRequestDTO(@JsonProperty("calendarUrl") String calendarUrl,
                                               @JsonProperty("durationMinutes") Integer durationMinutes,
                                               @JsonProperty("active") Boolean active,
+                                              @JsonProperty("name") Optional<String> name,
+                                              @JsonProperty("description") Optional<String> description,
                                               @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules) {
 
         public static BookingLinkInsertRequest toBookingLinkInsertRequest(CreateBookingLinkRequestDTO request,
@@ -79,7 +81,8 @@ public class BookingLinkCreateRoute extends CalendarRoute {
 
             Optional<AvailabilityRules> availabilityRules = getAvailabilityRules(request, defaultZone).or(() -> defaultAvailabilityRules);
 
-            return new BookingLinkInsertRequest(calendarURL, duration, request.active, availabilityRules);
+            return new BookingLinkInsertRequest(calendarURL, duration, request.active,
+                request.name(), request.description(), availabilityRules);
         }
 
         private static Optional<AvailabilityRules> getAvailabilityRules(CreateBookingLinkRequestDTO request, ZoneId defaultZone) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
@@ -60,11 +60,15 @@ public class BookingLinkPatchRoute extends CalendarRoute {
     private static final String FIELD_CALENDAR_URL = "calendarUrl";
     private static final String FIELD_DURATION_MINUTES = "durationMinutes";
     private static final String FIELD_ACTIVE = "active";
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_DESCRIPTION = "description";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
 
     public record PatchDto(@JsonProperty(FIELD_CALENDAR_URL) Optional<String> calendarUrl,
                            @JsonProperty(FIELD_DURATION_MINUTES) Optional<Integer> durationMinutes,
                            @JsonProperty(FIELD_ACTIVE) Optional<Boolean> active,
+                           @JsonProperty(FIELD_NAME) Optional<String> name,
+                           @JsonProperty(FIELD_DESCRIPTION) Optional<String> description,
                            @JsonProperty(FIELD_AVAILABILITY_RULES) Optional<List<AvailabilityRuleDTO>> availabilityRules) {
     }
 
@@ -124,6 +128,8 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                 parseCalendarUrl(node, dto),
                 parseDuration(node, dto),
                 parseActive(node, dto),
+                parseStringField(node, dto.name(), FIELD_NAME),
+                parseStringField(node, dto.description(), FIELD_DESCRIPTION),
                 parseAvailabilityRules(node, dto, defaultTimeZone));
         } catch (IllegalArgumentException e) {
             throw e;
@@ -168,6 +174,13 @@ public class BookingLinkPatchRoute extends CalendarRoute {
             return ValuePatch.keep();
         }
         return dto.active.map(ValuePatch::modifyTo).orElseThrow(() -> new IllegalArgumentException("'active' cannot be removed"));
+    }
+
+    private ValuePatch<String> parseStringField(JsonNode node, Optional<String> value, String fieldName) {
+        if (!node.has(fieldName)) {
+            return ValuePatch.keep();
+        }
+        return value.map(ValuePatch::modifyTo).orElseGet(ValuePatch::remove);
     }
 
     private ValuePatch<AvailabilityRules> parseAvailabilityRules(JsonNode node, PatchDto dto, ZoneId defaultTimeZone) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/BookingLinkDTO.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/BookingLinkDTO.java
@@ -30,6 +30,8 @@ public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
                              @JsonProperty("calendarUrl") String calendarUrl,
                              @JsonProperty("durationMinutes") long durationMinutes,
                              @JsonProperty("active") boolean active,
+                             @JsonProperty("name") Optional<String> name,
+                             @JsonProperty("description") Optional<String> description,
                              @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules) {
 
     public static BookingLinkDTO from(BookingLink bookingLink) {
@@ -43,6 +45,8 @@ public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
             bookingLink.calendarUrl().asUri().toString(),
             bookingLink.duration().toMinutes(),
             bookingLink.active(),
+            bookingLink.name(),
+            bookingLink.description(),
             ruleDTOs);
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
@@ -87,6 +87,8 @@ public class BookingLinkUserRoutes implements Routes {
     private static final String FIELD_CALENDAR_URL = "calendarUrl";
     private static final String FIELD_DURATION_MINUTES = "durationMinutes";
     private static final String FIELD_ACTIVE = "active";
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_DESCRIPTION = "description";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
     private static final String FIELD_PUBLIC_ID = "bookingLinkPublicId";
     private static final ZoneId DEFAULT_ZONE = ZoneId.of("UTC");
@@ -220,6 +222,8 @@ public class BookingLinkUserRoutes implements Routes {
                 parseCalendarUrl(node, dto),
                 parseDuration(node, dto),
                 parseActive(node, dto),
+                parseStringField(node, dto.name(), FIELD_NAME),
+                parseStringField(node, dto.description(), FIELD_DESCRIPTION),
                 parseAvailabilityRules(node, dto));
         } catch (IllegalArgumentException e) {
             throw badRequest(e.getMessage(), e);
@@ -254,6 +258,13 @@ public class BookingLinkUserRoutes implements Routes {
         }
         return dto.active().map(ValuePatch::modifyTo)
             .orElseThrow(() -> new IllegalArgumentException("'active' cannot be removed"));
+    }
+
+    private ValuePatch<String> parseStringField(JsonNode node, Optional<String> value, String fieldName) {
+        if (!node.has(fieldName)) {
+            return ValuePatch.keep();
+        }
+        return value.map(ValuePatch::modifyTo).orElseGet(ValuePatch::remove);
     }
 
     private ValuePatch<AvailabilityRules> parseAvailabilityRules(JsonNode node, PatchDto dto) {

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -23,7 +23,11 @@ Public users can use booking links to book events.
 | `calendarUrl`       | string           | Calendar URI in the form `/calendars/{baseId}/{calendarId}`                 |
 | `durationMinutes`   | integer          | Duration of each bookable slot in minutes (must be positive)                |
 | `active`            | boolean          | Whether the booking link is active                                          |
+| `name`              | string (optional)| Display name of the booking link                                            |
+| `description`       | string (optional)| Description of the booking link                                             |
 | `availabilityRules` | array (optional) | List of availability rule objects (weekly or fixed)                         |
+
+Optional fields (`name`, `description`, `availabilityRules`) are omitted from responses when not set.
 
 ### Availability rule object
 
@@ -61,6 +65,8 @@ Create a new booking link for the authenticated user.
 | `calendarUrl`       | yes      | Calendar URI (must be accessible by the user)                                                                                                            |
 | `durationMinutes`   | yes      | Slot duration in minutes, must be positive                                                                                                               |
 | `active`            | yes      | Whether the booking link is active                                                                                                                       |
+| `name`              | no       | Display name of the booking link                                                                                                                         |
+| `description`       | no       | Description of the booking link                                                                                                                          |
 | `availabilityRules` | no       | List of availability rules. Defaults to business hours from user settings when omitted. Each rule may specify its own `timeZone` (see availability rule object above). |
 
 **Sample request**
@@ -73,6 +79,8 @@ Content-Type: application/json
     "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
     "durationMinutes": 30,
     "active": true,
+    "name": "30-min intro call",
+    "description": "Book a quick introduction call",
     "availabilityRules": [
         { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Asia/Ho_Chi_Minh" },
         { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "timeZone": "Europe/London" },
@@ -158,6 +166,8 @@ Content-Type: application/json
     "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
     "durationMinutes": 30,
     "active": true,
+    "name": "30-min intro call",
+    "description": "Book a quick introduction call",
     "availabilityRules": [
         { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Asia/Ho_Chi_Minh" },
         { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "timeZone": "Europe/London" },
@@ -166,7 +176,7 @@ Content-Type: application/json
 }
 ```
 
-Fields `availabilityRules` are omitted from the response when not set.
+Fields `name`, `description` and `availabilityRules` are omitted from the response when not set.
 
 **Error responses**
 
@@ -192,6 +202,8 @@ All fields are optional. Include only the fields to update.
 | `calendarUrl`       | New calendar URI                                                                                                 |
 | `durationMinutes`   | New slot duration in minutes, must be positive                                                                   |
 | `active`            | New active state                                                                                                 |
+| `name`              | New display name. Set to `null` to remove it.                                                                    |
+| `description`       | New description. Set to `null` to remove it.                                                                     |
 | `availabilityRules` | Replaces all existing rules. Set to `null` to remove all rules. Each rule may specify its own `timeZone`. |
 
 **Sample request — update duration and deactivate**

--- a/docs/apis/webadmin.md
+++ b/docs/apis/webadmin.md
@@ -1171,13 +1171,15 @@ POST /users/{username}/booking-links
   "calendarUrl": "/calendars/67c3a792e4b0884b05ef8aef/67c3a792e4b0884b05ef8aef",
   "durationMinutes": 30,
   "active": true,
+  "name": "30-min intro call",
+  "description": "Book a quick introduction call",
   "availabilityRules": [
     { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Europe/Paris" }
   ]
 }
 ```
 
-`calendarUrl`, `durationMinutes` and `active` are required. `availabilityRules` is optional.
+`calendarUrl`, `durationMinutes` and `active` are required. `name`, `description` and `availabilityRules` are optional.
 
 ```
 HTTP/1.1 201 Created
@@ -1205,7 +1207,7 @@ PATCH /users/{username}/booking-links/{publicId}
 ```
 
 Only the fields present in the body are updated. At least one field must be provided.
-Set `availabilityRules` to `null` to remove all rules.
+Set `name`, `description` or `availabilityRules` to `null` to remove them.
 
 **Status codes**:
 - `204`: the booking link was updated

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLink.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLink.java
@@ -33,6 +33,8 @@ public record BookingLink(Username username,
                           CalendarURL calendarUrl,
                           Duration duration,
                           boolean active,
+                          Optional<String> name,
+                          Optional<String> description,
                           Optional<AvailabilityRules> availabilityRules,
                           Instant createdAt,
                           Instant updatedAt) {
@@ -43,6 +45,8 @@ public record BookingLink(Username username,
         Preconditions.checkNotNull(calendarUrl, "'calendarUrl' must not be null");
         Preconditions.checkNotNull(duration, "'eventDuration' must not be null");
         Preconditions.checkArgument(!duration.isNegative() && !duration.isZero(), "'eventDuration' must be positive");
+        Preconditions.checkNotNull(name, "'name' must not be null");
+        Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
         Preconditions.checkNotNull(createdAt, "'createdAt' must not be null");
     }
@@ -58,6 +62,8 @@ public record BookingLink(Username username,
             .calendarUrl(calendarUrl)
             .duration(duration)
             .active(active)
+            .name(name)
+            .description(description)
             .availabilityRules(availabilityRules)
             .createdAt(createdAt)
             .updatedAt(updatedAt);
@@ -69,6 +75,8 @@ public record BookingLink(Username username,
         private CalendarURL calendarUrl;
         private Duration duration;
         private boolean active;
+        private Optional<String> name = Optional.empty();
+        private Optional<String> description = Optional.empty();
         private Optional<AvailabilityRules> availabilityRules = Optional.empty();
         private Instant createdAt;
         private Instant updatedAt;
@@ -98,6 +106,16 @@ public record BookingLink(Username username,
             return this;
         }
 
+        public Builder name(Optional<String> name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder description(Optional<String> description) {
+            this.description = description;
+            return this;
+        }
+
         public Builder availabilityRules(Optional<AvailabilityRules> availabilityRules) {
             this.availabilityRules = availabilityRules;
             return this;
@@ -114,7 +132,7 @@ public record BookingLink(Username username,
         }
 
         public BookingLink build() {
-            return new BookingLink(username, publicId, calendarUrl, duration, active, availabilityRules, createdAt, updatedAt);
+            return new BookingLink(username, publicId, calendarUrl, duration, active, name, description, availabilityRules, createdAt, updatedAt);
         }
     }
 

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
@@ -28,6 +28,8 @@ import com.linagora.calendar.storage.CalendarURL;
 public record BookingLinkInsertRequest(CalendarURL calendarUrl,
                                        Duration eventDuration,
                                        boolean active,
+                                       Optional<String> name,
+                                       Optional<String> description,
                                        Optional<AvailabilityRules> availabilityRules) {
     public static final boolean ACTIVE = true;
 
@@ -35,13 +37,22 @@ public record BookingLinkInsertRequest(CalendarURL calendarUrl,
         Preconditions.checkNotNull(calendarUrl, "'calendarUrl' must not be null");
         Preconditions.checkNotNull(eventDuration, "'eventDuration' must not be null");
         Preconditions.checkArgument(!eventDuration.isNegative() && !eventDuration.isZero(), "'eventDuration' must be positive");
+        Preconditions.checkNotNull(name, "'name' must not be null");
+        Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
     }
 
     public BookingLinkInsertRequest(CalendarURL calendarUrl,
                                     Duration eventDuration,
+                                    boolean active,
+                                    Optional<AvailabilityRules> availabilityRules) {
+        this(calendarUrl, eventDuration, active, Optional.empty(), Optional.empty(), availabilityRules);
+    }
+
+    public BookingLinkInsertRequest(CalendarURL calendarUrl,
+                                    Duration eventDuration,
                                     AvailabilityRules availabilityRules) {
-        this(calendarUrl, eventDuration, ACTIVE, Optional.of(availabilityRules));
+        this(calendarUrl, eventDuration, ACTIVE, Optional.empty(), Optional.empty(), Optional.of(availabilityRules));
     }
 
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkPatchRequest.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkPatchRequest.java
@@ -29,11 +29,15 @@ import com.linagora.calendar.storage.CalendarURL;
 public record BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
                                       ValuePatch<Duration> duration,
                                       ValuePatch<Boolean> active,
+                                      ValuePatch<String> name,
+                                      ValuePatch<String> description,
                                       ValuePatch<AvailabilityRules> availabilityRules) {
     public BookingLinkPatchRequest {
         Preconditions.checkNotNull(calendarUrl, "'calendarUrl' must not be null");
         Preconditions.checkNotNull(duration, "'eventDuration' must not be null");
         Preconditions.checkNotNull(active, "'active' must not be null");
+        Preconditions.checkNotNull(name, "'name' must not be null");
+        Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
         Preconditions.checkArgument(!calendarUrl.isRemoved(), "'calendarUrl' can not be removed");
         Preconditions.checkArgument(!duration.isRemoved(), "'eventDuration' can not be removed");
@@ -46,6 +50,15 @@ public record BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
         Preconditions.checkArgument(!calendarUrl.isKept()
             || !duration.isKept()
             || !active.isKept()
+            || !name.isKept()
+            || !description.isKept()
             || !availabilityRules.isKept(), "At least one updatable field is required");
+    }
+
+    public BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
+                                   ValuePatch<Duration> duration,
+                                   ValuePatch<Boolean> active,
+                                   ValuePatch<AvailabilityRules> availabilityRules) {
+        this(calendarUrl, duration, active, ValuePatch.keep(), ValuePatch.keep(), availabilityRules);
     }
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
@@ -91,6 +91,8 @@ public class MemoryBookingLinkDAO implements BookingLinkDAO {
                 builder.calendarUrl(request.calendarUrl().getOrElse(existing.calendarUrl()));
                 builder.duration(request.duration().getOrElse(existing.duration()));
                 builder.active(request.active().getOrElse(existing.active()));
+                builder.name(request.name().notKeptOrElse(existing.name()));
+                builder.description(request.description().notKeptOrElse(existing.description()));
                 builder.availabilityRules(request.availabilityRules().notKeptOrElse(existing.availabilityRules()));
                 return builder.updatedAt(now).build();
             });

--- a/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
@@ -279,6 +279,63 @@ public interface BookingLinkDAOContract {
     }
 
     @Test
+    default void insertShouldDefaultNameAndDescriptionToEmpty() {
+        BookingLink inserted = testee().insert(USER_1, INSERT_REQUEST).block();
+
+        assertThat(inserted.name()).isEmpty();
+        assertThat(inserted.description()).isEmpty();
+    }
+
+    @Test
+    default void insertThenFindShouldPreserveNameAndDescription() {
+        BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE,
+            Optional.of("Intro call"), Optional.of("A short introduction call"), Optional.of(AVAILABILITY_RULES));
+        BookingLink inserted = testee().insert(USER_1, request).block();
+
+        assertThat(inserted.name()).contains("Intro call");
+        assertThat(inserted.description()).contains("A short introduction call");
+
+        assertThat(testee().findByPublicId(USER_1, inserted.publicId()).block())
+            .isEqualTo(inserted);
+    }
+
+    @Test
+    default void updateShouldApplyNameAndDescription() {
+        BookingLink inserted = testee().insert(USER_1, INSERT_REQUEST).block();
+        BookingLinkPatchRequest patchRequest = new BookingLinkPatchRequest(
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.modifyTo("Updated name"),
+            ValuePatch.modifyTo("Updated description"),
+            ValuePatch.keep());
+
+        BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
+
+        assertThat(updated.name()).contains("Updated name");
+        assertThat(updated.description()).contains("Updated description");
+    }
+
+    @Test
+    default void updateShouldAllowRemovingNameAndDescription() {
+        BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE,
+            Optional.of("Intro call"), Optional.of("A short introduction call"), Optional.of(AVAILABILITY_RULES));
+        BookingLink inserted = testee().insert(USER_1, request).block();
+        BookingLinkPatchRequest patchRequest = new BookingLinkPatchRequest(
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.remove(),
+            ValuePatch.remove(),
+            ValuePatch.keep());
+
+        BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
+
+        assertThat(updated.name()).isEmpty();
+        assertThat(updated.description()).isEmpty();
+    }
+
+    @Test
     default void resetPublicIdShouldFailWhenPublicIdDoesNotExist() {
         assertThatThrownBy(() -> testee().resetPublicId(USER_1, new BookingLinkPublicId(UUID.randomUUID())).block())
             .isInstanceOf(BookingLinkNotFoundException.class);

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
@@ -69,6 +69,8 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
     private static final String FIELD_CALENDAR_ID = "calendarId";
     private static final String FIELD_DURATION_SECONDS = "durationSeconds";
     private static final String FIELD_ACTIVE = "active";
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_DESCRIPTION = "description";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
     private static final String FIELD_CREATED_AT = "createdAt";
     private static final String FIELD_UPDATED_AT = "updatedAt";
@@ -198,6 +200,16 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
         if (request.active().isModified()) {
             setFields.append(FIELD_ACTIVE, request.active().get());
         }
+        if (request.name().isModified()) {
+            setFields.append(FIELD_NAME, request.name().get());
+        } else if (request.name().isRemoved()) {
+            unsetFields.append(FIELD_NAME, "");
+        }
+        if (request.description().isModified()) {
+            setFields.append(FIELD_DESCRIPTION, request.description().get());
+        } else if (request.description().isRemoved()) {
+            unsetFields.append(FIELD_DESCRIPTION, "");
+        }
         if (request.availabilityRules().isModified()) {
             setFields.append(FIELD_AVAILABILITY_RULES, serializeRules(request.availabilityRules().get()));
         } else if (request.availabilityRules().isRemoved()) {
@@ -221,6 +233,9 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
             .append(FIELD_ACTIVE, bookingLink.active())
             .append(FIELD_CREATED_AT, Date.from(bookingLink.createdAt()))
             .append(FIELD_UPDATED_AT, Date.from(bookingLink.updatedAt()));
+
+        bookingLink.name().ifPresent(name -> doc.append(FIELD_NAME, name));
+        bookingLink.description().ifPresent(description -> doc.append(FIELD_DESCRIPTION, description));
 
         bookingLink.availabilityRules().ifPresent(rules ->
             doc.append(FIELD_AVAILABILITY_RULES, serializeRules(rules)));
@@ -256,6 +271,8 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
         CalendarURL calendarURL = new CalendarURL(new OpenPaaSId(doc.getString(FIELD_PRINCIPAL_ID)), new OpenPaaSId(doc.getString(FIELD_CALENDAR_ID)));
         Duration duration = Duration.ofSeconds(doc.getLong(FIELD_DURATION_SECONDS));
         boolean active = doc.getBoolean(FIELD_ACTIVE);
+        Optional<String> name = Optional.ofNullable(doc.getString(FIELD_NAME));
+        Optional<String> description = Optional.ofNullable(doc.getString(FIELD_DESCRIPTION));
         Instant createdAt = doc.getDate(FIELD_CREATED_AT).toInstant();
         Instant updatedAt = doc.getDate(FIELD_UPDATED_AT).toInstant();
         Optional<AvailabilityRules> availabilityRules = Optional.ofNullable(doc.getList(FIELD_AVAILABILITY_RULES, Document.class))
@@ -268,6 +285,8 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
             .calendarUrl(calendarURL)
             .duration(duration)
             .active(active)
+            .name(name)
+            .description(description)
             .availabilityRules(availabilityRules)
             .createdAt(createdAt)
             .updatedAt(updatedAt)


### PR DESCRIPTION
Closes #860

Booking links can now carry an optional **name** and an optional **description** (both plain strings).

## Changes

- `BookingLink`, `BookingLinkInsertRequest` and `BookingLinkPatchRequest` carry the two new optional fields. In a `PATCH`, `name` and `description` can be set (non-null value), removed (explicit `null`) or left untouched (absent).
- **MongoDB storage**: both fields are serialized when present and read back with `Optional.ofNullable`. Documents stored before this change (without the fields) keep deserializing fine — retro-compatibility is preserved.
- **REST API** (`/api/booking-links` create / patch / get / list) accepts and exposes `name` and `description`; they are omitted from responses when not set.
- **WebAdmin API** (`/users/{username}/booking-links`) mirrors the same behavior.
- Documentation updated in both `docs/apis/bookingLink.md` and `docs/apis/webadmin.md`.
- DAO contract tests cover insert round-trip, patch update and patch removal of the new fields.

## Tests

`mvn test-compile` passes for all impacted modules (storage-api, storage-mongodb, calendar-rest-api, calendar-webadmin, app) with no checkstyle violations.
