### PR TITLE
ISSUE-889 feat(webadmin): expose task running options

### DIFF
--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/AlarmScheduleTask.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/AlarmScheduleTask.java
@@ -29,7 +29,8 @@ import org.apache.james.task.TaskType;
 import com.linagora.calendar.webadmin.service.AlarmScheduleService;
 
 public class AlarmScheduleTask implements Task {
-    public record Details(Instant instant, long processedEventCount, long failedEventCount) implements TaskExecutionDetails.AdditionalInformation {
+    public record Details(Instant instant, long processedEventCount, long failedEventCount,
+                          int eventsPerSecond) implements TaskExecutionDetails.AdditionalInformation {
         @Override
         public Instant timestamp() {
             return instant;
@@ -62,6 +63,7 @@ public class AlarmScheduleTask implements Task {
     public Optional<TaskExecutionDetails.AdditionalInformation> details() {
         return Optional.of(new Details(Clock.systemUTC().instant(),
             context.snapshot().processedEventCount(),
-            context.snapshot().failedEventCount()));
+            context.snapshot().failedEventCount(),
+            runningOptions.eventsPerSecond()));
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/AlarmScheduleTaskAdditionalInformationDTO.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/AlarmScheduleTaskAdditionalInformationDTO.java
@@ -19,6 +19,7 @@
 package com.linagora.calendar.webadmin.task;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import org.apache.james.json.DTOModule;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
@@ -27,7 +28,14 @@ import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 public record AlarmScheduleTaskAdditionalInformationDTO(String type,
                                                         Instant timestamp,
                                                         long processedEventCount,
-                                                        long failedEventCount) implements AdditionalInformationDTO {
+                                                        long failedEventCount,
+                                                        Optional<RunningOptionsDTO> runningOptions) implements AdditionalInformationDTO {
+    public record RunningOptionsDTO(int eventsPerSecond) {
+        static RunningOptionsDTO fromDomainObject(AlarmScheduleTask.Details details) {
+            return new RunningOptionsDTO(details.eventsPerSecond());
+        }
+    }
+
     @Override
     public String getType() {
         return type;
@@ -52,13 +60,16 @@ public record AlarmScheduleTaskAdditionalInformationDTO(String type,
             type,
             details.instant(),
             details.processedEventCount(),
-            details.failedEventCount());
+            details.failedEventCount(),
+            Optional.of(RunningOptionsDTO.fromDomainObject(details)));
     }
 
     private AlarmScheduleTask.Details toDomainObject() {
         return new AlarmScheduleTask.Details(
             timestamp,
             processedEventCount,
-            failedEventCount);
+            failedEventCount,
+            runningOptions.map(RunningOptionsDTO::eventsPerSecond)
+                .orElse(RunningOptions.DEFAULT_EVENTS_PER_SECOND));
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarArchivalTask.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarArchivalTask.java
@@ -36,7 +36,8 @@ public class CalendarArchivalTask implements Task {
                           long archivedEventCount,
                           long failedEventCount,
                           Optional<Username> targetUser,
-                          EventArchivalCriteria criteria) implements TaskExecutionDetails.AdditionalInformation {
+                          EventArchivalCriteria criteria,
+                          int eventsPerSecond) implements TaskExecutionDetails.AdditionalInformation {
 
         @Override
         public Instant timestamp() {
@@ -81,6 +82,6 @@ public class CalendarArchivalTask implements Task {
     public Optional<TaskExecutionDetails.AdditionalInformation> details() {
         return Optional.of(new Details(Clock.systemUTC().instant(),
             context.snapshot().success(),
-            context.snapshot().failure(), targetUser, criteria));
+            context.snapshot().failure(), targetUser, criteria, runningOptions.eventsPerSecond()));
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarArchivalTaskAdditionalInformationDTO.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarArchivalTaskAdditionalInformationDTO.java
@@ -33,7 +33,14 @@ public record CalendarArchivalTaskAdditionalInformationDTO(String type,
                                                            long archivedEventCount,
                                                            long failedEventCount,
                                                            Optional<String> targetUser,
-                                                           CriteriaDetailDTO criteria) implements AdditionalInformationDTO {
+                                                           CriteriaDetailDTO criteria,
+                                                           Optional<RunningOptionsDTO> runningOptions) implements AdditionalInformationDTO {
+    public record RunningOptionsDTO(int eventsPerSecond) {
+        static RunningOptionsDTO fromDomainObject(CalendarArchivalTask.Details details) {
+            return new RunningOptionsDTO(details.eventsPerSecond());
+        }
+    }
+
 
     record CriteriaDetailDTO(Optional<Instant> createdBefore,
                              Optional<Instant> lastModifiedBefore,
@@ -77,11 +84,19 @@ public record CalendarArchivalTaskAdditionalInformationDTO(String type,
         return new CalendarArchivalTaskAdditionalInformationDTO(type, details.instant(),
             details.archivedEventCount(), details.failedEventCount(),
             details.targetUser().map(Username::asString),
-            CriteriaDetailDTO.fromDomainObject(details.criteria()));
+            CriteriaDetailDTO.fromDomainObject(details.criteria()),
+            Optional.of(RunningOptionsDTO.fromDomainObject(details)));
     }
 
     private CalendarArchivalTask.Details toDomainObject() {
-        return new CalendarArchivalTask.Details(timestamp, archivedEventCount, failedEventCount, targetUser.map(Username::of), criteria.toDomainObject());
+        return new CalendarArchivalTask.Details(
+            timestamp,
+            archivedEventCount,
+            failedEventCount,
+            targetUser.map(Username::of),
+            criteria.toDomainObject(),
+            runningOptions.map(RunningOptionsDTO::eventsPerSecond)
+                .orElse(RunningOptions.DEFAULT_EVENTS_PER_SECOND));
     }
 
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarEventsReindexTask.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarEventsReindexTask.java
@@ -30,7 +30,8 @@ import com.google.common.base.Preconditions;
 import com.linagora.calendar.webadmin.service.CalendarEventsReindexService;
 
 public class CalendarEventsReindexTask implements Task {
-    public record Details(Instant instant, long processedEventCount, long failedEventCount) implements TaskExecutionDetails.AdditionalInformation {
+    public record Details(Instant instant, long processedEventCount, long failedEventCount,
+                          int eventsPerSecond, int calendarsConcurrency) implements TaskExecutionDetails.AdditionalInformation {
         @Override
         public Instant timestamp() {
             return instant;
@@ -82,6 +83,8 @@ public class CalendarEventsReindexTask implements Task {
     public Optional<TaskExecutionDetails.AdditionalInformation> details() {
         return Optional.of(new Details(Clock.systemUTC().instant(),
             context.snapshot().processedEventCount(),
-            context.snapshot().failedEventCount()));
+            context.snapshot().failedEventCount(),
+            runningOptions.eventsPerSecond(),
+            runningOptions.calendarsConcurrency()));
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarEventsReindexTaskAdditionalInformationDTO.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/CalendarEventsReindexTaskAdditionalInformationDTO.java
@@ -19,6 +19,7 @@
 package com.linagora.calendar.webadmin.task;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import org.apache.james.json.DTOModule;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
@@ -27,7 +28,14 @@ import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 public record CalendarEventsReindexTaskAdditionalInformationDTO(String type,
                                                                 Instant timestamp,
                                                                 long processedEventCount,
-                                                                long failedEventCount) implements AdditionalInformationDTO {
+                                                                long failedEventCount,
+                                                                Optional<RunningOptionsDTO> runningOptions) implements AdditionalInformationDTO {
+    public record RunningOptionsDTO(int eventsPerSecond, int calendarsConcurrency) {
+        static RunningOptionsDTO fromDomainObject(CalendarEventsReindexTask.Details details) {
+            return new RunningOptionsDTO(details.eventsPerSecond(), details.calendarsConcurrency());
+        }
+    }
+
     @Override
     public String getType() {
         return type;
@@ -52,13 +60,18 @@ public record CalendarEventsReindexTaskAdditionalInformationDTO(String type,
             type,
             details.instant(),
             details.processedEventCount(),
-            details.failedEventCount());
+            details.failedEventCount(),
+            Optional.of(RunningOptionsDTO.fromDomainObject(details)));
     }
 
     private CalendarEventsReindexTask.Details toDomainObject() {
         return new CalendarEventsReindexTask.Details(
             timestamp,
             processedEventCount,
-            failedEventCount);
+            failedEventCount,
+            runningOptions.map(RunningOptionsDTO::eventsPerSecond)
+                .orElse(CalendarEventsReindexTask.RunningOptions.DEFAULT_EVENTS_PER_SECOND),
+            runningOptions.map(RunningOptionsDTO::calendarsConcurrency)
+                .orElse(CalendarEventsReindexTask.RunningOptions.DEFAULT_CALENDARS_CONCURRENCY));
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/LdapUsersImportTask.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/LdapUsersImportTask.java
@@ -29,7 +29,8 @@ import org.apache.james.task.TaskType;
 import com.linagora.calendar.webadmin.service.LdapUsersImportService;
 
 public class LdapUsersImportTask implements Task {
-    public record Details(Instant instant, long processedUserCount, long failedUserCount) implements TaskExecutionDetails.AdditionalInformation {
+    public record Details(Instant instant, long processedUserCount, long failedUserCount,
+                          int usersPerSecond) implements TaskExecutionDetails.AdditionalInformation {
         @Override
         public Instant timestamp() {
             return instant;
@@ -62,6 +63,7 @@ public class LdapUsersImportTask implements Task {
     public Optional<TaskExecutionDetails.AdditionalInformation> details() {
         return Optional.of(new Details(Clock.systemUTC().instant(),
             context.snapshot().processedUserCount(),
-            context.snapshot().failedUserCount()));
+            context.snapshot().failedUserCount(),
+            runningOptions.usersPerSecond()));
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/LdapUsersImportTaskAdditionalInformationDTO.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/task/LdapUsersImportTaskAdditionalInformationDTO.java
@@ -19,6 +19,7 @@
 package com.linagora.calendar.webadmin.task;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import org.apache.james.json.DTOModule;
 import org.apache.james.server.task.json.dto.AdditionalInformationDTO;
@@ -27,7 +28,14 @@ import org.apache.james.server.task.json.dto.AdditionalInformationDTOModule;
 public record LdapUsersImportTaskAdditionalInformationDTO(String type,
                                                          Instant timestamp,
                                                          long processedUserCount,
-                                                         long failedUserCount) implements AdditionalInformationDTO {
+                                                         long failedUserCount,
+                                                         Optional<RunningOptionsDTO> runningOptions) implements AdditionalInformationDTO {
+    public record RunningOptionsDTO(int usersPerSecond) {
+        static RunningOptionsDTO fromDomainObject(LdapUsersImportTask.Details details) {
+            return new RunningOptionsDTO(details.usersPerSecond());
+        }
+    }
+
     @Override
     public String getType() {
         return type;
@@ -52,13 +60,16 @@ public record LdapUsersImportTaskAdditionalInformationDTO(String type,
             type,
             details.instant(),
             details.processedUserCount(),
-            details.failedUserCount());
+            details.failedUserCount(),
+            Optional.of(RunningOptionsDTO.fromDomainObject(details)));
     }
 
     private LdapUsersImportTask.Details toDomainObject() {
         return new LdapUsersImportTask.Details(
             timestamp,
             processedUserCount,
-            failedUserCount);
+            failedUserCount,
+            runningOptions.map(RunningOptionsDTO::usersPerSecond)
+                .orElse(LdapUsersImportRunningOptions.DEFAULT_USERS_PER_SECOND));
     }
 }

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/AlarmScheduleTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/AlarmScheduleTest.java
@@ -130,6 +130,7 @@ public class AlarmScheduleTest {
     void shouldShowAllInformationInResponse() {
         String taskId = given()
             .queryParam("task", "scheduleAlarms")
+            .queryParam("eventsPerSecond", 12)
             .when()
             .post()
             .jsonPath()
@@ -145,6 +146,7 @@ public class AlarmScheduleTest {
             .body("type", is("schedule-alarms"))
             .body("additionalInformation.processedEventCount", is(0))
             .body("additionalInformation.failedEventCount", is(0))
+            .body("additionalInformation.runningOptions.eventsPerSecond", is(12))
             .body("additionalInformation.timestamp", is(notNullValue()))
             .body("additionalInformation.type", is("schedule-alarms"))
             .body("startedDate", is(notNullValue()))

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarArchivalTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarArchivalTest.java
@@ -735,6 +735,7 @@ public class CalendarArchivalTest {
             .queryParam("masterDtStartBefore", "5d")
             .queryParam("isRejected", "true")
             .queryParam("isNotRecurring", "true")
+            .queryParam("eventsPerSecond", 12)
         .when()
             .post()
         .then()
@@ -754,7 +755,8 @@ public class CalendarArchivalTest {
             .body("additionalInformation.criteria.lastModifiedBefore", is("2025-12-25T00:00:00Z"))
             .body("additionalInformation.criteria.masterDtStartBefore", is("2025-12-27T00:00:00Z"))
             .body("additionalInformation.criteria.rejectedOnly", is(true))
-            .body("additionalInformation.criteria.isNotRecurring", is(true));
+            .body("additionalInformation.criteria.isNotRecurring", is(true))
+            .body("additionalInformation.runningOptions.eventsPerSecond", is(12));
     }
 
     @Test

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
@@ -142,6 +142,8 @@ public class CalendarRoutesTest {
     void shouldShowAllInformationInResponse() {
         String taskId = given()
             .queryParam("task", "reindex")
+            .queryParam("eventsPerSecond", 12)
+            .queryParam("calendarsConcurrency", 3)
             .when()
             .post()
             .jsonPath()
@@ -157,6 +159,8 @@ public class CalendarRoutesTest {
             .body("type", is("reindex-calendar-events"))
             .body("additionalInformation.processedEventCount", is(0))
             .body("additionalInformation.failedEventCount", is(0))
+            .body("additionalInformation.runningOptions.eventsPerSecond", is(12))
+            .body("additionalInformation.runningOptions.calendarsConcurrency", is(3))
             .body("additionalInformation.timestamp", is(notNullValue()))
             .body("additionalInformation.type", is("reindex-calendar-events"))
             .body("startedDate", is(notNullValue()))

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/LdapUsersImportTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/LdapUsersImportTest.java
@@ -105,6 +105,7 @@ class LdapUsersImportTest {
 
         String taskId = given()
             .queryParam("task", "importFromLDAP")
+            .queryParam("usersPerSecond", 12)
             .when()
             .post()
             .jsonPath()
@@ -120,6 +121,7 @@ class LdapUsersImportTest {
             .body("type", is("import-ldap-users"))
             .body("additionalInformation.processedUserCount", is(1))
             .body("additionalInformation.failedUserCount", is(0))
+            .body("additionalInformation.runningOptions.usersPerSecond", is(12))
             .body("additionalInformation.timestamp", is(notNullValue()))
             .body("additionalInformation.type", is("import-ldap-users"))
             .body("startedDate", is(notNullValue()))

--- a/docs/apis/webadmin.md
+++ b/docs/apis/webadmin.md
@@ -115,6 +115,7 @@ This endpoint returns a webdmin task with the following additional information:
 
 - processedUserCount: integer
 - failedUserCount: integer
+- runningOptions.usersPerSecond: integer
 
 ### Add missing fields to registered users
 
@@ -292,6 +293,8 @@ This endpoint returns a webdmin task with the following additional information:
 
  - processedEventCount: integer
  - failedEventCount: integer
+ - runningOptions.eventsPerSecond: integer
+ - runningOptions.calendarsConcurrency: integer
  
 
 ### Alarm rescheduling
@@ -308,6 +311,7 @@ This endpoint returns a webdmin task with the following additional information:
 
 - processedEventCount: integer
 - failedEventCount: integer
+- runningOptions.eventsPerSecond: integer
 
 ### Calendar event archival
 
@@ -386,6 +390,9 @@ Example task result:
   "additionalInformation": {
     "archivedEventCount": 12,
     "failedEventCount": 0,
+    "runningOptions": {
+      "eventsPerSecond": 100
+    },
     "criteria": {
       "createdBefore": "2025-12-22T00:00:00Z",
       "lastModifiedBefore": null,
@@ -400,6 +407,7 @@ Example task result:
 Where:
 - `archivedEventCount`: Number of events successfully archived
 - `failedEventCount`: Number of events that failed to be archived
+- `runningOptions.eventsPerSecond`: Effective throttling parameter used by the task
 - `criteria`: Effective archival criteria applied for the task
 
 **Note:** When using the single-user archival endpoint (`POST /calendars/{username}?task=archive`),


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-side-service/issues/889

Add runningOptions to webadmin task additionalInformation DTOs for LDAP import, alarm scheduling, calendar archival, and calendar event reindexing. Preserve backward compatibility by defaulting missing serialized options.