### PR TITLE
Booking links: index and expose an event search criterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### New Features
 
  - ISSUE-864 Booking links: reference the originating booking link in generated event ICS through the `X-OPENPAAS-BOOKING-LINK` property
+ - ISSUE-867 Booking links: index the originating booking link and expose a `bookingLink` event search criterion on it
 
 ## [2.1.0] - 2026-05-07
 

--- a/app/src/main/java/com/linagora/calendar/app/modules/CalendarDataProbe.java
+++ b/app/src/main/java/com/linagora/calendar/app/modules/CalendarDataProbe.java
@@ -185,7 +185,7 @@ public class CalendarDataProbe implements GuiceProbe {
 
     private EventSearchQuery simpleQuery(String query, CalendarURL calendarURL) {
         return new EventSearchQuery(query, Optional.of(List.of(calendarURL)),
-            Optional.empty(), Optional.empty(),
+            Optional.empty(), Optional.empty(), Optional.empty(),
             MAX_LIMIT, 0);
     }
 }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/CalendarSearchRouteContract.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/CalendarSearchRouteContract.java
@@ -656,6 +656,62 @@ public interface CalendarSearchRouteContract {
             .body("_embedded.events[0].data.x-openpaas-videoconference", equalTo(videoconferenceUrl));
     }
 
+    @Test
+    default void shouldFilterByBookingLinkWhenProvided(TwakeCalendarGuiceServer server) {
+        CalendarURL calendarURL = defaultCalendarURL(server);
+        String userId = calendarURL.base().value();
+        String calendarId = calendarURL.calendarId().value();
+        String bookingLink = "a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d";
+
+        EventFields bookedEvent = EventFields.builder()
+            .uid("booked-event")
+            .summary("Booked slot")
+            .start(Instant.parse("2025-04-19T11:00:00Z"))
+            .end(Instant.parse("2025-04-19T11:30:00Z"))
+            .clazz("PUBLIC")
+            .allDay(false)
+            .isRecurrentMaster(false)
+            .bookingLinkId(bookingLink)
+            .calendarURL(calendarURL)
+            .dtStamp(Instant.parse("2025-04-18T07:47:48Z"))
+            .build();
+
+        EventFields otherEvent = EventFields.builder()
+            .uid("other-event")
+            .summary("Booked slot")
+            .start(Instant.parse("2025-04-20T11:00:00Z"))
+            .end(Instant.parse("2025-04-20T11:30:00Z"))
+            .clazz("PUBLIC")
+            .allDay(false)
+            .isRecurrentMaster(false)
+            .calendarURL(calendarURL)
+            .dtStamp(Instant.parse("2025-04-18T07:47:48Z"))
+            .build();
+
+        server.getProbe(CalendarDataProbe.class).indexCalendar(CalendarEvents.of(bookedEvent));
+        server.getProbe(CalendarDataProbe.class).indexCalendar(CalendarEvents.of(otherEvent));
+
+        String requestBody = """
+            {
+                "calendars": [
+                    { "userId": "%s", "calendarId": "%s" }
+                ],
+                "query": "Booked",
+                "bookingLink": "%s"
+            }
+            """.formatted(userId, calendarId, bookingLink);
+
+        given()
+            .body(requestBody)
+            .post("/calendar/api/events/search")
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("_total_hits", equalTo(1))
+            .body("_embedded.events[0].data.uid", equalTo("booked-event"))
+            .body("_embedded.events[0].data.x-openpaas-booking-link", equalTo(bookingLink));
+    }
+
     private CalendarURL defaultCalendarURL(TwakeCalendarGuiceServer server) {
         return CalendarURL.from(server.getProbe(CalendarDataProbe.class).userId(USERNAME));
     }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventFieldConverter.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventFieldConverter.java
@@ -128,6 +128,7 @@ public class EventFieldConverter {
                 case EventProperty.RRULE_PROPERTY -> builder.isRecurrentMaster(true);
                 case EventProperty.SEQUENCE_PROPERTY -> builder.sequence(((SequenceProperty) property).getSequence());
                 case EventProperty.VIDEOCONFERENCE -> builder.videoconferenceUrl(property.value);
+                case EventProperty.BOOKING_LINK -> builder.bookingLinkId(property.value);
                 default -> {
                 }
             }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventProperty.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventProperty.java
