### PR TITLE
Booking links: public slots route exposes owner infos (#877)

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -162,6 +162,10 @@ class BookingLinkSlotsRouteTest {
             .isEqualTo("""
                 {
                   "durationMinutes": 30,
+                  "owner": {
+                    "displayName": "%s",
+                    "email": "%s"
+                  },
                   "range": {
                     "from": "2036-01-26T00:00:00Z",
                     "to": "2036-01-27T00:00:00Z"
@@ -175,7 +179,36 @@ class BookingLinkSlotsRouteTest {
                     { "start": "2036-01-26T11:30:00Z" }
                   ]
                 }
-                """);
+                """.formatted(openPaaSUser.fullName(), openPaaSUser.username().asString()));
+    }
+
+    @Test
+    void shouldExposeOwnerDisplayNameAndMailAddress(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should expose the booking link owner display name and mail address")
+            .inPath("$.owner")
+            .isEqualTo("""
+                {
+                  "displayName": "%s",
+                  "email": "%s"
+                }
+                """.formatted(openPaaSUser.fullName(), openPaaSUser.username().asString()));
     }
 
     @Test

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -162,6 +162,7 @@ class BookingLinkSlotsRouteTest {
             .isEqualTo("""
                 {
                   "durationMinutes": 30,
+                  "autoAccept": false,
                   "owner": {
                     "displayName": "%s",
                     "email": "%s"
@@ -207,6 +208,53 @@ class BookingLinkSlotsRouteTest {
                 {
                   "displayName": "%s",
                   "email": "%s"
+                }
+                """.formatted(openPaaSUser.fullName(), openPaaSUser.username().asString()));
+    }
+
+    @Test
+    void shouldExposeNameDescriptionAndAutoAccept(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, true, true,
+            Optional.of(AVAILABILITY_RULE), Optional.of("Interview"), Optional.of("A 30 minutes interview"));
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should expose the booking link name, description and autoAccept")
+            .isEqualTo("""
+                {
+                  "durationMinutes": 30,
+                  "autoAccept": true,
+                  "name": "Interview",
+                  "description": "A 30 minutes interview",
+                  "owner": {
+                    "displayName": "%s",
+                    "email": "%s"
+                  },
+                  "range": {
+                    "from": "2036-01-26T00:00:00Z",
+                    "to": "2036-01-27T00:00:00Z"
+                  },
+                  "slots": [
+                    { "start": "2036-01-26T09:00:00Z" },
+                    { "start": "2036-01-26T09:30:00Z" },
+                    { "start": "2036-01-26T10:00:00Z" },
+                    { "start": "2036-01-26T10:30:00Z" },
+                    { "start": "2036-01-26T11:00:00Z" },
+                    { "start": "2036-01-26T11:30:00Z" }
+                  ]
                 }
                 """.formatted(openPaaSUser.fullName(), openPaaSUser.username().asString()));
     }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -24,6 +24,7 @@ import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 import static io.restassured.http.ContentType.JSON;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -181,6 +182,11 @@ class BookingLinkSlotsRouteTest {
                   ]
                 }
                 """.formatted(openPaaSUser.fullName(), openPaaSUser.username().asString()));
+
+        assertThat(response)
+            .describedAs("should omit optional booking link name and description when unset")
+            .doesNotContain("\"name\"")
+            .doesNotContain("\"description\"");
     }
 
     @Test

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -784,6 +784,37 @@ class BookingLinkSlotsRouteTest {
     }
 
     @Test
+    void shouldReturnNotFoundWhenBookingLinkOwnerDoesNotExist(TwakeCalendarGuiceServer server) {
+        Username missingOwner = Username.of("missing-owner@domain.tld");
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(missingOwner, insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return not found when the booking link owner no longer exists")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 404,
+                        "message": "Not Found",
+                        "details": "Cannot find booking link with publicId %s"
+                    }
+                }""".formatted(inserted.publicId().value()));
+    }
+
+    @Test
     void shouldReturnNotFoundWhenBookingLinkIsInactive(TwakeCalendarGuiceServer server) {
         boolean inactive = false;
         BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, inactive, Optional.of(AVAILABILITY_RULE));

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
@@ -23,7 +23,6 @@ import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
@@ -35,9 +34,7 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
 import com.linagora.calendar.restapi.routes.response.BookingLinkSlotsResponse;
-import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 
@@ -88,7 +85,7 @@ public class BookingLinkSlotsRoute implements JMAPRoutes {
                 BookingLinkPublicId bookingLinkPublicId = BookingLinkPublicId.from(request.param(BOOKING_LINK_PUBLIC_ID_PARAM));
 
                 return bookingLinkSlotsService.computeSlots(bookingLinkPublicId, queryStart, queryEnd)
-                    .flatMap(result -> doResponse(response, queryStart, queryEnd, result.getLeft(), result.getRight()));
+                    .flatMap(result -> doResponse(response, queryStart, queryEnd, result));
             })
             .onErrorResume(Exception.class, exception -> switch (exception) {
                 case BookingLinkNotFoundException notFound -> {
@@ -131,9 +128,8 @@ public class BookingLinkSlotsRoute implements JMAPRoutes {
     private Mono<Void> doResponse(HttpServerResponse response,
                                   Instant queryStart,
                                   Instant queryEnd,
-                                  BookingLink bookingLink,
-                                  Set<AvailabilitySlot> slots) {
-        return Mono.fromCallable(() -> BookingLinkSlotsResponse.of(bookingLink, queryStart, queryEnd, slots).jsonAsBytes())
+                                  BookingLinkSlotsService.SlotsResult result) {
+        return Mono.fromCallable(() -> BookingLinkSlotsResponse.of(result.bookingLink(), result.owner(), queryStart, queryEnd, result.slots()).jsonAsBytes())
             .flatMap(bytes -> response.status(HttpResponseStatus.OK)
                 .headers(JSON_HEADER)
                 .sendByteArray(Mono.just(bytes))

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
@@ -62,7 +62,7 @@ public class BookingLinkSlotsService {
     public Mono<SlotsResult> computeSlots(BookingLinkPublicId publicId, Instant from, Instant to) {
         return findActiveBookingLink(publicId)
             .flatMap(bookingLink -> Mono.zip(
-                    openPaaSUserDAO.retrieve(bookingLink.username()),
+                    retrieveOwner(bookingLink),
                     computeSlots(bookingLink, from, to))
                 .map(tuple -> new SlotsResult(bookingLink, tuple.getT1(), tuple.getT2())));
     }
@@ -95,6 +95,12 @@ public class BookingLinkSlotsService {
     private Mono<BookingLink> findActiveBookingLink(BookingLinkPublicId publicId) {
         return bookingLinkDAO.findActiveByPublicId(publicId)
             .switchIfEmpty(Mono.error(() -> new BookingLinkNotFoundException(publicId)));
+    }
+
+    private Mono<OpenPaaSUser> retrieveOwner(BookingLink bookingLink) {
+        return openPaaSUserDAO.retrieve(bookingLink.username())
+            // Public booking links whose owner disappeared should behave as unavailable.
+            .switchIfEmpty(Mono.error(() -> new BookingLinkNotFoundException(bookingLink.publicId())));
     }
 
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
@@ -25,8 +25,6 @@ import java.util.Set;
 
 import jakarta.inject.Inject;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator;
@@ -35,6 +33,8 @@ import com.linagora.calendar.api.booking.AvailableSlotsCalculator.ComputeSlotsRe
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.UnavailableTimeRanges;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.UnavailableTimeRanges.TimeRange;
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
@@ -43,21 +43,28 @@ import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 import reactor.core.publisher.Mono;
 
 public class BookingLinkSlotsService {
+    public record SlotsResult(BookingLink bookingLink, OpenPaaSUser owner, Set<AvailabilitySlot> slots) {
+    }
+
     private final BookingLinkDAO bookingLinkDAO;
+    private final OpenPaaSUserDAO openPaaSUserDAO;
     private final CalDavClient calDavClient;
     private final AvailableSlotsCalculator availableSlotsCalculator;
 
     @Inject
-    public BookingLinkSlotsService(BookingLinkDAO bookingLinkDAO, CalDavClient calDavClient) {
+    public BookingLinkSlotsService(BookingLinkDAO bookingLinkDAO, OpenPaaSUserDAO openPaaSUserDAO, CalDavClient calDavClient) {
         this.bookingLinkDAO = bookingLinkDAO;
+        this.openPaaSUserDAO = openPaaSUserDAO;
         this.calDavClient = calDavClient;
         this.availableSlotsCalculator = new AvailableSlotsCalculator.Default();
     }
 
-    public Mono<Pair<BookingLink, Set<AvailabilitySlot>>> computeSlots(BookingLinkPublicId publicId, Instant from, Instant to) {
+    public Mono<SlotsResult> computeSlots(BookingLinkPublicId publicId, Instant from, Instant to) {
         return findActiveBookingLink(publicId)
-            .flatMap(bookingLink -> computeSlots(bookingLink, from, to)
-                .map(set -> Pair.of(bookingLink, set)));
+            .flatMap(bookingLink -> Mono.zip(
+                    openPaaSUserDAO.retrieve(bookingLink.username()),
+                    computeSlots(bookingLink, from, to))
+                .map(tuple -> new SlotsResult(bookingLink, tuple.getT1(), tuple.getT2())));
     }
 
     Mono<Set<AvailabilitySlot>> computeSlots(BookingLink bookingLink, Instant from, Instant to) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
@@ -20,9 +20,11 @@ package com.linagora.calendar.restapi.routes.response;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,7 +34,11 @@ import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySl
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
 public record BookingLinkSlotsResponse(long durationMinutes,
+                                       boolean autoAccept,
+                                       Optional<String> name,
+                                       Optional<String> description,
                                        OwnerDTO owner,
                                        RangeDTO range,
                                        List<SlotDTO> slots) {
@@ -42,6 +48,9 @@ public record BookingLinkSlotsResponse(long durationMinutes,
 
     public static BookingLinkSlotsResponse of(BookingLink bookingLink, OpenPaaSUser owner, Instant from, Instant to, Set<AvailabilitySlot> slots) {
         return new BookingLinkSlotsResponse(bookingLink.duration().toMinutes(),
+            bookingLink.autoAccept(),
+            bookingLink.name(),
+            bookingLink.description(),
             new OwnerDTO(owner.fullName(), owner.username().asString()),
             new RangeDTO(from, to),
             slots.stream()

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
 import com.linagora.calendar.storage.OpenPaaSUser;
@@ -44,6 +45,7 @@ public record BookingLinkSlotsResponse(long durationMinutes,
                                        List<SlotDTO> slots) {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
         .registerModule(new JavaTimeModule())
+        .registerModule(new Jdk8Module())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
     public static BookingLinkSlotsResponse of(BookingLink bookingLink, OpenPaaSUser owner, Instant from, Instant to, Set<AvailabilitySlot> slots) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
@@ -29,22 +29,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
+import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 
 public record BookingLinkSlotsResponse(long durationMinutes,
+                                       OwnerDTO owner,
                                        RangeDTO range,
                                        List<SlotDTO> slots) {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
         .registerModule(new JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-    public static BookingLinkSlotsResponse of(BookingLink bookingLink, Instant from, Instant to, Set<AvailabilitySlot> slots) {
-        return new BookingLinkSlotsResponse(bookingLink.duration().toMinutes(), new RangeDTO(from, to),
+    public static BookingLinkSlotsResponse of(BookingLink bookingLink, OpenPaaSUser owner, Instant from, Instant to, Set<AvailabilitySlot> slots) {
+        return new BookingLinkSlotsResponse(bookingLink.duration().toMinutes(),
+            new OwnerDTO(owner.fullName(), owner.username().asString()),
+            new RangeDTO(from, to),
             slots.stream()
                 .map(AvailabilitySlot::start)
                 .sorted()
                 .map(SlotDTO::new)
                 .toList());
+    }
+
+    public record OwnerDTO(@JsonProperty("displayName") String displayName,
+                           @JsonProperty("email") String email) {
     }
 
     public record RangeDTO(@JsonProperty("from")

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -350,6 +350,9 @@ Content-Type: application/json
 
 {
   "durationMinutes": 30,
+  "autoAccept": false,
+  "name": "Interview",
+  "description": "A 30 minutes interview",
   "owner": {
     "displayName": "John Doe",
     "email": "john.doe@open-paas.org"
@@ -367,6 +370,8 @@ Content-Type: application/json
 ```
 
 The `owner` object exposes the public booking link owner `displayName` and `email`.
+
+The response also exposes the booking link `autoAccept` flag, along with the optional `name` and `description` (omitted when not set), so the bookee can access that information too.
 
 **Error responses**
 

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -350,6 +350,10 @@ Content-Type: application/json
 
 {
   "durationMinutes": 30,
+  "owner": {
+    "displayName": "John Doe",
+    "email": "john.doe@open-paas.org"
+  },
   "range": {
     "from": "2036-01-26T00:00:00Z",
     "to": "2036-01-27T00:00:00Z"
@@ -361,6 +365,8 @@ Content-Type: application/json
   ]
 }
 ```
+
+The `owner` object exposes the public booking link owner `displayName` and `email`.
 
 **Error responses**
 


### PR DESCRIPTION
Closes #877

## What

The public booking-link slots route (`GET /api/booking-links/{bookingLinkPublicId}/slots`) now exposes the booking link owner's information, so a bookee landing on the public booking page can see who they are booking with.

The response gains an `owner` object:

```json
{
  "durationMinutes": 30,
  "owner": {
    "displayName": "John Doe",
    "email": "john.doe@open-paas.org"
  },
  "range": { "from": "...", "to": "..." },
  "slots": [ ... ]
}
```

- `displayName`: the owner's full name
- `email`: the owner's mail address

As requested in the issue, this is added to that endpoint only.

## How

- `BookingLinkSlotsService` now resolves the owner via `OpenPaaSUserDAO` from the booking link's username and returns a `SlotsResult(bookingLink, owner, slots)`.
- `BookingLinkSlotsResponse` serializes the new `owner` object.
- Docs (`docs/apis/bookingLink.md`) updated with the new field.

## Tests

- Updated the full-payload assertion and added a dedicated test asserting the owner display name and mail address.
- `BookingLinkSlotsRouteTest` (17 tests) passes.

---
*Generated automatically*
875
