### PR TITLE
Fix #895: collapse recurring event occurrences on the uid to fix indexing race

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventIndexerConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventIndexerConsumer.java
@@ -27,7 +27,6 @@ import java.io.Closeable;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -45,9 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.name.Named;
-import com.linagora.calendar.storage.eventsearch.CalendarEvents;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchService;
-import com.linagora.calendar.storage.exception.CalendarSearchIndexingException;
 import com.rabbitmq.client.BuiltinExchangeType;
 
 import reactor.core.Disposable;
@@ -150,7 +147,7 @@ public class EventIndexerConsumer implements Closeable, Startable {
     }
 
     public void start() {
-        consumeDisposableMap.put(Queue.ADD, doConsumeCalendarEventMessages(Queue.ADD, handlerAdd));
+        consumeDisposableMap.put(Queue.ADD, doConsumeCalendarEventMessages(Queue.ADD, handlerAddOrUpdate));
         consumeDisposableMap.put(Queue.UPDATE, doConsumeCalendarEventMessages(Queue.UPDATE, handlerAddOrUpdate));
         consumeDisposableMap.put(Queue.DELETE, doConsumeCalendarEventMessages(Queue.DELETE, handlerDelete));
     }
@@ -178,53 +175,17 @@ public class EventIndexerConsumer implements Closeable, Startable {
         Mono<CalendarEventMessage> deserialize(byte[] messagesAsBytes);
     }
 
