### PR TITLE
fix: [Public agenda]  Define clear booking link ICS custom value types

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -306,7 +306,7 @@ class BookingLinkReservationRouteTest {
             softly.assertThat(getPropertyValue.apply(Property.DESCRIPTION))
                 .isEqualTo("Please call via Zoom.\nVisio: " + getPropertyValue.apply("X-OPENPAAS-VIDEOCONFERENCE"));
             softly.assertThat(getPropertyValue.apply("X-PUBLICLY-CREATED"))
-                .isEqualTo("true");
+                .isEqualTo("TRUE");
             softly.assertThat(getPropertyValue.apply("X-PUBLICLY-CREATOR"))
                 .isEqualTo("creator@example.com");
             softly.assertThat(getPropertyValue.apply("X-OPENPAAS-BOOKING-LINK"))

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilder.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilder.java
@@ -46,6 +46,7 @@ import net.fortuna.ical4j.model.parameter.CuType;
 import net.fortuna.ical4j.model.parameter.PartStat;
 import net.fortuna.ical4j.model.parameter.Role;
 import net.fortuna.ical4j.model.parameter.Rsvp;
+import net.fortuna.ical4j.model.parameter.Value;
 import net.fortuna.ical4j.model.property.Attendee;
 import net.fortuna.ical4j.model.property.Clazz;
 import net.fortuna.ical4j.model.property.Description;
@@ -68,7 +69,7 @@ public class BookingLinkEventIcsBuilder {
     private static final String X_OPENPAAS_VIDEOCONFERENCE = "X-OPENPAAS-VIDEOCONFERENCE";
     private static final String VISIO_DESCRIPTION_PREFIX = "Visio: ";
     private static final Transp TRANSP_OPAQUE = new Transp(Transp.VALUE_OPAQUE);
-    private static final XProperty X_PROPERTY_PUBLIC = new XProperty("X-PUBLICLY-CREATED", "true");
+    private static final XProperty X_PROPERTY_PUBLIC = new XProperty("X-PUBLICLY-CREATED", "TRUE").add(Value.BOOLEAN);
     private static final String MAIL_TO_PREFIX = "mailto:";
 
     private final Clock clock;
@@ -129,7 +130,8 @@ public class BookingLinkEventIcsBuilder {
             .add(X_PROPERTY_PUBLIC)
             .add(new XProperty(X_PUBLICLY_CREATOR, request.creator().email().asString()))
             .add(new XProperty(X_OPENPAAS_BOOKING_LINK, bookingLinkPublicId.value().toString()));
-        maybeMeetingLink.ifPresent(visioLink -> properties.add(new XProperty(X_OPENPAAS_VIDEOCONFERENCE, visioLink.toString())));
+        maybeMeetingLink.ifPresent(visioLink -> properties.add(
+            new XProperty(X_OPENPAAS_VIDEOCONFERENCE, visioLink.toString()).add(Value.URI)));
 
         VEvent event = new VEvent(new PropertyList(properties.build()));
         ValidationResult validationResult = event.validate();

--- a/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilderTest.java
+++ b/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilderTest.java
@@ -82,10 +82,10 @@ public class BookingLinkEventIcsBuilderTest {
             ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;PARTSTAT=ACCEPTED;CN=Nguyen Van A:mailto:vana@example.com
             DESCRIPTION:Please call via Zoom.\\nVisio: https://jitsi.example.com
             CLASS:PUBLIC
-            X-PUBLICLY-CREATED:true
+            X-PUBLICLY-CREATED;VALUE=BOOLEAN:TRUE
             X-PUBLICLY-CREATOR:creator@example.com
             X-OPENPAAS-BOOKING-LINK:a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d
-            X-OPENPAAS-VIDEOCONFERENCE:https://jitsi.example.com
+            X-OPENPAAS-VIDEOCONFERENCE;VALUE=URI:https://jitsi.example.com
             END:VEVENT
             END:VCALENDAR
             """;
@@ -128,7 +128,7 @@ public class BookingLinkEventIcsBuilderTest {
             ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;PARTSTAT=ACCEPTED;CN=BOB:mailto:creator@example.com
             ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;PARTSTAT=ACCEPTED;CN=Nguyen Van A:mailto:vana@example.com
             CLASS:PUBLIC
-            X-PUBLICLY-CREATED:true
+            X-PUBLICLY-CREATED;VALUE=BOOLEAN:TRUE
             X-PUBLICLY-CREATOR:creator@example.com
             X-OPENPAAS-BOOKING-LINK:a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d
             END:VEVENT
@@ -158,7 +158,7 @@ public class BookingLinkEventIcsBuilderTest {
         assertThat(ics)
             .contains("DESCRIPTION:Visio: https://jitsi.example.com");
         assertThat(ics)
-            .contains("X-OPENPAAS-VIDEOCONFERENCE:https://jitsi.example.com");
+            .contains("X-OPENPAAS-VIDEOCONFERENCE;VALUE=URI:https://jitsi.example.com");
     }
 
     @Test
@@ -192,7 +192,7 @@ public class BookingLinkEventIcsBuilderTest {
             ATTENDEE;RSVP=TRUE;ROLE=CHAIR;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION:mailto:owner@example.com
             ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;PARTSTAT=ACCEPTED:mailto:creator@example.com
             CLASS:PUBLIC
-            X-PUBLICLY-CREATED:true
+            X-PUBLICLY-CREATED;VALUE=BOOLEAN:TRUE
             X-PUBLICLY-CREATOR:creator@example.com
             X-OPENPAAS-BOOKING-LINK:a1b2c3d4-e5f6-4a5b-8c7d-0e1f2a3b4c5d
             END:VEVENT


### PR DESCRIPTION
Strengthen custom booking link ICS property value declarations to align better with RFC expectations.

## Why
This makes custom `X-*` property typing stronger and more explicit according to RFC-style iCalendar value declarations. For example, boolean values should be represented with uppercase `TRUE`/`FALSE` and declared as `VALUE=BOOLEAN`.

No breaking change