### PR TITLE
Booking links: reference the booking link in generated event ICS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 
+### New Features
+
+ - ISSUE-864 Booking links: reference the originating booking link in generated event ICS through the `X-OPENPAAS-BOOKING-LINK` property
+
 ## [2.1.0] - 2026-05-07
 
 ### New Features

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -309,6 +309,8 @@ class BookingLinkReservationRouteTest {
                 .isEqualTo("true");
             softly.assertThat(getPropertyValue.apply("X-PUBLICLY-CREATOR"))
                 .isEqualTo("creator@example.com");
+            softly.assertThat(getPropertyValue.apply("X-OPENPAAS-BOOKING-LINK"))
+                .isEqualTo(inserted.publicId().value().toString());
         });
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilder.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilder.java
@@ -35,6 +35,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest.BookingAttendee;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Property;
@@ -63,6 +64,7 @@ public class BookingLinkEventIcsBuilder {
 
     private static final String PROD_ID = "-//Twake Calendar//Public Booking//EN";
     private static final String X_PUBLICLY_CREATOR = "X-PUBLICLY-CREATOR";
+    private static final String X_OPENPAAS_BOOKING_LINK = "X-OPENPAAS-BOOKING-LINK";
     private static final String X_OPENPAAS_VIDEOCONFERENCE = "X-OPENPAAS-VIDEOCONFERENCE";
     private static final String VISIO_DESCRIPTION_PREFIX = "Visio: ";
     private static final Transp TRANSP_OPAQUE = new Transp(Transp.VALUE_OPAQUE);
@@ -84,7 +86,7 @@ public class BookingLinkEventIcsBuilder {
         this.uidGenerator = uidGenerator;
     }
 
-    public BuildResult build(BookingRequest request, BookingAttendee organizer, Duration eventDuration) {
+    public BuildResult build(BookingRequest request, BookingAttendee organizer, Duration eventDuration, BookingLinkPublicId bookingLinkPublicId) {
         Uid eventUid = uidGenerator.generateUid();
         Optional<URL> maybeMeetingLink = Optional.of(request.visioLink())
             .filter(FunctionalUtils.identityPredicate())
@@ -93,7 +95,7 @@ public class BookingLinkEventIcsBuilder {
         Calendar calendar = new Calendar()
             .withDefaults()
             .withProdId(PROD_ID)
-            .withComponent(buildEvent(request, organizer, eventUid, eventDuration, maybeMeetingLink))
+            .withComponent(buildEvent(request, organizer, eventUid, eventDuration, maybeMeetingLink, bookingLinkPublicId))
             .getFluentTarget();
 
         return new BuildResult(eventUid, calendar, maybeMeetingLink);
@@ -103,7 +105,8 @@ public class BookingLinkEventIcsBuilder {
                               BookingAttendee organizer,
                               Uid eventUid,
                               Duration eventDuration,
-                              Optional<URL> maybeMeetingLink) {
+                              Optional<URL> maybeMeetingLink,
+                              BookingLinkPublicId bookingLinkPublicId) {
         ImmutableList.Builder<Property> properties = ImmutableList.<Property>builder()
             .add(eventUid)
             .add(TRANSP_OPAQUE)
@@ -124,7 +127,8 @@ public class BookingLinkEventIcsBuilder {
         properties
             .add(new Clazz(Clazz.VALUE_PUBLIC))
             .add(X_PROPERTY_PUBLIC)
-            .add(new XProperty(X_PUBLICLY_CREATOR, request.creator().email().asString()));
+            .add(new XProperty(X_PUBLICLY_CREATOR, request.creator().email().asString()))
+            .add(new XProperty(X_OPENPAAS_BOOKING_LINK, bookingLinkPublicId.value().toString()));
         maybeMeetingLink.ifPresent(visioLink -> properties.add(new XProperty(X_OPENPAAS_VIDEOCONFERENCE, visioLink.toString())));
 
         VEvent event = new VEvent(new PropertyList(properties.build()));

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
@@ -97,7 +97,7 @@ public class BookingLinkReservationService {
         return openPaaSUserDAO.retrieve(bookingLink.username())
             .flatMap(organizer -> {
                 BuildResult eventIcsResult = bookingLinkEventIcsBuilder.build(request,
-                    BookingAttendee.from(organizer.fullName(), organizer.username().asString()), bookingLink.duration());
+                    BookingAttendee.from(organizer.fullName(), organizer.username().asString()), bookingLink.duration(), bookingLink.publicId());
 
                 return calDavClient.importCalendar(bookingLink.calendarUrl(), eventIcsResult.eventIdAsString(), bookingLink.username(), eventIcsResult.icsBytes())
                     .onErrorMap(throwable -> BookingLinkReservationException.createEventFailed(bookingLink.publicId(), eventIcsResult.eventIdAsString(), throwable))

--- a/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilderTest.java
+++ b/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilderTest.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +36,7 @@ import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.restapi.routes.BookingLinkEventIcsBuilder.BuildResult;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest.BookingAttendee;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 
 import net.fortuna.ical4j.model.property.Uid;
 import net.fortuna.ical4j.util.UidGenerator;
@@ -45,6 +47,7 @@ public class BookingLinkEventIcsBuilderTest {
     private static final URL VISIO_URL = Throwing.supplier(() -> URI.create("https://jitsi.example.com").toURL()).get();
     private static final UidGenerator FIXED_UID_GENERATOR = () -> new Uid("event-123");
     private static final BookingAttendee OWNER = BookingAttendee.from("Alice Owner", "owner@example.com");
+    private static final BookingLinkPublicId BOOKING_LINK_PUBLIC_ID = new BookingLinkPublicId(UUID.fromString("a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d"));
 
     @Test
     void buildShouldIncludeRequiredPublicBookingProperties() {
@@ -58,7 +61,7 @@ public class BookingLinkEventIcsBuilderTest {
             true,
             "Please call via Zoom.");
 
-        BuildResult result = testee.build(request, OWNER, Duration.ofMinutes(30));
+        BuildResult result = testee.build(request, OWNER, Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID);
         String ics = new String(result.icsBytes(), StandardCharsets.UTF_8);
 
         String expected = """
@@ -81,6 +84,7 @@ public class BookingLinkEventIcsBuilderTest {
             CLASS:PUBLIC
             X-PUBLICLY-CREATED:true
             X-PUBLICLY-CREATOR:creator@example.com
+            X-OPENPAAS-BOOKING-LINK:a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d
             X-OPENPAAS-VIDEOCONFERENCE:https://jitsi.example.com
             END:VEVENT
             END:VCALENDAR
@@ -104,7 +108,7 @@ public class BookingLinkEventIcsBuilderTest {
             false,
             "");
 
-        BuildResult result = testee.build(request, OWNER, Duration.ofMinutes(30));
+        BuildResult result = testee.build(request, OWNER, Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID);
         String ics = new String(result.icsBytes(), StandardCharsets.UTF_8);
 
         String expected = """
@@ -126,6 +130,7 @@ public class BookingLinkEventIcsBuilderTest {
             CLASS:PUBLIC
             X-PUBLICLY-CREATED:true
             X-PUBLICLY-CREATOR:creator@example.com
+            X-OPENPAAS-BOOKING-LINK:a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d
             END:VEVENT
             END:VCALENDAR
             """;
@@ -148,7 +153,7 @@ public class BookingLinkEventIcsBuilderTest {
             true,
             null);
 
-        String ics = new String(testee.build(request, OWNER, Duration.ofMinutes(30)).icsBytes(), StandardCharsets.UTF_8);
+        String ics = new String(testee.build(request, OWNER, Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID).icsBytes(), StandardCharsets.UTF_8);
 
         assertThat(ics)
             .contains("DESCRIPTION:Visio: https://jitsi.example.com");
@@ -168,7 +173,7 @@ public class BookingLinkEventIcsBuilderTest {
             false,
             null);
 
-        BuildResult result = testee.build(request, BookingAttendee.from(null, "owner@example.com"), Duration.ofMinutes(30));
+        BuildResult result = testee.build(request, BookingAttendee.from(null, "owner@example.com"), Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID);
         String ics = new String(result.icsBytes(), StandardCharsets.UTF_8);
 
         String expected = """
@@ -189,6 +194,7 @@ public class BookingLinkEventIcsBuilderTest {
             CLASS:PUBLIC
             X-PUBLICLY-CREATED:true
             X-PUBLICLY-CREATOR:creator@example.com
+            X-OPENPAAS-BOOKING-LINK:a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d
             END:VEVENT
             END:VCALENDAR
             """;
@@ -211,12 +217,30 @@ public class BookingLinkEventIcsBuilderTest {
             false,
             null);
 
-        String ics = new String(testee.build(request, OWNER, Duration.ofMinutes(30)).icsBytes(), StandardCharsets.UTF_8);
+        String ics = new String(testee.build(request, OWNER, Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID).icsBytes(), StandardCharsets.UTF_8);
 
         assertThat(ics)
             .contains("ORGANIZER;CN=Alice Owner:mailto:owner@example.com");
         assertThat(ics)
             .contains("ATTENDEE;RSVP=TRUE;ROLE=CHAIR;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;CN=Alice Owner:mailto:owner@example.com");
+    }
+
+    @Test
+    void buildShouldReferenceTheBookingLink() {
+        BookingLinkEventIcsBuilder testee = new BookingLinkEventIcsBuilder(FIXED_CLOCK, () -> VISIO_URL, FIXED_UID_GENERATOR);
+
+        BookingRequest request = new BookingRequest(
+            Instant.parse("2036-01-26T09:30:00Z"),
+            BookingAttendee.from("BOB", "creator@example.com"),
+            List.of(),
+            "eventTitle",
+            false,
+            null);
+
+        String ics = new String(testee.build(request, OWNER, Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID).icsBytes(), StandardCharsets.UTF_8);
+
+        assertThat(ics)
+            .contains("X-OPENPAAS-BOOKING-LINK:a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d");
     }
 
 }


### PR DESCRIPTION
Closes #864

First step of #864: events created through a public booking link now carry an `X-OPENPAAS-BOOKING-LINK` ICS property holding the booking link public id.

This ties every booked event back to its originating booking link, which is the prerequisite for the remaining items of the ticket (indexing booking links, exposing an OpenPaaS event search criterion on them, and a user task to clean up all the events of a compromised booking link).

### Changes
- `BookingLinkEventIcsBuilder` adds the `X-OPENPAAS-BOOKING-LINK` property, placed alongside the other `X-OPENPAAS-*` / `X-PUBLICLY-*` properties.
- `BookingLinkReservationService` passes the booking link public id when building the event ICS.
- Unit coverage in `BookingLinkEventIcsBuilderTest` and an assertion in the `BookingLinkReservationRouteTest` integration test.
- CHANGELOG entry.