@@ -67,6 +67,7 @@ public class EventProperty {
     public static final String RRULE_PROPERTY = "rrule";
     public static final String DURATION_PROPERTY = "duration";
     public static final String VIDEOCONFERENCE = "x-openpaas-videoconference";
+    public static final String BOOKING_LINK = "x-openpaas-booking-link";
 
     protected final String name;
     protected final JsonNode attributes;

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventFieldConverterTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventFieldConverterTest.java
@@ -236,6 +236,44 @@ public class EventFieldConverterTest {
     }
 
     @Test
+    void fromCreatedMessageShouldExtractBookingLink() {
+        String json = """
+            {
+                 "eventPath": "\\/calendars\\/6801fcef72cc50005a04e5fb\\/6801fcef72cc50005a04e5fb\\/booking-event.ics",
+                 "event": [
+                     "vcalendar",
+                     [
+                         [ "version", {}, "text", "2.0" ],
+                         [ "prodid", {}, "text", "-\\/\\/Twake Calendar\\/\\/Public Booking\\/\\/EN" ]
+                     ],
+                     [
+                         [
+                             "vevent",
+                             [
+                                 [ "uid", {}, "text", "booking-event" ],
+                                 [ "dtstart", {}, "date-time", "2025-04-19T11:00:00Z" ],
+                                 [ "dtstamp", {}, "date-time", "2025-04-18T07:47:48Z" ],
+                                 [ "summary", {}, "text", "Booked slot" ],
+                                 [ "x-openpaas-booking-link", {}, "text", "a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d" ]
+                             ],
+                             []
+                         ]
+                     ]
+                 ],
+                 "import": true,
+                 "etag": "\\"f066260d3a4fca51ae0de0618e9555cc\\""
+             }""";
+
+        CalendarEventMessage createdMessage = CalendarEventMessage.CreatedOrUpdated.deserialize(json.getBytes(StandardCharsets.UTF_8));
+
+        Set<EventFields> eventProperties = EventFieldConverter.from(createdMessage).events();
+
+        assertThat(eventProperties).hasSize(1);
+        assertThat(eventProperties.iterator().next().bookingLinkId())
+            .isEqualTo("a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d");
+    }
+
+    @Test
     void fromCreatedMessageWithRecurrenceEventShouldSucceed() {
         String json = """
             {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
@@ -1078,7 +1078,7 @@ public class EventIndexerConsumerTest {
 
     private EventSearchQuery simpleQuery(String query, CalendarURL calendarURL) {
         return new EventSearchQuery(query, Optional.of(List.of(calendarURL)),
-            Optional.empty(), Optional.empty(),
+            Optional.empty(), Optional.empty(), Optional.empty(),
             EventSearchQuery.MAX_LIMIT, 0);
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CalendarSearchRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CalendarSearchRoute.java
@@ -43,6 +43,7 @@ import com.linagora.calendar.dav.CalendarSearchSourceResolver;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 import com.linagora.calendar.storage.event.EventFields;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchService;
 import com.linagora.calendar.storage.eventsearch.EventSearchQuery;
@@ -56,16 +57,18 @@ import reactor.netty.http.server.HttpServerResponse;
 public class CalendarSearchRoute extends CalendarRoute {
 
     public record SearchRequest(List<CalendarRef> calendars, String query, List<String> organizers,
-                                List<String> attendees) {
+                                List<String> attendees, String bookingLink) {
         @JsonCreator
         public SearchRequest(@JsonProperty("calendars") List<CalendarRef> calendars,
                              @JsonProperty("query") String query,
                              @JsonProperty("organizers") List<String> organizers,
-                             @JsonProperty("attendees") List<String> attendees) {
+                             @JsonProperty("attendees") List<String> attendees,
+                             @JsonProperty("bookingLink") String bookingLink) {
             this.calendars = calendars;
             this.query = query;
             this.organizers = organizers;
             this.attendees = attendees;
+            this.bookingLink = bookingLink;
         }
 
         public record CalendarRef(String userId, String calendarId) {
@@ -136,12 +139,13 @@ public class CalendarSearchRoute extends CalendarRoute {
                                Integer durationInDays, Boolean isRecurrentMaster, List<Attendee> attendees,
                                EventResource.Data.Organizer organizer, List<Resource> resources,
                                @JsonProperty("x-openpaas-videoconference") Optional<String> videoconferenceUrl,
+                               @JsonProperty("x-openpaas-booking-link") Optional<String> bookingLinkId,
                                String userId, String calendarId, String dtstamp) {
                 public Data(String uid, Optional<String> summary, Optional<String> location, Optional<String> description,
                             Optional<String> start, Optional<String> end, String clazz,
                             Boolean allDay, Boolean hasResources, Integer durationInDays, Boolean isRecurrentMaster,
                             List<Attendee> attendees, Organizer organizer, List<Resource> resources,
-                            Optional<String> videoconferenceUrl, String userId, String calendarId, String dtstamp) {
+                            Optional<String> videoconferenceUrl, Optional<String> bookingLinkId, String userId, String calendarId, String dtstamp) {
                     this.uid = uid;
                     this.summary = summary;
                     this.location = location;
@@ -157,6 +161,7 @@ public class CalendarSearchRoute extends CalendarRoute {
                     this.organizer = organizer;
                     this.resources = resources;
                     this.videoconferenceUrl = videoconferenceUrl;
+                    this.bookingLinkId = bookingLinkId;
                     this.userId = userId;
                     this.calendarId = calendarId;
                     this.dtstamp = dtstamp;
@@ -194,6 +199,7 @@ public class CalendarSearchRoute extends CalendarRoute {
                         organizer,
                         resources,
                         Optional.ofNullable(event.videoconferenceUrl()),
+                        Optional.ofNullable(event.bookingLinkId()),
                         userId,
                         calendarId,
                         ISO_INSTANT.format(event.dtStamp()));
@@ -284,6 +290,7 @@ public class CalendarSearchRoute extends CalendarRoute {
             .offset(offset);
         extractOrganizers(searchRequest).ifPresent(queryBuilder::organizers);
         extractAttendees(searchRequest).ifPresent(queryBuilder::attendees);
+        extractBookingLink(searchRequest).ifPresent(queryBuilder::bookingLink);
         return queryBuilder.build();
     }
 
@@ -337,6 +344,18 @@ public class CalendarSearchRoute extends CalendarRoute {
                 })
                 .collect(Collectors.toList()))
             .orElse(List.of());
+    }
+
+    private Optional<BookingLinkPublicId> extractBookingLink(SearchRequest searchRequest) {
+        return Optional.ofNullable(searchRequest.bookingLink)
+            .filter(bookingLink -> !bookingLink.isBlank())
+            .map(bookingLink -> {
+                try {
+                    return BookingLinkPublicId.from(bookingLink);
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException("Invalid bookingLink: " + bookingLink, e);
+                }
+            });
     }
 
     private Optional<List<MailAddress>> extractOrganizers(SearchRequest searchRequest) {

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
@@ -702,7 +702,7 @@ public class CalendarRoutesTest {
 
     private EventSearchQuery simpleQuery(String query, CalendarURL calendarURL) {
         return new EventSearchQuery(query, Optional.of(List.of(calendarURL)),
-            Optional.empty(), Optional.empty(),
+            Optional.empty(), Optional.empty(), Optional.empty(),
             MAX_LIMIT, 0);
     }
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/EventFields.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/EventFields.java
@@ -55,6 +55,7 @@ public record EventFields(EventUid uid,
                           List<Person> attendees,
                           List<Person> resources,
                           String videoconferenceUrl,
+                          String bookingLinkId,
                           Optional<Integer> sequence,
                           Optional<String> recurrenceId,
                           Optional<String> resourceName,
@@ -101,6 +102,7 @@ public record EventFields(EventUid uid,
         private List<EventFields.Person> attendees = new ArrayList<>();
         private List<EventFields.Person> resources = new ArrayList<>();
         private String videoconferenceUrl;
+        private String bookingLinkId;
         private CalendarURL calendarURL;
         private Optional<Integer> sequence = Optional.empty();
         private Optional<String> recurrenceId = Optional.empty();
@@ -190,6 +192,11 @@ public record EventFields(EventUid uid,
             return this;
         }
 
+        public Builder bookingLinkId(String bookingLinkId) {
+            this.bookingLinkId = bookingLinkId;
+            return this;
+        }
+
         public Builder calendarURL(CalendarURL calendarURL) {
             this.calendarURL = calendarURL;
             return this;
@@ -239,6 +246,7 @@ public record EventFields(EventUid uid,
                 attendees,
                 resources,
                 videoconferenceUrl,
+                bookingLinkId,
                 sequence,
                 recurrenceId,
                 resourceName,
@@ -264,6 +272,7 @@ public record EventFields(EventUid uid,
         vEvent.getProperty(Property.DTSTAMP).flatMap(EventParseUtils::parseTimeAsInstant).ifPresent(builder::dtStamp);
         EventParseUtils.isRecurrentMaster(vEvent).ifPresent(builder::isRecurrentMaster);
         EventParseUtils.getPropertyValueIgnoreCase(vEvent, "X-OPENPAAS-VIDEOCONFERENCE").ifPresent(builder::videoconferenceUrl);
+        EventParseUtils.getPropertyValueIgnoreCase(vEvent, "X-OPENPAAS-BOOKING-LINK").ifPresent(builder::bookingLinkId);
         EventParseUtils.getOrganizer(vEvent).ifPresent(builder::organizer);
         builder.attendees(EventParseUtils.getAttendees(vEvent));
         builder.resources(EventParseUtils.getResources(vEvent));

--- a/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/EventSearchQuery.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/EventSearchQuery.java
@@ -26,11 +26,13 @@ import org.apache.james.core.MailAddress;
 
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 
 public record EventSearchQuery(String query,
                                Optional<List<CalendarURL>> calendars,
                                Optional<List<MailAddress>> organizers,
                                Optional<List<MailAddress>> attendees,
+                               Optional<BookingLinkPublicId> bookingLink,
                                int limit,
                                int offset) {
 
@@ -47,6 +49,7 @@ public record EventSearchQuery(String query,
         Preconditions.checkNotNull(calendars, "calendars must not be null");
         Preconditions.checkNotNull(organizers, "organizers must not be null");
         Preconditions.checkNotNull(attendees, "attendees must not be null");
+        Preconditions.checkNotNull(bookingLink, "bookingLink must not be null");
         Preconditions.checkArgument(limit > 0, "limit must be positive");
         Preconditions.checkArgument(offset >= 0, "offset must be non-negative");
         Preconditions.checkArgument(limit <= MAX_LIMIT, "limit must be less than or equal to " + MAX_LIMIT);
@@ -57,6 +60,7 @@ public record EventSearchQuery(String query,
         private Optional<List<CalendarURL>> calendars = Optional.empty();
         private Optional<List<MailAddress>> organizers = Optional.empty();
         private Optional<List<MailAddress>> attendees = Optional.empty();
+        private Optional<BookingLinkPublicId> bookingLink = Optional.empty();
         private int limit = DEFAULT_LIMIT;
         private int offset = OFFSET_INITIAL;
 
@@ -95,6 +99,11 @@ public record EventSearchQuery(String query,
             return this;
         }
 
+        public Builder bookingLink(BookingLinkPublicId bookingLink) {
+            this.bookingLink = Optional.of(bookingLink);
+            return this;
+        }
+
         public Builder limit(int limit) {
             this.limit = limit;
             return this;
@@ -106,7 +115,7 @@ public record EventSearchQuery(String query,
         }
 
         public EventSearchQuery build() {
-            return new EventSearchQuery(query, calendars, organizers, attendees, limit, offset);
+            return new EventSearchQuery(query, calendars, organizers, attendees, bookingLink, limit, offset);
         }
     }
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
@@ -119,7 +119,8 @@ public class MemoryCalendarSearchService implements CalendarSearchService {
     private boolean matchesOptionalFields(EventFields event, EventSearchQuery query) {
         return query.calendars().map(calendarRefList -> matchesCalendarRef(event, calendarRefList)).orElse(true) &&
             query.organizers().map(organizers -> matchesOrganizers(event, organizers)).orElse(true) &&
-            query.attendees().map(attendees -> matchesAttendees(event, attendees)).orElse(true);
+            query.attendees().map(attendees -> matchesAttendees(event, attendees)).orElse(true) &&
+            query.bookingLink().map(bookingLink -> Strings.CS.equals(bookingLink.value().toString(), event.bookingLinkId())).orElse(true);
     }
 
     private boolean matchesQueryKeyword(EventFields event, String keyword) {

--- a/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 import com.linagora.calendar.storage.event.EventFields;
 import com.linagora.calendar.storage.event.EventFields.Person;
 
@@ -939,6 +940,50 @@ public interface CalendarSearchServiceContract {
 
         assertThat(searchResults).containsExactly(event1.uid())
             .doesNotContain(event2.uid());
+    }
+
+    @Test
+    default void searchShouldFilterByBookingLinkWhenProvided() {
+        BookingLinkPublicId bookingLink1 = BookingLinkPublicId.generate();
+        BookingLinkPublicId bookingLink2 = BookingLinkPublicId.generate();
+        CalendarURL calendarURL = generateCalendarURL();
+
+        EventFields event1 = EventFields.builder()
+            .uid(generateEventUid())
+            .summary("Booking Sync")
+            .bookingLinkId(bookingLink1.value().toString())
+            .calendarURL(calendarURL)
+            .build();
+
+        EventFields event2 = EventFields.builder()
+            .uid(generateEventUid())
+            .summary("Booking Marketing")
+            .bookingLinkId(bookingLink2.value().toString())
+            .calendarURL(calendarURL)
+            .build();
+
+        EventFields event3 = EventFields.builder()
+            .uid(generateEventUid())
+            .summary("Booking Standalone")
+            .calendarURL(calendarURL)
+            .build();
+
+        indexEvents(event1);
+        indexEvents(event2);
+        indexEvents(event3);
+
+        EventSearchQuery query = EventSearchQuery.builder()
+            .query("Booking")
+            .calendars(calendarURL)
+            .bookingLink(bookingLink1)
+            .build();
+
+        List<EventUid> searchResults = testee().search(query)
+            .map(EventFields::uid)
+            .collectList().block();
+
+        assertThat(searchResults).containsExactly(event1.uid())
+            .doesNotContain(event2.uid(), event3.uid());
     }
 
     @Test
@@ -1856,7 +1901,7 @@ public interface CalendarSearchServiceContract {
             .toList();
 
         return new EventSearchQuery(query, Optional.of(calendarURLs),
-            Optional.empty(), Optional.empty(),
+            Optional.empty(), Optional.empty(), Optional.empty(),
             MAX_LIMIT, 0);
     }
 

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
@@ -77,6 +77,7 @@ public class CalendarEventIndexMappingFactory {
         String IS_RECURRENT_MASTER = "isRecurrentMaster";
         String CLAZZ = "clazz";
         String VIDEOCONFERENCE_URL = "videoconferenceUrl";
+        String BOOKING_LINK_ID = "bookingLinkId";
         String SEQUENCE = "sequence";
         String RESOURCE_NAME = "resourceName";
     }
@@ -190,6 +191,7 @@ public class CalendarEventIndexMappingFactory {
                 .put(CalendarFields.BASE_CALENDAR_ID, indexedKeywordProperty)
                 .put(CalendarFields.EVENT_UID, indexedKeywordProperty)
                 .put(CalendarFields.CALENDAR_URL, indexedKeywordProperty)
+                .put(CalendarFields.BOOKING_LINK_ID, indexedKeywordProperty)
                 .put(CalendarFields.SUMMARY, summaryProperty(configuration.searchSummaryPrefix()))
                 .put(CalendarFields.LOCATION,  new Property(new TextProperty.Builder().analyzer(CalendarAnalyzers.LOCATION_ANALYZER).build()))
                 .put(CalendarFields.DESCRIPTION,  new Property(new TextProperty.Builder().analyzer(CalendarAnalyzers.STANDARD).build()))

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
@@ -44,6 +44,7 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.BASE_CALENDAR_
                                      @JsonProperty(CalendarFields.ATTENDEES) List<SimplePerson> attendees,
                                      @JsonProperty(CalendarFields.RESOURCES) List<SimplePerson> resources,
                                      @JsonProperty(CalendarFields.VIDEOCONFERENCE_URL) String videoconferenceUrl,
+                                     @JsonProperty(CalendarFields.BOOKING_LINK_ID) String bookingLinkId,
                                      @JsonProperty(CalendarFields.CALENDAR_URL) String calendarURL,
                                      @JsonProperty(CalendarFields.SEQUENCE) Integer sequence,
                                      @JsonProperty(CalendarFields.RESOURCE_NAME) String resourceName) {
@@ -93,6 +94,7 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.BASE_CALENDAR_
                 .map(SimplePerson::from)
                 .toList(),
             eventFields.videoconferenceUrl(),
+            eventFields.bookingLinkId(),
             eventFields.calendarURL().serialize(),
             eventFields.sequence().orElse(null),
             eventFields.resourceName().orElse(null));
@@ -118,6 +120,7 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.BASE_CALENDAR_
                 .map(SimplePerson::toEventPerson)
                 .toList())
             .videoconferenceUrl(videoconferenceUrl)
+            .bookingLinkId(bookingLinkId)
             .calendarURL(CalendarURL.deserialize(calendarURL));
 
         if (allDay != null) {

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
@@ -63,6 +63,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 import com.linagora.calendar.storage.event.EventFields;
 import com.linagora.calendar.storage.eventsearch.CalendarEvents;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchService;
@@ -205,6 +206,8 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
             mustClauses.add(buildAddressFilter(organizerList, CalendarFields.ORGANIZER)));
         query.attendees().ifPresent(attendeeList ->
             mustClauses.add(buildAddressFilter(attendeeList, CalendarFields.ATTENDEES)));
+        query.bookingLink().ifPresent(bookingLink ->
+            mustClauses.add(buildBookingLinkFilter(bookingLink)));
 
         Query openSearchQuery = QueryBuilders.bool()
             .must(mustClauses)
@@ -340,6 +343,14 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
                     .map(calendarURL -> FieldValue.of(calendarURL.serialize()))
                     .toList())
                 .build())
+            .build()
+            .toQuery();
+    }
+
+    private Query buildBookingLinkFilter(BookingLinkPublicId bookingLink) {
+        return QueryBuilders.term()
+            .field(CalendarFields.BOOKING_LINK_ID)
+            .value(FieldValue.of(bookingLink.value().toString()))
             .build()
             .toQuery();
     }

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -53,6 +53,32 @@ index only after confirming no calendar-side-service instance still uses the old
 DELETE /calendar-events
 ```
 
+### Added bookingLinkId field to Calendar Event index mapping
+
+Date: 29/06/2026
+
+We added the `bookingLinkId` field to the OpenSearch calendar event index. This field stores the public
+booking link identifier from the `X-OPENPAAS-BOOKING-LINK` ICS property and powers the `bookingLink`
+criterion of the event search API (`POST /calendar/api/events/search`).
+
+#### Required Actions
+
+**Add the field to your existing index mapping:**
+
+```bash
+PUT /calendar_events/_mapping
+{
+  "properties": {
+    "bookingLinkId": {
+      "type": "keyword",
+      "index": true
+    }
+  }
+}
+```
+
+**Note:** Replace `calendar_events` with your actual index name if different.
+
 ## 2.2.0
 
 ### Removed obsolete search queues


### PR DESCRIPTION
Closes #867

Part 2 of the booking links traceability work (see #864), building on the ICS property added in #865.

## What

Index the originating booking link carried by events created through a public booking link (the `X-OPENPAAS-BOOKING-LINK` property added in #865), and expose a `bookingLink` criterion on the OpenPaaS event search API so all events of a given booking link can be retrieved.

## Changes

- **Indexing**: parse the `X-OPENPAAS-BOOKING-LINK` property on both ingestion paths — the AMQP live-indexing path (`EventFieldConverter` / `EventProperty`) and the CalDAV reindex path (`EventFields.fromVEvent`). The value is carried through `EventFields`, `CalendarEventsDocument`, and mapped as an **indexed** keyword in `CalendarEventIndexMappingFactory` so it is searchable.
- **Search criterion**: add an optional `bookingLink` filter to `EventSearchQuery`, implemented as a term filter in `OpensearchCalendarSearchService` and mirrored in `MemoryCalendarSearchService`.
- **REST exposure (end-user search)**: accept a `bookingLink` field in the `CalendarSearchRoute` search request and expose `x-openpaas-booking-link` in the response data.

## Tests

- `EventFieldConverterTest`: the booking link property is extracted from the jCal message.
- `CalendarSearchServiceContract`: search filters by booking link (runs against both the memory and OpenSearch implementations).
- `CalendarSearchRouteContract`: the REST search filters by `bookingLink` and returns it in the response.

Pre-existing booking events created before this change carry no booking link property and will only be found after a reindex; per #864 this needs no documentation as booking links are not in use yet.

Note: the repository does not currently compile on `calendar-redis` (a `RedisKeyEventDispatcher` constructor mismatch from a snapshot dependency) — this is unrelated to this change and pre-exists on `main`. The touched modules and their dependencies build, and the Docker-free tests pass.
