### PR TITLE
Booking links: expose slots in a requested time zone (#879)

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -266,6 +266,115 @@ class BookingLinkSlotsRouteTest {
     }
 
     @Test
+    void shouldConvertSlotsToRequestedTimeZone(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+            .queryParam("timeZone", "Europe/Paris")
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should express range and slots in the requested time zone")
+            .isEqualTo("""
+                {
+                  "durationMinutes": 30,
+                  "autoAccept": false,
+                  "owner": {
+                    "displayName": "%s",
+                    "email": "%s"
+                  },
+                  "range": {
+                    "from": "2036-01-26T01:00:00+01:00",
+                    "to": "2036-01-27T01:00:00+01:00"
+                  },
+                  "slots": [
+                    { "start": "2036-01-26T10:00:00+01:00" },
+                    { "start": "2036-01-26T10:30:00+01:00" },
+                    { "start": "2036-01-26T11:00:00+01:00" },
+                    { "start": "2036-01-26T11:30:00+01:00" },
+                    { "start": "2036-01-26T12:00:00+01:00" },
+                    { "start": "2036-01-26T12:30:00+01:00" }
+                  ]
+                }
+                """.formatted(openPaaSUser.fullName(), openPaaSUser.username().asString()));
+    }
+
+    @Test
+    void shouldDefaultToUtcWhenTimeZoneIsAbsent(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should default to UTC when no time zone is provided")
+            .inPath("$.slots")
+            .isEqualTo("""
+                [
+                  { "start": "2036-01-26T09:00:00Z" },
+                  { "start": "2036-01-26T09:30:00Z" },
+                  { "start": "2036-01-26T10:00:00Z" },
+                  { "start": "2036-01-26T10:30:00Z" },
+                  { "start": "2036-01-26T11:00:00Z" },
+                  { "start": "2036-01-26T11:30:00Z" }
+                ]
+                """);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenTimeZoneIsInvalid(TwakeCalendarGuiceServer server) {
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+            .queryParam("timeZone", "Invalid/Zone")
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should return bad request when 'timeZone' is not a valid time zone")
+            .isEqualTo("""
+                {
+                    "error": {
+                        "code": 400,
+                        "message": "Bad Request",
+                        "details": "Invalid query parameter 'timeZone': Invalid/Zone"
+                    }
+                }""");
+    }
+
+    @Test
     void shouldReturnSlotsWithoutAuthentication(TwakeCalendarGuiceServer server) {
         BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
         BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -311,6 +311,50 @@ class BookingLinkSlotsRouteTest {
     }
 
     @Test
+    void shouldApplyDaylightSavingRulesForLegacyTimeZoneIdentifier(TwakeCalendarGuiceServer server) {
+        AvailabilityRules summerAvailabilityRule = AvailabilityRules.of(new FixedAvailabilityRule(
+            ZonedDateTime.parse("2036-07-01T09:00:00Z"),
+            ZonedDateTime.parse("2036-07-01T10:00:00Z")));
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, summerAvailabilityRule);
+        BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", "2036-07-01T00:00:00Z")
+            .queryParam("to", "2036-07-02T00:00:00Z")
+            .queryParam("timeZone", "Romance Standard Time")
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("should apply DST offsets when resolving legacy time zone identifiers")
+            .isEqualTo("""
+                {
+                  "durationMinutes": 30,
+                  "autoAccept": false,
+                  "owner": {
+                    "displayName": "%s",
+                    "email": "%s"
+                  },
+                  "range": {
+                    "from": "2036-07-01T02:00:00+02:00",
+                    "to": "2036-07-02T02:00:00+02:00"
+                  },
+                  "slots": [
+                    { "start": "2036-07-01T11:00:00+02:00" },
+                    { "start": "2036-07-01T11:30:00+02:00" }
+                  ]
+                }
+                """.formatted(openPaaSUser.fullName(), openPaaSUser.username().asString()));
+    }
+
+    @Test
     void shouldDefaultToUtcWhenTimeZoneIsAbsent(TwakeCalendarGuiceServer server) {
         BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, AVAILABILITY_RULE);
         BookingLink inserted = server.getProbe(BookingLinkSlotsProbe.class).insert(openPaaSUser.username(), insertRequest);

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsRoute.java
@@ -22,6 +22,8 @@ import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -34,6 +36,7 @@ import org.apache.james.metrics.api.MetricFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linagora.calendar.api.CalendarUtil;
 import com.linagora.calendar.restapi.routes.response.BookingLinkSlotsResponse;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
@@ -52,6 +55,9 @@ public class BookingLinkSlotsRoute implements JMAPRoutes {
     private static final String BOOKING_LINK_PUBLIC_ID_PARAM = "bookingLinkPublicId";
     private static final String FROM_QUERY_PARAM = "from";
     private static final String TO_QUERY_PARAM = "to";
+    private static final String TIME_ZONE_QUERY_PARAM = "timeZone";
+    private static final ZoneId DEFAULT_ZONE = ZoneOffset.UTC;
+    private static final CalendarUtil.CustomizedTimeZoneRegistry TIME_ZONE_REGISTRY = new CalendarUtil.CustomizedTimeZoneRegistry();
     private static final Duration MAX_QUERY_RANGE = Duration.ofDays(60);
 
     private final MetricFactory metricFactory;
@@ -81,11 +87,12 @@ public class BookingLinkSlotsRoute implements JMAPRoutes {
             .flatMap(queryStringDecoder -> {
                 Instant queryStart = parseRequiredInstant(queryStringDecoder, FROM_QUERY_PARAM);
                 Instant queryEnd = parseRequiredInstant(queryStringDecoder, TO_QUERY_PARAM);
+                ZoneId zoneId = parseTimeZone(queryStringDecoder);
                 validateRange(queryStart, queryEnd);
                 BookingLinkPublicId bookingLinkPublicId = BookingLinkPublicId.from(request.param(BOOKING_LINK_PUBLIC_ID_PARAM));
 
                 return bookingLinkSlotsService.computeSlots(bookingLinkPublicId, queryStart, queryEnd)
-                    .flatMap(result -> doResponse(response, queryStart, queryEnd, result));
+                    .flatMap(result -> doResponse(response, queryStart, queryEnd, zoneId, result));
             })
             .onErrorResume(Exception.class, exception -> switch (exception) {
                 case BookingLinkNotFoundException notFound -> {
@@ -112,6 +119,22 @@ public class BookingLinkSlotsRoute implements JMAPRoutes {
         }
     }
 
+    private ZoneId parseTimeZone(QueryStringDecoder queryStringDecoder) {
+        return queryStringDecoder.parameters().getOrDefault(TIME_ZONE_QUERY_PARAM, List.of())
+            .stream()
+            .findFirst()
+            .map(this::resolveZone)
+            .orElse(DEFAULT_ZONE);
+    }
+
+    private ZoneId resolveZone(String timeZone) {
+        try {
+            return TIME_ZONE_REGISTRY.getZoneId(timeZone);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("Invalid query parameter '%s': %s".formatted(TIME_ZONE_QUERY_PARAM, timeZone), e);
+        }
+    }
+
     private Instant parseRequiredInstant(QueryStringDecoder queryStringDecoder, String parameterName) {
         try {
             return queryStringDecoder.parameters().getOrDefault(parameterName, List.of())
@@ -128,8 +151,9 @@ public class BookingLinkSlotsRoute implements JMAPRoutes {
     private Mono<Void> doResponse(HttpServerResponse response,
                                   Instant queryStart,
                                   Instant queryEnd,
+                                  ZoneId zoneId,
                                   BookingLinkSlotsService.SlotsResult result) {
-        return Mono.fromCallable(() -> BookingLinkSlotsResponse.of(result.bookingLink(), result.owner(), queryStart, queryEnd, result.slots()).jsonAsBytes())
+        return Mono.fromCallable(() -> BookingLinkSlotsResponse.of(result.bookingLink(), result.owner(), queryStart, queryEnd, result.slots(), zoneId).jsonAsBytes())
             .flatMap(bytes -> response.status(HttpResponseStatus.OK)
                 .headers(JSON_HEADER)
                 .sendByteArray(Mono.just(bytes))

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/response/BookingLinkSlotsResponse.java
@@ -19,6 +19,8 @@
 package com.linagora.calendar.restapi.routes.response;
 
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -48,17 +50,17 @@ public record BookingLinkSlotsResponse(long durationMinutes,
         .registerModule(new Jdk8Module())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-    public static BookingLinkSlotsResponse of(BookingLink bookingLink, OpenPaaSUser owner, Instant from, Instant to, Set<AvailabilitySlot> slots) {
+    public static BookingLinkSlotsResponse of(BookingLink bookingLink, OpenPaaSUser owner, Instant from, Instant to, Set<AvailabilitySlot> slots, ZoneId zoneId) {
         return new BookingLinkSlotsResponse(bookingLink.duration().toMinutes(),
             bookingLink.autoAccept(),
             bookingLink.name(),
             bookingLink.description(),
             new OwnerDTO(owner.fullName(), owner.username().asString()),
-            new RangeDTO(from, to),
+            new RangeDTO(from.atZone(zoneId), to.atZone(zoneId)),
             slots.stream()
                 .map(AvailabilitySlot::start)
                 .sorted()
-                .map(SlotDTO::new)
+                .map(start -> new SlotDTO(start.atZone(zoneId)))
                 .toList());
     }
 
@@ -67,13 +69,13 @@ public record BookingLinkSlotsResponse(long durationMinutes,
     }
 
     public record RangeDTO(@JsonProperty("from")
-                           @JsonFormat(shape = JsonFormat.Shape.STRING) Instant from,
+                           @JsonFormat(shape = JsonFormat.Shape.STRING) ZonedDateTime from,
                            @JsonProperty("to")
-                           @JsonFormat(shape = JsonFormat.Shape.STRING) Instant to) {
+                           @JsonFormat(shape = JsonFormat.Shape.STRING) ZonedDateTime to) {
     }
 
     public record SlotDTO(@JsonProperty("start")
-                          @JsonFormat(shape = JsonFormat.Shape.STRING) Instant start) {
+                          @JsonFormat(shape = JsonFormat.Shape.STRING) ZonedDateTime start) {
     }
 
     public byte[] jsonAsBytes() throws JsonProcessingException {

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -331,7 +331,7 @@ Compute available slots for a public booking link in a query time range.
 |-----------|----------|-------------|
 | `from`    | yes      | Range start, ISO-8601 instant (example: `2036-01-26T00:00:00Z`) |
 | `to`      | yes      | Range end, ISO-8601 instant (must be strictly after `from`) |
-| `timeZone` | no      | IANA timezone (e.g. `Europe/Paris`, `UTC`) used to express `range` and `slots` in the response. Defaults to `UTC` when omitted. |
+| `timeZone` | no      | Timezone identifier (e.g. `Europe/Paris`, `UTC`, or an ical4j-supported legacy identifier) used to express `range` and `slots` in the response. Defaults to `UTC` when omitted. |
 
 Constraints:
 

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -331,6 +331,7 @@ Compute available slots for a public booking link in a query time range.
 |-----------|----------|-------------|
 | `from`    | yes      | Range start, ISO-8601 instant (example: `2036-01-26T00:00:00Z`) |
 | `to`      | yes      | Range end, ISO-8601 instant (must be strictly after `from`) |
+| `timeZone` | no      | IANA timezone (e.g. `Europe/Paris`, `UTC`) used to express `range` and `slots` in the response. Defaults to `UTC` when omitted. |
 
 Constraints:
 
@@ -339,7 +340,7 @@ Constraints:
 **Sample request**
 
 ```
-GET /api/booking-links/550e8400-e29b-41d4-a716-446655440000/slots?from=2036-01-26T00:00:00Z&to=2036-01-27T00:00:00Z
+GET /api/booking-links/550e8400-e29b-41d4-a716-446655440000/slots?from=2036-01-26T00:00:00Z&to=2036-01-27T00:00:00Z&timeZone=Europe/Paris
 ```
 
 **Sample response**
@@ -358,13 +359,13 @@ Content-Type: application/json
     "email": "john.doe@open-paas.org"
   },
   "range": {
-    "from": "2036-01-26T00:00:00Z",
-    "to": "2036-01-27T00:00:00Z"
+    "from": "2036-01-26T01:00:00+01:00",
+    "to": "2036-01-27T01:00:00+01:00"
   },
   "slots": [
-    { "start": "2036-01-26T09:00:00Z" },
-    { "start": "2036-01-26T09:30:00Z" },
-    { "start": "2036-01-26T10:00:00Z" }
+    { "start": "2036-01-26T10:00:00+01:00" },
+    { "start": "2036-01-26T10:30:00+01:00" },
+    { "start": "2036-01-26T11:00:00+01:00" }
   ]
 }
 ```
@@ -377,7 +378,7 @@ The response also exposes the booking link `autoAccept` flag, along with the opt
 
 | Status | Cause |
 |--------|-------|
-| 400    | Missing/invalid `from` or `to`, invalid UUID, `to <= from`, range > 60 days |
+| 400    | Missing/invalid `from` or `to`, invalid UUID, `to <= from`, range > 60 days, invalid `timeZone` |
 | 404    | Booking link not found or inactive |
 
 ---


### PR DESCRIPTION
Closes #879

## What

`GET /api/booking-links/{bookingLinkPublicId}/slots` now accepts an optional `timeZone` query parameter. The `range` and `slots` of the response are expressed in that time zone instead of always UTC.

## Why

The front shall not need any advanced time zone logic and should rely on the back for this.

## How

- The time zone string is resolved through the ical4j timezone registry (`CalendarUtil.CustomizedTimeZoneRegistry`), which also handles legacy / non-IANA identifiers.
- `range.from`, `range.to` and each slot `start` are serialized as `ZonedDateTime` at the requested zone (e.g. `2036-01-26T10:00:00+01:00`).
- The parameter is optional and defaults to `UTC`, so existing callers keep the exact previous behaviour (`...Z`).
- An invalid `timeZone` yields `400 Bad Request`.

## Tests

Added in `BookingLinkSlotsRouteTest`:
- conversion to `Europe/Paris`
- default to UTC when the parameter is absent
- `400` on an invalid time zone

All 19 tests in the class pass. Docs updated in `docs/apis/bookingLink.md`.

---
*Generated automatically*
