### PR TITLE
[FIX] Handle observance-less VTIMEZONE during ICS parsing (reindex 896)

### DIFF
--- a/calendar-api/src/main/java/com/linagora/calendar/api/CalendarUtil.java
+++ b/calendar-api/src/main/java/com/linagora/calendar/api/CalendarUtil.java
@@ -31,6 +31,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.DateTimeException;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 import net.fortuna.ical4j.data.CalendarBuilder;
 import net.fortuna.ical4j.data.CalendarParserFactory;
@@ -84,13 +87,62 @@ public class CalendarUtil {
             new ContentHandlerContext().withSuppressInvalidProperties(true),
             new CustomizedTimeZoneRegistry());
         try {
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(icsContent);
+            byte[] sanitized = dropVTimeZonesWithoutObservance(new String(icsContent, StandardCharsets.UTF_8))
+                .getBytes(StandardCharsets.UTF_8);
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(sanitized);
             return builder.build(inputStream);
         } catch (IOException e) {
             throw new RuntimeException("Error while reading calendar input", e);
         } catch (ParserException e) {
             throw new RuntimeException("Error while parsing ICal object", e);
         }
+    }
+
+    /**
+     * Some clients (e.g. Sabre) may emit a VTIMEZONE without any STANDARD or DAYLIGHT observance.
+     * Such a component is invalid per RFC 5545 and makes ical4j fail with a NullPointerException
+     * ("Cannot invoke Observance.getRequiredProperty(...)") while building the calendar.
+     * Since an observance-less VTIMEZONE carries no offset information, it can safely be dropped:
+     * the TZID referenced by the events is still resolved through the timezone registry.
+     */
+    private static String dropVTimeZonesWithoutObservance(String icsContent) {
+        if (!icsContent.toUpperCase(Locale.US).contains("BEGIN:VTIMEZONE")) {
+            return icsContent;
+        }
+        String[] lines = icsContent.split("\r\n|\r|\n", -1);
+        StringBuilder result = new StringBuilder(icsContent.length());
+        List<String> currentBlock = null;
+        boolean hasObservance = false;
+        boolean dropped = false;
+        for (String line : lines) {
+            String directive = line.trim().toUpperCase(Locale.US);
+            if (directive.equals("BEGIN:VTIMEZONE")) {
+                currentBlock = new ArrayList<>();
+                hasObservance = false;
+                currentBlock.add(line);
+            } else if (currentBlock != null) {
+                currentBlock.add(line);
+                if (directive.equals("BEGIN:STANDARD") || directive.equals("BEGIN:DAYLIGHT")) {
+                    hasObservance = true;
+                } else if (directive.equals("END:VTIMEZONE")) {
+                    if (hasObservance) {
+                        currentBlock.forEach(kept -> result.append(kept).append("\r\n"));
+                    } else {
+                        dropped = true;
+                    }
+                    currentBlock = null;
+                }
+            } else {
+                result.append(line).append("\r\n");
+            }
+        }
+        if (currentBlock != null) {
+            currentBlock.forEach(kept -> result.append(kept).append("\r\n"));
+        }
+        if (!dropped) {
+            return icsContent;
+        }
+        return result.toString();
     }
 
     public static Calendar withSingleVEvent(Calendar template, VEvent vevent) {

--- a/calendar-api/src/test/java/com/linagora/calendar/api/CalendarUtilTest.java
+++ b/calendar-api/src/test/java/com/linagora/calendar/api/CalendarUtilTest.java
@@ -1,0 +1,112 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.Component;
+
+class CalendarUtilTest {
+
+    @Test
+    void parseIcsShouldNotThrowWhenVTimezoneHasNoObservance() {
+        // Reproduces https://github.com/linagora/twake-calendar-side-service/issues/896
+        // Sabre may generate a VTIMEZONE without any STANDARD/DAYLIGHT observance which makes
+        // ical4j fail with a NullPointerException on Observance.getRequiredProperty(...).
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            BEGIN:VTIMEZONE
+            TZID:Europe/Paris
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            UID:87e925b3-a715-4930-8a81-f8f423672c00
+            TRANSP:OPAQUE
+            DTSTART;TZID=Europe/Paris:20250714T073000
+            CLASS:PUBLIC
+            SUMMARY:testFromNewfront
+            DTEND;TZID=Europe/Paris:20250714T073000
+            DTSTAMP:20250717T140746Z
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("\n", "\r\n");
+
+        assertThatCode(() -> CalendarUtil.parseIcs(ics)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void parseIcsShouldKeepVEventWhenVTimezoneHasNoObservance() {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            BEGIN:VTIMEZONE
+            TZID:Europe/Paris
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            UID:87e925b3-a715-4930-8a81-f8f423672c00
+            DTSTART;TZID=Europe/Paris:20250714T073000
+            SUMMARY:testFromNewfront
+            DTEND;TZID=Europe/Paris:20250714T073000
+            DTSTAMP:20250717T140746Z
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("\n", "\r\n");
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+
+        assertThat(calendar.getComponents(Component.VEVENT)).hasSize(1);
+    }
+
+    @Test
+    void parseIcsShouldKeepValidVTimezone() {
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Sabre//Sabre VObject 4.1.3//EN
+            BEGIN:VTIMEZONE
+            TZID:Asia/Saigon
+            BEGIN:STANDARD
+            TZOFFSETFROM:+0700
+            TZOFFSETTO:+0700
+            TZNAME:WIB
+            DTSTART:19700101T000000
+            END:STANDARD
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            UID:87e925b3-a715-4930-8a81-f8f423672c00
+            DTSTART;TZID=Asia/Saigon:20250714T073000
+            SUMMARY:testFromNewfront
+            DTEND;TZID=Asia/Saigon:20250714T083000
+            DTSTAMP:20250717T140746Z
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("\n", "\r\n");
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+
+        assertThat(calendar.getComponents(Component.VTIMEZONE)).hasSize(1);
+        assertThat(calendar.getComponents(Component.VEVENT)).hasSize(1);
+    }
+}


### PR DESCRIPTION
Closes #896

## Problem

During a `reindex-calendar-events` WebAdmin task, some events failed to be indexed:

```
Error while parsing ICal object
ParserException: Error at line 6
NullPointerException: Cannot invoke
"net.fortuna.ical4j.model.component.Observance.getRequiredProperty(String)"
```

The offending ICS contains a `VTIMEZONE` component with **no** `STANDARD` or `DAYLIGHT` observance:

```
BEGIN:VTIMEZONE
TZID:Europe/Paris
END:VTIMEZONE
```

Such a component is invalid per RFC 5545, and ical4j (4.2.5) throws a `NullPointerException` (`currentStandard is null`) while building the calendar, which surfaces as a failed event in the reindex task.

## Fix

Since an observance-less `VTIMEZONE` carries no offset information, it is now stripped from the ICS before parsing in `CalendarUtil.parseIcs`. The `TZID` referenced by the events (e.g. `Europe/Paris`) is still resolved through the timezone registry (`CustomizedTimeZoneRegistry` falls back to the global zone id), so event dates remain correct.

Valid `VTIMEZONE` components are left untouched.

## Tests

Added `CalendarUtilTest` covering:
- parsing no longer throws on an observance-less `VTIMEZONE`;
- the `VEVENT` is still retained;
- a valid `VTIMEZONE` is preserved.

---
*Generated automatically*
