### PR TITLE
Fix #887: materialize user/resource listing to avoid MongoDB cursor timeout during reindex

### DIFF
--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/CalendarEventsReindexService.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/CalendarEventsReindexService.java
@@ -136,8 +136,12 @@ public class CalendarEventsReindexService {
     public Mono<Task.Result> reindex(Context context, CalendarEventsReindexTask.RunningOptions runningOptions) {
         return Flux.concat(
                 userDAO.list()
+                    .collectList()
+                    .flatMapMany(Flux::fromIterable)
                     .concatMap(user -> collectEvents(context, user, runningOptions.calendarsConcurrency())),
                 resourceDAO.findAll()
+                    .collectList()
+                    .flatMapMany(Flux::fromIterable)
                     .concatMap(resource -> collectEvents(context, resource)))
             .transform(ReactorUtils.<IndexItem, Task.Result>throttle()
                 .elements(runningOptions.eventsPerSecond())


### PR DESCRIPTION
Closes #887

## Problem

The `reindex-calendar-events` task fails with `MongoCursorNotFoundException` (code 43, `CursorNotFound`), ending as `failed`/`PARTIAL` even though `failedEventCount = 0`.

## Root cause

`CalendarEventsReindexService.reindex(...)` streamed an open MongoDB cursor while doing slow, throttled per-item work on it:

```java
Flux.concat(
    userDAO.list().concatMap(user -> collectEvents(...)),
    resourceDAO.findAll().concatMap(resource -> collectEvents(...)))
```

The reactive driver reads the cursor batch by batch and only issues the next `getMore` once the current batch is drained. Draining is extremely slow here: default `calendarsConcurrency = 1` (sequential `concatMap`), each item does `deleteAll` + CalDAV report + ICS parse + reindex, and the whole pipeline is throttled to `eventsPerSecond`. With tens of thousands of events, the gap between two `getMore` calls exceeds MongoDB's idle-cursor timeout, the server reaps the cursor, and the next `getMore` fails. That error propagates past the per-item `onErrorResume` handlers up to the top-level one, which logs *"Task reindex is incomplete"* and returns `PARTIAL`.

## Fix

Materialize `userDAO.list()` and `resourceDAO.findAll()` into memory with `collectList()` before per-item processing. The listings are lightweight, bounded records (thousands, not the 26k events), so buffering closes the cursor immediately and fully removes the timeout window.

Compiled successfully (`calendar-webadmin`).

---
*Generated automatically*