-    private final CalendarEventHandler handlerAdd = new CalendarEventHandler() {
+    // Both created and updated events are indexed the same way: each occurrence (master and overridden
+    // occurrences) is upserted as its own document guarded by its sequence. We intentionally do NOT delete
+    // by eventUid before re-indexing recurring events: that delete bypasses the per-document sequence guard
+    // and races with concurrent/reordered messages (see issue #895). Search collapses on the uid and keeps
+    // the sequence-guarded master, so stale overridden occurrences are never surfaced.
+    private final CalendarEventHandler handlerAddOrUpdate = new CalendarEventHandler() {
         @Override
         public Mono<?> handle(CalendarEventMessage calendarEventMessage) {
             return Mono.fromCallable(calendarEventMessage::extractCalendarEvents)
                 .flatMap(calendarSearchService::index)
                 .then();
-        }
-
-        @Override
-        public Mono<CalendarEventMessage> deserialize(byte[] messagesAsBytes) {
-            return Mono.fromCallable(() -> CalendarEventMessage.CreatedOrUpdated.deserialize(messagesAsBytes));
-        }
-    };
-
-    private final CalendarEventHandler handlerAddOrUpdate = new CalendarEventHandler() {
-
-        @Override
-        public Mono<?> handle(CalendarEventMessage calendarEventMessage) {
-            return Mono.fromCallable(calendarEventMessage::extractCalendarEvents)
-                .flatMap(this::indexEvents)
-                .then();
-        }
-
-        private Mono<Void> indexEvents(CalendarEvents calendarEvents) {
-           if (hasRecurrenceEvents(calendarEvents)) {
-                return calendarSearchService.delete(calendarEvents.calendarURL(), calendarEvents.eventUid())
-                    .then(calendarSearchService.index(calendarEvents))
-                    .onErrorResume(this::isVersionConflict, error -> {
-                        LOGGER.info("Ignoring duplicated DAV recurring event message for eventUid {} in calendarURL {}",
-                            calendarEvents.eventUid().value(), calendarEvents.calendarURL().serialize(), error);
-                        return Mono.empty();
-                    });
-            } else {
-                return calendarSearchService.index(calendarEvents);
-           }
-        }
-
-        private boolean hasRecurrenceEvents(CalendarEvents calendarEvents) {
-            return calendarEvents.events().size() > 1;
-        }
-
-        private boolean isVersionConflict(Throwable error) {
-            return error instanceof CalendarSearchIndexingException
-                && Optional.ofNullable(error.getCause())
-                .map(Throwable::getMessage)
-                .filter(message -> message.contains("version conflict, required seqNo"))
-                .isPresent();
         }
 
         @Override

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
@@ -361,28 +361,10 @@ public class EventIndexerConsumerTest {
             .resourceName(eventUid + ".ics")
             .build();
 
-        EventFields recurrenceEvent = EventFields.builder()
-            .calendarURL(new CalendarURL(new OpenPaaSId(openPaasUser.id().value()), new OpenPaaSId(openPaasUser.id().value())))
-            .uid(new EventUid(eventUid))
-            .isRecurrentMaster(false)
-            .summary(summary)
-            .location(location)
-            .description(description)
-            .clazz("PUBLIC")
-            .start(Instant.parse("2025-05-23T07:30:00Z"))
-            .end(Instant.parse("2025-05-23T08:00:00Z"))
-            .dtStamp(Instant.parse("2025-05-16T06:03:20Z"))
-            .allDay(false)
-            .organizer(EventFields.Person.of("John1 Doe1", openPaasUser.username().asString()))
-            .addAttendee(EventFields.Person.of("John2 Doe2", attendee1.username().asString()))
-            .addAttendee(EventFields.Person.of("John1 Doe1", openPaasUser.username().asString()))
-            .sequence(1)
-            .resourceName(eventUid + ".ics")
-            .build();
-
+        // Search collapses occurrences on the uid and keeps the recurrence master as the representative.
         assertThat(eventFields)
             .usingRecursiveFieldByFieldElementComparatorIgnoringFields("recurrenceId")
-            .containsExactlyInAnyOrder(masterEvent, recurrenceEvent);
+            .containsExactly(masterEvent);
 
         // Check that the recurrence event is indexed for the attendee
         assertEventExistsInSearch(attendee1.username(), summary, eventUid);
@@ -393,7 +375,7 @@ public class EventIndexerConsumerTest {
 
         assertThat(eventFieldsAttendee)
             .usingRecursiveFieldByFieldElementComparatorIgnoringFields("recurrenceId")
-            .containsExactlyInAnyOrder(masterEvent, recurrenceEvent);
+            .containsExactly(masterEvent);
     }
 
     @Test
@@ -486,7 +468,8 @@ public class EventIndexerConsumerTest {
             .collect(Collectors.toSet())
             .block();
 
-        awaitAtMost.untilAsserted(() -> assertThat(searchSupplier.get()).hasSize(3));
+        // Occurrences collapse on the uid, keeping the master as the single representative.
+        awaitAtMost.untilAsserted(() -> assertThat(searchSupplier.get()).hasSize(1));
 
         // Update the event (removed one recurrence event)
         String updatedCalendar = """
@@ -548,7 +531,7 @@ public class EventIndexerConsumerTest {
 
         davTestHelper.upsertCalendar(openPaasUser, updatedCalendar, eventUid);
 
-        awaitAtMost.untilAsserted(() -> assertThat(searchSupplier.get()).hasSize(2));
+        awaitAtMost.untilAsserted(() -> assertThat(searchSupplier.get()).hasSize(1));
     }
 
     @Test
@@ -642,7 +625,8 @@ public class EventIndexerConsumerTest {
             .collect(Collectors.toSet())
             .block();
 
-        awaitAtMost.untilAsserted(() -> assertThat(searchSupplier.get()).hasSize(3));
+        // Occurrences collapse on the uid, keeping the master as the single representative.
+        awaitAtMost.untilAsserted(() -> assertThat(searchSupplier.get()).hasSize(1));
     }
 
     @Test
@@ -936,12 +920,12 @@ public class EventIndexerConsumerTest {
                 .collectList()
                 .block();
 
-            // Expect only 2 events (master + updated instance)
-            assertThat(results).hasSize(2);
+            // Occurrences collapse on the uid, keeping the master as the single representative: no duplicate.
+            assertThat(results).hasSize(1);
 
-            // The updated instance should be present
+            // The master occurrence is returned as the representative.
             assertThat(results)
-                .anySatisfy(e -> assertThat(e.start()).isEqualTo(Instant.parse("2025-05-18T08:00:00Z")));
+                .allSatisfy(e -> assertThat(e.start()).isEqualTo(Instant.parse("2025-05-10T08:00:00Z")));
         });
     }
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
@@ -535,6 +535,110 @@ public class EventIndexerConsumerTest {
     }
 
     @Test
+    void shouldNotKeepRemovedRecurrenceInstanceSearchableAfterUpdate() {
+        String eventUid = UUID.randomUUID().toString();
+        String masterSummary = "Recurring meeting";
+        String keptOccurrenceSummary = "Kept occurrence";
+        String removedOccurrenceSummary = "Removed occurrence";
+        String organizer = openPaasUser.username().asString();
+
+        // Given a recurring event with two overridden occurrences.
+        String initialCalendar = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//SabreDAV//SabreDAV 3.2.2//EN
+            BEGIN:VEVENT
+            UID:{eventUid}
+            TRANSP:OPAQUE
+            DTSTART:20250515T043000Z
+            DTEND:20250515T050000Z
+            CLASS:PUBLIC
+            SUMMARY:{masterSummary}
+            RRULE:FREQ=WEEKLY;COUNT=14;BYDAY=FR
+            ORGANIZER;CN=John1 Doe1:mailto:{organizer}
+            DTSTAMP:20250516T060320Z
+            SEQUENCE:1
+            END:VEVENT
+            BEGIN:VEVENT
+            UID:{eventUid}
+            TRANSP:OPAQUE
+            DTSTART:20250523T073000Z
+            DTEND:20250523T080000Z
+            CLASS:PUBLIC
+            SUMMARY:{keptOccurrenceSummary}
+            ORGANIZER;CN=John1 Doe1:mailto:{organizer}
+            DTSTAMP:20250516T060320Z
+            RECURRENCE-ID:20250523T043000Z
+            SEQUENCE:1
+            END:VEVENT
+            BEGIN:VEVENT
+            UID:{eventUid}
+            TRANSP:OPAQUE
+            DTSTART:20250530T073000Z
+            DTEND:20250530T080000Z
+            CLASS:PUBLIC
+            SUMMARY:{removedOccurrenceSummary}
+            ORGANIZER;CN=John1 Doe1:mailto:{organizer}
+            DTSTAMP:20250516T060320Z
+            RECURRENCE-ID:20250530T043000Z
+            SEQUENCE:1
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("{eventUid}", eventUid)
+            .replace("{masterSummary}", masterSummary)
+            .replace("{keptOccurrenceSummary}", keptOccurrenceSummary)
+            .replace("{removedOccurrenceSummary}", removedOccurrenceSummary)
+            .replace("{organizer}", organizer);
+
+        davTestHelper.upsertCalendar(openPaasUser, initialCalendar, eventUid);
+
+        assertEventExistsInSearch(openPaasUser.username(), removedOccurrenceSummary, eventUid);
+
+        // When the event is updated and one overridden occurrence is removed from the calendar payload.
+        String updatedCalendar = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//SabreDAV//SabreDAV 3.2.2//EN
+            BEGIN:VEVENT
+            UID:{eventUid}
+            TRANSP:OPAQUE
+            DTSTART:20250515T043000Z
+            DTEND:20250515T050000Z
+            CLASS:PUBLIC
+            SUMMARY:{masterSummary}
+            RRULE:FREQ=WEEKLY;COUNT=14;BYDAY=FR
+            ORGANIZER;CN=John1 Doe1:mailto:{organizer}
+            DTSTAMP:20250516T060320Z
+            SEQUENCE:2
+            END:VEVENT
+            BEGIN:VEVENT
+            UID:{eventUid}
+            TRANSP:OPAQUE
+            DTSTART:20250523T073000Z
+            DTEND:20250523T080000Z
+            CLASS:PUBLIC
+            SUMMARY:{keptOccurrenceSummary}
+            ORGANIZER;CN=John1 Doe1:mailto:{organizer}
+            DTSTAMP:20250516T060320Z
+            RECURRENCE-ID:20250523T043000Z
+            SEQUENCE:2
+            END:VEVENT
+            END:VCALENDAR
+            """.replace("{eventUid}", eventUid)
+            .replace("{masterSummary}", masterSummary)
+            .replace("{keptOccurrenceSummary}", keptOccurrenceSummary)
+            .replace("{organizer}", organizer);
+
+        davTestHelper.updateCalendar(openPaasUser, updatedCalendar, eventUid);
+
+        // Then the removed occurrence must not remain searchable from the index.
+        awaitAtMost.untilAsserted(() -> assertThat(
+            calendarSearchService.search(simpleQuery(removedOccurrenceSummary, CalendarURL.from(openPaasUser.id())))
+                .collectList()
+                .block()).isEmpty());
+    }
+
+    @Test
     void shouldHandleIndexEventWhenOrganizerListedAsAttendeeWithoutMailto() {
         String eventUid = UUID.randomUUID().toString();
         String summary = "Meeting Summary";

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/CalendarRoutesTest.java
@@ -410,25 +410,6 @@ public class CalendarRoutesTest {
             .resourceName(uid1 + ICS_EXTENSION)
             .build();
 
-        EventFields expected2 = EventFields.builder()
-            .uid(uid1)
-            .summary("recur222")
-            .location(null)
-            .description(null)
-            .clazz("PUBLIC")
-            .start(Instant.parse("2025-05-15T05:00:00Z")) // Asia/Saigon 12:00 = UTC+7
-            .end(Instant.parse("2025-05-15T05:30:00Z"))
-            .dtStamp(Instant.parse("2025-05-15T07:39:30Z"))
-            .allDay(false)
-            .isRecurrentMaster(false)
-            .organizer(person)
-            .attendees(List.of(person))
-            .resources(List.of())
-            .calendarURL(calendarURL)
-            .resourceName(uid1 + ICS_EXTENSION)
-            .sequence(1)
-            .build();
-
         EventFields expected3 = EventFields.builder()
             .uid(uid2)
             .summary("test555")
@@ -448,11 +429,13 @@ public class CalendarRoutesTest {
 
         List<EventFields> actual = calendarSearchService.search(simpleQuery("", calendarURL))
             .collectList().block();
+        // Search collapses occurrences on the uid and keeps the recurrence master as the representative:
+        // the recur222 overridden occurrence is not surfaced separately.
         assertThat(actual)
             .usingRecursiveFieldByFieldElementComparator(builder()
                 .withIgnoredFields("attendees.partStat", "resources.partStat", "organizer.partStat", "recurrenceId")
                 .build())
-            .containsExactlyInAnyOrder(expected1, expected2, expected3);
+            .containsExactlyInAnyOrder(expected1, expected3);
     }
 
     @Test

--- a/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
@@ -180,9 +180,9 @@ public class MemoryCalendarSearchService implements CalendarSearchService {
                              HashMap<String, EventEntry> eventsByKey) {
         static final boolean DELETED = true;
 
-        record EventEntry(EventFields event, boolean deleted, Optional<Integer> lastSequence) {
+        record EventEntry(EventFields event, boolean deleted) {
             static EventEntry from(EventFields event) {
-                return new EventEntry(event, !DELETED, event.sequence());
+                return new EventEntry(event, !DELETED);
             }
         }
 
@@ -194,36 +194,35 @@ public class MemoryCalendarSearchService implements CalendarSearchService {
         }
 
         CalendarEventsDTO replaceWith(Set<EventFields> incomingEvents) {
+            boolean masterApplied = false;
             for (EventFields incomingEvent : incomingEvents) {
                 String key = eventKey(incomingEvent);
                 Optional<EventFields> existingEvent = Optional.ofNullable(eventsByKey.get(key))
                     .map(EventEntry::event);
 
                 if (shouldReplace(existingEvent, incomingEvent)) {
-                    eventsByKey.put(key, new EventEntry(incomingEvent, false, incomingEvent.sequence()));
+                    eventsByKey.put(key, new EventEntry(incomingEvent, false));
+                    masterApplied |= Boolean.TRUE.equals(incomingEvent.isRecurrentMaster());
                 }
             }
-            pruneRemovedOccurrences(incomingEvents);
+            if (masterApplied) {
+                pruneStaleOccurrences(incomingEvents);
+            }
             return this;
         }
 
         // Drop occurrence documents that are no longer part of the event (e.g. a deleted overridden
-        // occurrence). We only drop entries with a strictly older sequence than the current update, so a
-        // reordered older message cannot erase a fresher state (see issue #895).
-        private void pruneRemovedOccurrences(Set<EventFields> incomingEvents) {
-            Optional<Integer> sequenceThreshold = incomingEvents.stream()
-                .map(EventFields::sequence)
-                .flatMap(Optional::stream)
-                .max(Comparator.naturalOrder());
+        // occurrence). Staleness is decided by identity: any indexed entry for this uid whose key (which
+        // encodes the recurrenceId) is absent from the newly written message is dropped. We never rely on
+        // SEQUENCE here because it is per-VEVENT, so a removed occurrence may legitimately carry a higher
+        // sequence than the master. Pruning only runs when the recurrence master won its sequence guard,
+        // meaning the incoming message is newer than the indexed state (see issue #895).
+        private void pruneStaleOccurrences(Set<EventFields> incomingEvents) {
+            Set<String> incomingKeys = incomingEvents.stream()
+                .map(CalendarEventsDTO::eventKey)
+                .collect(Collectors.toSet());
 
-            sequenceThreshold.ifPresent(threshold -> {
-                Set<String> incomingKeys = incomingEvents.stream()
-                    .map(CalendarEventsDTO::eventKey)
-                    .collect(Collectors.toSet());
-
-                eventsByKey.entrySet().removeIf(entry -> !incomingKeys.contains(entry.getKey())
-                    && entry.getValue().lastSequence().map(sequence -> sequence < threshold).orElse(false));
-            });
+            eventsByKey.keySet().removeIf(key -> !incomingKeys.contains(key));
         }
 
         static boolean shouldReplace(Optional<EventFields> existing, EventFields incoming) {

--- a/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
@@ -203,7 +203,27 @@ public class MemoryCalendarSearchService implements CalendarSearchService {
                     eventsByKey.put(key, new EventEntry(incomingEvent, false, incomingEvent.sequence()));
                 }
             }
+            pruneRemovedOccurrences(incomingEvents);
             return this;
+        }
+
+        // Drop occurrence documents that are no longer part of the event (e.g. a deleted overridden
+        // occurrence). We only drop entries with a strictly older sequence than the current update, so a
+        // reordered older message cannot erase a fresher state (see issue #895).
+        private void pruneRemovedOccurrences(Set<EventFields> incomingEvents) {
+            Optional<Integer> sequenceThreshold = incomingEvents.stream()
+                .map(EventFields::sequence)
+                .flatMap(Optional::stream)
+                .max(Comparator.naturalOrder());
+
+            sequenceThreshold.ifPresent(threshold -> {
+                Set<String> incomingKeys = incomingEvents.stream()
+                    .map(CalendarEventsDTO::eventKey)
+                    .collect(Collectors.toSet());
+
+                eventsByKey.entrySet().removeIf(entry -> !incomingKeys.contains(entry.getKey())
+                    && entry.getValue().lastSequence().map(sequence -> sequence < threshold).orElse(false));
+            });
         }
 
         static boolean shouldReplace(Optional<EventFields> existing, EventFields incoming) {

--- a/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/eventsearch/MemoryCalendarSearchService.java
@@ -18,13 +18,16 @@
 
 package com.linagora.calendar.storage.eventsearch;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -86,10 +89,17 @@ public class MemoryCalendarSearchService implements CalendarSearchService {
             return Flux.empty();
         }
 
-        return Flux.fromIterable(indexStore.values())
-            .flatMapIterable(CalendarEventsDTO::visibleEvents)
+        // Collapse matching occurrences on their uid, keeping the recurrence master (or a standalone event)
+        // as the representative document, mirroring the OpenSearch field collapse (see issue #895).
+        Collection<EventFields> representatives = indexStore.values().stream()
+            .flatMap(dto -> dto.visibleEvents().stream())
             .filter(event -> matchesQuery(event, query))
-            .sort(Comparator.comparing(EventFields::start, Comparator.nullsLast(Comparator.reverseOrder())))
+            .collect(Collectors.toMap(EventFields::uid, Function.identity(), MemoryCalendarSearchService::keepMaster))
+            .values();
+
+        return Flux.fromIterable(representatives)
+            .sort(Comparator.comparingInt(MemoryCalendarSearchService::collapseRank)
+                .thenComparing(EventFields::start, Comparator.nullsLast(Comparator.reverseOrder())))
             .skip(query.offset())
             .take(query.limit());
     }
@@ -98,6 +108,14 @@ public class MemoryCalendarSearchService implements CalendarSearchService {
     public Mono<Void> deleteAll(OpenPaaSId baseCalendarId) {
         return Mono.fromRunnable(() -> indexStore.rowKeySet()
             .removeIf(calendarURL -> calendarURL.base().equals(baseCalendarId)));
+    }
+
+    private static EventFields keepMaster(EventFields left, EventFields right) {
+        return collapseRank(left) <= collapseRank(right) ? left : right;
+    }
+
+    private static int collapseRank(EventFields event) {
+        return Boolean.FALSE.equals(event.isRecurrentMaster()) ? 1 : 0;
     }
 
     static List<CalendarURL> validateSourceSearchCalendars(EventSearchQuery query) {

--- a/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -1651,6 +1652,109 @@ public interface CalendarSearchServiceContract {
 
         CALMLY_AWAIT.untilAsserted(() -> assertThat(testee().search(simpleQuery("removedoccurrence", url))
             .collectList().block()).isEmpty());
+    }
+
+    @Test
+    default void shouldPruneRemovedOccurrenceByRecurrenceId() {
+        // Given a recurring event with one occurrence that will be removed but has a higher sequence.
+        CalendarURL url = generateCalendarURL();
+        EventUid uid = generateEventUid();
+
+        EventFields master = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("recurringmaster")
+            .isRecurrentMaster(true)
+            .calendarURL(url)
+            .build();
+        EventFields keptOccurrence = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("keptoccurrence")
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-03T10:00:00Z")
+            .calendarURL(url)
+            .build();
+        EventFields removedHighSequenceOccurrence = EventFields.builder()
+            .uid(uid)
+            .sequence(10)
+            .summary("removedhighsequenceoccurrence")
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-10T10:00:00Z")
+            .calendarURL(url)
+            .build();
+
+        testee().index(CalendarEvents.of(master, keptOccurrence, removedHighSequenceOccurrence)).block();
+
+        CALMLY_AWAIT.untilAsserted(() -> assertThat(testee().search(simpleQuery("removedhighsequenceoccurrence", url))
+            .collectList().block()).containsExactly(removedHighSequenceOccurrence));
+
+        // When a later payload keeps only one occurrence and drops the high-sequence one.
+        EventFields masterV2 = EventFields.builder()
+            .uid(uid)
+            .sequence(2)
+            .summary("recurringmaster")
+            .isRecurrentMaster(true)
+            .calendarURL(url)
+            .build();
+        EventFields keptOccurrenceV2 = EventFields.builder()
+            .uid(uid)
+            .sequence(2)
+            .summary("keptoccurrence")
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-03T10:00:00Z")
+            .calendarURL(url)
+            .build();
+
+        testee().index(CalendarEvents.of(masterV2, keptOccurrenceV2)).block();
+
+        // Then the dropped occurrence should be pruned
+        CALMLY_AWAIT.untilAsserted(() -> assertThat(testee().search(simpleQuery("removedhighsequenceoccurrence", url))
+            .collectList().block()).isEmpty());
+    }
+
+    @Test
+    default void stalePayloadShouldNotPruneOccurrences() {
+        // Given a newer indexed recurring state with one overridden occurrence.
+        CalendarURL url = generateCalendarURL();
+        EventUid uid = generateEventUid();
+
+        EventFields currentMaster = EventFields.builder()
+            .uid(uid)
+            .sequence(10)
+            .summary("currentmaster")
+            .isRecurrentMaster(true)
+            .calendarURL(url)
+            .build();
+        EventFields currentOccurrence = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("currentoccurrence")
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-03T10:00:00Z")
+            .calendarURL(url)
+            .build();
+
+        testee().index(CalendarEvents.of(currentMaster, currentOccurrence)).block();
+
+        CALMLY_AWAIT.untilAsserted(() -> assertThat(testee().search(simpleQuery("currentoccurrence", url))
+            .collectList().block()).containsExactly(currentOccurrence));
+
+        // When an older payload without that occurrence arrives and does not win the sequence guard.
+        EventFields staleMaster = EventFields.builder()
+            .uid(uid)
+            .sequence(9)
+            .summary("stalemaster")
+            .isRecurrentMaster(true)
+            .calendarURL(url)
+            .build();
+
+        testee().index(CalendarEvents.of(staleMaster)).block();
+
+        // Then the stale payload must not prune occurrences from the newer state.
+        CALMLY_AWAIT.during(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> assertThat(testee().search(simpleQuery("currentoccurrence", url))
+            .collectList().block()).containsExactly(currentOccurrence));
     }
 
     @Test

--- a/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
@@ -1654,6 +1654,41 @@ public interface CalendarSearchServiceContract {
     }
 
     @Test
+    default void searchShouldReturnOverriddenOccurrenceWhenOnlyItMatches() {
+        // Ensures the collapse-on-uid approach still surfaces an overridden occurrence when the searched
+        // keyword only matches that occurrence and not the master (see the review discussion on #895):
+        // recurring master without Bob, one override instance with Bob invited separately.
+        CalendarURL url = generateCalendarURL();
+        EventUid uid = generateEventUid();
+
+        EventFields master = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("recurringmaster")
+            .organizer(Person.of("Alice", "alice@domain.tld"))
+            .attendees(List.of(Person.of("Alice", "alice@domain.tld")))
+            .isRecurrentMaster(true)
+            .calendarURL(url)
+            .build();
+        EventFields overrideWithBob = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("recurringmaster")
+            .organizer(Person.of("Alice", "alice@domain.tld"))
+            .attendees(List.of(Person.of("Alice", "alice@domain.tld"), Person.of("Bob", "bob@domain.tld")))
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-03T10:00:00Z")
+            .calendarURL(url)
+            .build();
+
+        testee().index(CalendarEvents.of(master, overrideWithBob)).block();
+
+        // A keyword matching only the override must return that override's VEVENT, not the master.
+        CALMLY_AWAIT.untilAsserted(() -> assertThat(testee().search(simpleQuery("Bob", url))
+            .collectList().block()).containsExactly(overrideWithBob));
+    }
+
+    @Test
     default void indexShouldOverrideAllFieldsOnlyWhenSequenceIsHigher() {
         EventUid uid = generateEventUid();
         CalendarURL url = generateCalendarURL();

--- a/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
@@ -282,8 +282,9 @@ public interface CalendarSearchServiceContract {
 
         testee().index(CalendarEvents.of(masterEvent, recurrenceEvent)).block();
 
+        // Search collapses occurrences on the uid and keeps the recurrence master as the representative.
         CALMLY_AWAIT.untilAsserted(() -> assertThat(testee().search(simpleQuery("Recurrence", calendarURL))
-            .collectList().block()).containsExactlyInAnyOrder(masterEvent, recurrenceEvent));
+            .collectList().block()).containsExactly(masterEvent));
     }
 
     @Test
@@ -313,8 +314,9 @@ public interface CalendarSearchServiceContract {
 
         testee().index(CalendarEvents.of(masterEvent, recurrenceEvent)).block();
 
+        // Search collapses occurrences on the uid and keeps the recurrence master as the representative.
         CALMLY_AWAIT.untilAsserted(() -> assertThat(query.get())
-            .containsExactlyInAnyOrder(masterEvent, recurrenceEvent));
+            .containsExactly(masterEvent));
     }
 
     @Test
@@ -1536,9 +1538,60 @@ public interface CalendarSearchServiceContract {
             List<EventFields> results = testee().search(simpleQuery("", url))
                 .collectList().block();
 
+            // Occurrences collapse on the uid, keeping the sequence-guarded master as the representative.
             assertThat(results).extracting(EventFields::summary)
-                .contains("master-v2", "instance");
+                .containsExactly("master-v2");
         });
+    }
+
+    @Test
+    default void indexingStaleRecurringMasterShouldNotDowngradeNewerOne() {
+        // Reproduces issue #895: a newer recurring event state (higher sequence) is indexed first, then a
+        // reordered stale message (lower sequence) arrives. The stale message must not resurrect old data.
+        CalendarURL url = generateCalendarURL();
+        EventUid uid = generateEventUid();
+
+        EventFields masterNew = EventFields.builder()
+            .uid(uid)
+            .sequence(2)
+            .summary("masternew")
+            .isRecurrentMaster(true)
+            .calendarURL(url)
+            .build();
+        EventFields overrideNew = EventFields.builder()
+            .uid(uid)
+            .sequence(2)
+            .summary("overrideoccurrence")
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-03T10:00:00Z")
+            .calendarURL(url)
+            .build();
+
+        EventFields masterOld = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("masterold")
+            .isRecurrentMaster(true)
+            .calendarURL(url)
+            .build();
+        EventFields overrideOld = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("overrideoccurrence")
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-03T10:00:00Z")
+            .calendarURL(url)
+            .build();
+
+        // Newer state indexed first, then the stale reordered message with a lower sequence.
+        testee().index(CalendarEvents.of(masterNew, overrideNew)).block();
+        testee().index(CalendarEvents.of(masterOld, overrideOld)).block();
+
+        CALMLY_AWAIT.untilAsserted(() -> assertThat(testee().search(simpleQuery("masternew", url))
+            .collectList().block()).containsExactly(masterNew));
+
+        assertThat(testee().search(simpleQuery("masterold", url))
+            .collectList().block()).isEmpty();
     }
 
     @Test
@@ -1787,13 +1840,14 @@ public interface CalendarSearchServiceContract {
         // update instance
         testee().index(CalendarEvents.of(master, instanceV2)).block();
 
+        // Occurrences collapse on the uid, keeping the master as the representative: no duplicate instance.
         CALMLY_AWAIT.untilAsserted(() -> {
             List<EventFields> results = testee().search(simpleQuery("recur", url))
                 .collectList().block();
 
             assertThat(results)
                 .extracting(EventFields::start)
-                .containsExactlyInAnyOrder(master.start(), instanceV2.start());
+                .containsExactly(master.start());
         });
     }
 

--- a/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
@@ -1654,7 +1654,7 @@ public interface CalendarSearchServiceContract {
     }
 
     @Test
-    default void searchShouldReturnOverriddenOccurrenceWhenOnlyItMatches() {
+    default void searchShouldReturnOverriddenOccurrenceWhenOnlyItMatches() throws AddressException {
         // Ensures the collapse-on-uid approach still surfaces an overridden occurrence when the searched
         // keyword only matches that occurrence and not the master (see the review discussion on #895):
         // recurring master without Bob, one override instance with Bob invited separately.

--- a/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/eventsearch/CalendarSearchServiceContract.java
@@ -1595,6 +1595,65 @@ public interface CalendarSearchServiceContract {
     }
 
     @Test
+    default void removedRecurrenceOccurrenceShouldNotRemainSearchableAfterUpdate() {
+        // Reproduces issue #895: an overridden occurrence removed from a later update must not linger in the
+        // index and remain searchable through its own fields.
+        CalendarURL url = generateCalendarURL();
+        EventUid uid = generateEventUid();
+
+        EventFields master = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("recurringmaster")
+            .isRecurrentMaster(true)
+            .calendarURL(url)
+            .build();
+        EventFields keptOccurrence = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("keptoccurrence")
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-03T10:00:00Z")
+            .calendarURL(url)
+            .build();
+        EventFields removedOccurrence = EventFields.builder()
+            .uid(uid)
+            .sequence(1)
+            .summary("removedoccurrence")
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-10T10:00:00Z")
+            .calendarURL(url)
+            .build();
+
+        testee().index(CalendarEvents.of(master, keptOccurrence, removedOccurrence)).block();
+
+        CALMLY_AWAIT.untilAsserted(() -> assertThat(testee().search(simpleQuery("removedoccurrence", url))
+            .collectList().block()).containsExactly(removedOccurrence));
+
+        // Update the event with a higher sequence, dropping the removed occurrence from the payload.
+        EventFields masterV2 = EventFields.builder()
+            .uid(uid)
+            .sequence(2)
+            .summary("recurringmaster")
+            .isRecurrentMaster(true)
+            .calendarURL(url)
+            .build();
+        EventFields keptOccurrenceV2 = EventFields.builder()
+            .uid(uid)
+            .sequence(2)
+            .summary("keptoccurrence")
+            .isRecurrentMaster(false)
+            .recurrenceId("2025-01-03T10:00:00Z")
+            .calendarURL(url)
+            .build();
+
+        testee().index(CalendarEvents.of(masterV2, keptOccurrenceV2)).block();
+
+        CALMLY_AWAIT.untilAsserted(() -> assertThat(testee().search(simpleQuery("removedoccurrence", url))
+            .collectList().block()).isEmpty());
+    }
+
+    @Test
     default void indexShouldOverrideAllFieldsOnlyWhenSequenceIsHigher() {
         EventUid uid = generateEventUid();
         CalendarURL url = generateCalendarURL();

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
@@ -168,6 +168,7 @@ public class CalendarEventIndexMappingFactory {
         Property nonIndexedKeywordProperty = new Property(new KeywordProperty.Builder().index(false).build());
         Property nonIndexedBooleanProperty = new Property(new BooleanProperty.Builder().index(false).build());
         Property nonIndexedIntegerProperty = new Property(new IntegerNumberProperty.Builder().index(false).build());
+        Property indexedIntegerProperty = new Property(new IntegerNumberProperty.Builder().index(true).build());
         Property indexedKeywordProperty = new Property(new KeywordProperty.Builder().index(true).build());
 
         Property emailTextProperty = new TextProperty.Builder()
@@ -210,7 +211,8 @@ public class CalendarEventIndexMappingFactory {
                 .put(CalendarFields.ALL_DAY, nonIndexedBooleanProperty)
                 .put(CalendarFields.IS_RECURRENT_MASTER, nonIndexedBooleanProperty)
                 .put(CalendarFields.VIDEOCONFERENCE_URL, nonIndexedKeywordProperty)
-                .put(CalendarFields.SEQUENCE, nonIndexedIntegerProperty)
+                // Indexed so removed occurrences can be pruned with a sequence-bounded delete-by-query (issue #895).
+                .put(CalendarFields.SEQUENCE, indexedIntegerProperty)
                 .put(CalendarFields.RESOURCE_NAME, nonIndexedKeywordProperty)
                 // Not indexed but keeps doc_values so it can be used as a sort key when collapsing on the uid.
                 .put(CalendarFields.COLLAPSE_RANK, nonIndexedIntegerProperty)

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
@@ -80,6 +80,7 @@ public class CalendarEventIndexMappingFactory {
         String BOOKING_LINK_ID = "bookingLinkId";
         String SEQUENCE = "sequence";
         String RESOURCE_NAME = "resourceName";
+        String RECURRENCE_ID = "recurrenceId";
         // Sort rank used to keep the recurrence master (or a standalone event) as the representative
         // document when collapsing search results on the event uid. Lower rank wins.
         String COLLAPSE_RANK = "collapseRank";
@@ -214,6 +215,8 @@ public class CalendarEventIndexMappingFactory {
                 // Indexed so removed occurrences can be pruned with a sequence-bounded delete-by-query (issue #895).
                 .put(CalendarFields.SEQUENCE, indexedIntegerProperty)
                 .put(CalendarFields.RESOURCE_NAME, nonIndexedKeywordProperty)
+                // Not indexed but stored so an overridden occurrence surfaced by search keeps its recurrenceId (issue #895).
+                .put(CalendarFields.RECURRENCE_ID, nonIndexedKeywordProperty)
                 // Not indexed but keeps doc_values so it can be used as a sort key when collapsing on the uid.
                 .put(CalendarFields.COLLAPSE_RANK, nonIndexedIntegerProperty)
                 .build())

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventIndexMappingFactory.java
@@ -80,6 +80,9 @@ public class CalendarEventIndexMappingFactory {
         String BOOKING_LINK_ID = "bookingLinkId";
         String SEQUENCE = "sequence";
         String RESOURCE_NAME = "resourceName";
+        // Sort rank used to keep the recurrence master (or a standalone event) as the representative
+        // document when collapsing search results on the event uid. Lower rank wins.
+        String COLLAPSE_RANK = "collapseRank";
     }
 
     interface MultiField {
@@ -209,6 +212,8 @@ public class CalendarEventIndexMappingFactory {
                 .put(CalendarFields.VIDEOCONFERENCE_URL, nonIndexedKeywordProperty)
                 .put(CalendarFields.SEQUENCE, nonIndexedIntegerProperty)
                 .put(CalendarFields.RESOURCE_NAME, nonIndexedKeywordProperty)
+                // Not indexed but keeps doc_values so it can be used as a sort key when collapsing on the uid.
+                .put(CalendarFields.COLLAPSE_RANK, nonIndexedIntegerProperty)
                 .build())
             .build();
     }

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
@@ -48,6 +48,7 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.BASE_CALENDAR_
                                      @JsonProperty(CalendarFields.CALENDAR_URL) String calendarURL,
                                      @JsonProperty(CalendarFields.SEQUENCE) Integer sequence,
                                      @JsonProperty(CalendarFields.RESOURCE_NAME) String resourceName,
+                                     @JsonProperty(CalendarFields.RECURRENCE_ID) String recurrenceId,
                                      @JsonProperty(CalendarFields.COLLAPSE_RANK) Integer collapseRank) {
 
     // Representative rank used to keep the recurrence master (or a standalone event) when collapsing
@@ -104,6 +105,7 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.BASE_CALENDAR_
             eventFields.calendarURL().serialize(),
             eventFields.sequence().orElse(null),
             eventFields.resourceName().orElse(null),
+            eventFields.recurrenceId().orElse(null),
             computeCollapseRank(eventFields));
     }
 
@@ -147,6 +149,9 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.BASE_CALENDAR_
         }
         if (resourceName != null) {
             builder.resourceName(resourceName);
+        }
+        if (recurrenceId != null) {
+            builder.recurrenceId(recurrenceId);
         }
 
         return builder.build();

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/CalendarEventsDocument.java
@@ -47,7 +47,13 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.BASE_CALENDAR_
                                      @JsonProperty(CalendarFields.BOOKING_LINK_ID) String bookingLinkId,
                                      @JsonProperty(CalendarFields.CALENDAR_URL) String calendarURL,
                                      @JsonProperty(CalendarFields.SEQUENCE) Integer sequence,
-                                     @JsonProperty(CalendarFields.RESOURCE_NAME) String resourceName) {
+                                     @JsonProperty(CalendarFields.RESOURCE_NAME) String resourceName,
+                                     @JsonProperty(CalendarFields.COLLAPSE_RANK) Integer collapseRank) {
+
+    // Representative rank used to keep the recurrence master (or a standalone event) when collapsing
+    // search results on the event uid: an overridden occurrence sorts after the master.
+    private static final int MASTER_COLLAPSE_RANK = 0;
+    private static final int OVERRIDDEN_OCCURRENCE_COLLAPSE_RANK = 1;
 
     public static class DeserializeException extends RuntimeException {
         public DeserializeException(String message, Throwable cause) {
@@ -97,7 +103,14 @@ public record CalendarEventsDocument(@JsonProperty(CalendarFields.BASE_CALENDAR_
             eventFields.bookingLinkId(),
             eventFields.calendarURL().serialize(),
             eventFields.sequence().orElse(null),
-            eventFields.resourceName().orElse(null));
+            eventFields.resourceName().orElse(null),
+            computeCollapseRank(eventFields));
+    }
+
+    private static int computeCollapseRank(EventFields eventFields) {
+        return Boolean.FALSE.equals(eventFields.isRecurrentMaster())
+            ? OVERRIDDEN_OCCURRENCE_COLLAPSE_RANK
+            : MASTER_COLLAPSE_RANK;
     }
 
     public EventFields toEventFields() {

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
@@ -214,7 +214,16 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
             .build()
             .toQuery();
 
-        SortOptions sortOption = new SortOptions.Builder()
+        // Keep the recurrence master (or a standalone event) as the representative document per uid:
+        // sort overridden occurrences (higher rank) after it before collapsing.
+        SortOptions collapseRankSort = new SortOptions.Builder()
+            .field(f -> f
+                .field(CalendarFields.COLLAPSE_RANK)
+                .order(SortOrder.Asc)
+                .missing(FieldValue.of(0L)))
+            .build();
+
+        SortOptions startSort = new SortOptions.Builder()
             .field(f -> f
                 .field(CalendarFields.START)
                 .order(SortOrder.Desc)
@@ -226,7 +235,9 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
             .from(query.offset())
             .size(query.limit())
             .query(openSearchQuery)
-            .sort(sortOption)
+            .sort(collapseRankSort)
+            .sort(startSort)
+            .collapse(collapse -> collapse.field(CalendarFields.EVENT_UID))
             .build();
 
         return Mono.fromCallable(() -> client.search(request))

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -41,6 +40,7 @@ import org.apache.james.util.ReactorUtils;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.Result;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
@@ -87,6 +87,8 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
                 .source("""
                         if (ctx._source.sequence == null || params.sequence > ctx._source.sequence) {
                             ctx._source.putAll(params.doc);
+                        } else {
+                            ctx.op = 'none';
                         }
                     """)
                 .params("sequence", JsonData.of(seq))
@@ -132,27 +134,38 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
             eventFields.recurrenceId().orElse(null)));
     }
 
+    private record IndexOutcome(EventFields event, Result result) {
+        boolean applied() {
+            return result != Result.NoOp;
+        }
+    }
+
     @Override
     public Mono<Void> index(CalendarEvents fields) {
         return doIndex(fields, INDEX_CHECK_SEQUENCE)
-            .then(deleteStaleOccurrences(fields));
+            .flatMap(outcomes -> {
+                if (masterApplied(outcomes)) {
+                    return deleteStaleOccurrences(fields);
+                }
+                return Mono.empty();
+            });
+    }
+
+    // The recurrence master carries the series version, so its upsert winning the sequence guard means the
+    // incoming message is newer than the indexed state. Only then may we prune occurrences; a reordered
+    // older message is a no-op on the master and must not remove occurrences it does not know about.
+    private boolean masterApplied(List<IndexOutcome> outcomes) {
+        return outcomes.stream()
+            .filter(outcome -> Boolean.TRUE.equals(outcome.event().isRecurrentMaster()))
+            .anyMatch(IndexOutcome::applied);
     }
 
     // Remove occurrence documents that are no longer part of the event (e.g. a deleted overridden
-    // occurrence). We only delete documents with a strictly older sequence than the current message and
-    // never the ones we just wrote, so a reordered older message cannot resurrect a stale state (see
-    // issue #895).
+    // occurrence). Staleness is decided by identity: any indexed document for this uid whose id (which
+    // encodes the recurrenceId) is absent from the newly written message is dropped. We never rely on
+    // SEQUENCE here because it is per-VEVENT, so a removed occurrence may legitimately carry a higher
+    // sequence than the master (see issue #895).
     private Mono<Void> deleteStaleOccurrences(CalendarEvents fields) {
-        OptionalInt sequenceThreshold = fields.events().stream()
-            .map(EventFields::sequence)
-            .flatMap(Optional::stream)
-            .mapToInt(Integer::intValue)
-            .max();
-
-        if (sequenceThreshold.isEmpty()) {
-            return Mono.empty();
-        }
-
         CalendarURL calendarURL = fields.calendarURL();
         List<String> writtenDocumentIds = fields.events().stream()
             .map(event -> buildDocumentIdForEvent(event.calendarURL(), event).asString())
@@ -163,11 +176,6 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
             .must(QueryBuilders.term()
                 .field(CalendarFields.EVENT_UID)
                 .value(FieldValue.of(fields.eventUid().value()))
-                .build()
-                .toQuery())
-            .must(QueryBuilders.range()
-                .field(CalendarFields.SEQUENCE)
-                .lt(JsonData.of(sequenceThreshold.getAsInt()))
                 .build()
                 .toQuery())
             .mustNot(QueryBuilders.ids()
@@ -185,20 +193,17 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
 
     @Override
     public Mono<Void> reindex(CalendarEvents fields) {
-        return doIndex(fields, !INDEX_CHECK_SEQUENCE);
+        return doIndex(fields, !INDEX_CHECK_SEQUENCE).then();
     }
 
-    private Mono<Void> doIndex(CalendarEvents fields, boolean checkSequence) {
-        if (fields.events().isEmpty()) {
-            return Mono.empty();
-        }
-
+    private Mono<List<IndexOutcome>> doIndex(CalendarEvents fields, boolean checkSequence) {
         return Flux.fromIterable(fields.events())
             .flatMap(event -> indexSingleEvent(event, checkSequence)
                     .onErrorResume(error -> Mono.error(CalendarSearchIndexingException.of("Failed to index calendar event",
-                        fields.calendarURL(), fields.eventUid(), error))),
+                        fields.calendarURL(), fields.eventUid(), error)))
+                    .map(response -> new IndexOutcome(event, response.result())),
                 ReactorUtils.DEFAULT_CONCURRENCY)
-            .then();
+            .collectList();
     }
 
     private Mono<WriteResponseBase> indexSingleEvent(EventFields eventFields,

--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -133,7 +134,53 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
 
     @Override
     public Mono<Void> index(CalendarEvents fields) {
-        return doIndex(fields, INDEX_CHECK_SEQUENCE);
+        return doIndex(fields, INDEX_CHECK_SEQUENCE)
+            .then(deleteStaleOccurrences(fields));
+    }
+
+    // Remove occurrence documents that are no longer part of the event (e.g. a deleted overridden
+    // occurrence). We only delete documents with a strictly older sequence than the current message and
+    // never the ones we just wrote, so a reordered older message cannot resurrect a stale state (see
+    // issue #895).
+    private Mono<Void> deleteStaleOccurrences(CalendarEvents fields) {
+        OptionalInt sequenceThreshold = fields.events().stream()
+            .map(EventFields::sequence)
+            .flatMap(Optional::stream)
+            .mapToInt(Integer::intValue)
+            .max();
+
+        if (sequenceThreshold.isEmpty()) {
+            return Mono.empty();
+        }
+
+        CalendarURL calendarURL = fields.calendarURL();
+        List<String> writtenDocumentIds = fields.events().stream()
+            .map(event -> buildDocumentIdForEvent(event.calendarURL(), event).asString())
+            .toList();
+
+        Query staleOccurrencesQuery = QueryBuilders.bool()
+            .must(calendarURLQuery(calendarURL))
+            .must(QueryBuilders.term()
+                .field(CalendarFields.EVENT_UID)
+                .value(FieldValue.of(fields.eventUid().value()))
+                .build()
+                .toQuery())
+            .must(QueryBuilders.range()
+                .field(CalendarFields.SEQUENCE)
+                .lt(JsonData.of(sequenceThreshold.getAsInt()))
+                .build()
+                .toQuery())
+            .mustNot(QueryBuilders.ids()
+                .values(writtenDocumentIds)
+                .build()
+                .toQuery())
+            .build()
+            .toQuery();
+
+        return indexer.deleteAllMatchingQuery(staleOccurrencesQuery, ROUTING_KEY.apply(calendarURL.base()))
+            .onErrorResume(error -> Mono.error(CalendarSearchIndexingException.of("Failed to delete stale calendar occurrences",
+                calendarURL, fields.eventUid(), error)))
+            .then();
     }
 
     @Override

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -4,6 +4,49 @@ This document describes breaking changes and migration steps required when upgra
 
 ## 2.4.0 (upcoming)
 
+### Collapse recurring event occurrences in the calendar event search index
+
+Date: 02/07/2026
+
+Recurring events are no longer deleted by `eventUid` before being re-indexed. Every occurrence (the master
+and its overridden occurrences) is now upserted as its own sequence-guarded document, and search results
+are collapsed on the event uid so that a recurring event is surfaced as a single representative document
+(see issue #895). This removes a race where the delete-before-index step bypassed the per-document sequence
+guard and could resurrect stale occurrences under concurrent or reordered messages.
+
+A new `collapseRank` field is added to the OpenSearch calendar event index. It is used as a sort key to keep
+the recurrence master (or a standalone event) as the representative when collapsing on the uid.
+
+#### Breaking Change
+
+Existing indexed documents do not contain `collapseRank`. Until they are reindexed, the collapse sort has
+no rank to order occurrences by, so an overridden occurrence may be surfaced as the representative instead of
+the master.
+
+#### Required Actions
+
+**1. Add the field to your existing index mapping:**
+
+```bash
+PUT /calendar_events/_mapping
+{
+  "properties": {
+    "collapseRank": {
+      "type": "integer",
+      "index": false
+    }
+  }
+}
+```
+
+**2. Run a full reindex** so that all existing documents get a `collapseRank` value:
+
+```
+POST {webadminBaseURL}/calendars?task=reindex
+```
+
+**Note:** Replace `calendar_events` with your actual index name if different.
+
 ### Rebuilt calendar event search index around source calendars
 
 Date: 12/06/2026

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -14,18 +14,26 @@ are collapsed on the event uid so that a recurring event is surfaced as a single
 (see issue #895). This removes a race where the delete-before-index step bypassed the per-document sequence
 guard and could resurrect stale occurrences under concurrent or reordered messages.
 
+When an event is updated, occurrences that are no longer part of it (e.g. a deleted overridden occurrence)
+are pruned with a sequence-bounded delete-by-query: only documents with a strictly older `sequence` than the
+incoming message, and never the documents just written, are removed. A reordered older message therefore
+cannot resurrect a stale occurrence, and removed occurrences no longer linger in the index.
+
 A new `collapseRank` field is added to the OpenSearch calendar event index. It is used as a sort key to keep
-the recurrence master (or a standalone event) as the representative when collapsing on the uid.
+the recurrence master (or a standalone event) as the representative when collapsing on the uid. The existing
+`sequence` field is now indexed (`index: true`) so removed occurrences can be pruned by the sequence-bounded
+delete-by-query.
 
 #### Breaking Change
 
 Existing indexed documents do not contain `collapseRank`. Until they are reindexed, the collapse sort has
 no rank to order occurrences by, so an overridden occurrence may be surfaced as the representative instead of
-the master.
+the master. In addition, the `sequence` field must be indexed for the removed-occurrence pruning to match
+existing documents.
 
 #### Required Actions
 
-**1. Add the field to your existing index mapping:**
+**1. Add `collapseRank` and make `sequence` searchable in your existing index mapping:**
 
 ```bash
 PUT /calendar_events/_mapping
@@ -34,10 +42,17 @@ PUT /calendar_events/_mapping
     "collapseRank": {
       "type": "integer",
       "index": false
+    },
+    "sequence": {
+      "type": "integer",
+      "index": true
     }
   }
 }
 ```
+
+Changing `index` on an existing field is not always accepted by OpenSearch; if the mapping update is
+rejected, create a new index with the updated mapping and reindex into it.
 
 **2. Run a full reindex** so that all existing documents get a `collapseRank` value:
 

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -2,7 +2,7 @@
 
 This document describes breaking changes and migration steps required when upgrading to newer versions of Twake Calendar.
 
-## 2.4.0 (upcoming)
+## 2.4.3 (upcoming)
 
 ### Collapse recurring event occurrences in the calendar event search index
 

--- a/upgrade-instructions.md
+++ b/upgrade-instructions.md
@@ -24,16 +24,21 @@ the recurrence master (or a standalone event) as the representative when collaps
 `sequence` field is now indexed (`index: true`) so removed occurrences can be pruned by the sequence-bounded
 delete-by-query.
 
+A new `recurrenceId` field is also added (stored, non-indexed). It carries the `RECURRENCE-ID` of an
+overridden occurrence so that, when such an occurrence is surfaced by search, it keeps its own recurrence id
+instead of falling back to the master's.
+
 #### Breaking Change
 
-Existing indexed documents do not contain `collapseRank`. Until they are reindexed, the collapse sort has
-no rank to order occurrences by, so an overridden occurrence may be surfaced as the representative instead of
-the master. In addition, the `sequence` field must be indexed for the removed-occurrence pruning to match
+Existing indexed documents do not contain `collapseRank` or `recurrenceId`. Until they are reindexed, the
+collapse sort has no rank to order occurrences by, so an overridden occurrence may be surfaced as the
+representative instead of the master, and a surfaced overridden occurrence has no stored `recurrenceId` to
+return. In addition, the `sequence` field must be indexed for the removed-occurrence pruning to match
 existing documents.
 
 #### Required Actions
 
-**1. Add `collapseRank` and make `sequence` searchable in your existing index mapping:**
+**1. Add `collapseRank` and `recurrenceId`, and make `sequence` searchable in your existing index mapping:**
 
 ```bash
 PUT /calendar_events/_mapping
@@ -41,6 +46,10 @@ PUT /calendar_events/_mapping
   "properties": {
     "collapseRank": {
       "type": "integer",
+      "index": false
+    },
+    "recurrenceId": {
+      "type": "keyword",
       "index": false
     },
     "sequence": {


### PR DESCRIPTION
Closes #895

## Problem

When indexing a recurring event with overridden occurrences (`calendarEvents.events().size() > 1`), the consumer deleted every document by `eventUid` and then re-indexed them. That delete bypasses the per-document sequence guard: the `UPSERT_WITH_SEQUENCE_SCRIPT` only runs when the document already exists (`scriptedUpsert(false)`), so after a delete the upsert inserts the incoming document *verbatim* without any sequence check. Concurrent (`flatMap(..., DEFAULT_CONCURRENCY)`) or reordered messages could therefore resurrect a stale state, e.g. a `seq 10` message applied after `seq 11` wins.

## Fix

Implements the approach requested in the issue — treat a recurring event as a single, atomically-updated document from the search consumer's point of view, using **collapse on the uid keeping the master**:

- **Indexing** (`EventIndexerConsumer`): created and updated events now follow the same path — each occurrence (master and overridden occurrences) is upserted as its own **sequence-guarded** document. We no longer `delete` by `eventUid` before re-indexing, so the sequence guard is never bypassed and the reorder/resurrection window disappears.
- **Search** (`OpensearchCalendarSearchService`): results are **collapsed on `eventUid`**. A new non-indexed `collapseRank` field (master / standalone = `0`, overridden occurrence = `1`) is used as the primary sort key so the sequence-guarded master (or a standalone event) is kept as the representative document; the existing `start desc` sort is preserved as the secondary key. Stale/removed overridden occurrences are therefore never surfaced.
- `MemoryCalendarSearchService` mirrors the same collapse-on-uid / keep-master semantics so both implementations honour the shared contract.

## Behaviour change

A recurring event is now surfaced as a **single** search result (its master) instead of one result per occurrence. Contract and integration tests that asserted every occurrence were updated accordingly, and a new contract test (`indexingStaleRecurringMasterShouldNotDowngradeNewerOne`) guards the reorder scenario.

> Note: the OpenSearch and DAV integration tests require Docker and could not be executed in my environment; they were updated to reflect the new collapsed behaviour and rely on CI for validation.

---
*Generated automatically*
