### PR TITLE
ISSUE-904 SaaS: register provisioned user as a Domain Member regardless of user search mode

### DIFF
--- a/saas/saas-rabbitmq/src/main/java/com/linagora/calendar/saas/SaaSUserProvisioner.java
+++ b/saas/saas-rabbitmq/src/main/java/com/linagora/calendar/saas/SaaSUserProvisioner.java
@@ -27,12 +27,10 @@ import org.slf4j.LoggerFactory;
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.dav.AddressBookContact;
 import com.linagora.calendar.dav.CardDavClient;
-import com.linagora.calendar.storage.DomainSettingsResolver;
 import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
-import com.linagora.calendar.storage.UserSearchMode;
 
 import reactor.core.publisher.Mono;
 
@@ -42,17 +40,14 @@ public class SaaSUserProvisioner {
     private final OpenPaaSUserDAO userDAO;
     private final OpenPaaSDomainDAO domainDAO;
     private final CardDavClient cardDavClient;
-    private final DomainSettingsResolver domainSettingsResolver;
 
     @Inject
     public SaaSUserProvisioner(OpenPaaSUserDAO userDAO,
                                OpenPaaSDomainDAO domainDAO,
-                               CardDavClient cardDavClient,
-                               DomainSettingsResolver domainSettingsResolver) {
+                               CardDavClient cardDavClient) {
         this.userDAO = userDAO;
         this.domainDAO = domainDAO;
         this.cardDavClient = cardDavClient;
-        this.domainSettingsResolver = domainSettingsResolver;
     }
 
     public Mono<OpenPaaSUser> provisionUser(Username username) {
@@ -69,9 +64,7 @@ public class SaaSUserProvisioner {
 
     private Mono<Void> addUserToDomainAddressBook(OpenPaaSUser user) {
         return Mono.justOrEmpty(user.username().getDomainPart())
-            .flatMap(domain -> domainSettingsResolver.resolveUserSearchMode(domain)
-                .filter(mode -> mode != UserSearchMode.DISABLED)
-                .flatMap(ignored -> domainDAO.retrieve(domain))
+            .flatMap(domain -> domainDAO.retrieve(domain)
                 .flatMap(openPaaSDomain -> upsertUserContact(openPaaSDomain, user)));
     }
 

--- a/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/CalendarSettingUpdaterTest.java
+++ b/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/CalendarSettingUpdaterTest.java
@@ -24,12 +24,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.james.core.Username;
 import org.apache.james.mailbox.store.RandomMailboxSessionIdGenerator;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,8 +37,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.linagora.calendar.storage.DomainSettingsResolver;
-import com.linagora.calendar.storage.MemoryDomainSettingsDAO;
 import com.linagora.calendar.storage.MemoryOpenPaaSDomainDAO;
 import com.linagora.calendar.storage.MemoryOpenPaaSUserDAO;
 import com.linagora.calendar.storage.MemoryUserConfigurationDAO;
@@ -64,12 +60,11 @@ public class CalendarSettingUpdaterTest {
     void setup() {
         openPaaSUserDAO = new MemoryOpenPaaSUserDAO();
         userConfigurationDAO = new MemoryUserConfigurationDAO(openPaaSUserDAO);
-        // Disable user search for the test domain so the provisioner skips the (CardDav) address book step,
-        // keeping this an in-memory test. Auto-provisioning thus only creates the OpenPaaSUser.
-        DomainSettingsResolver domainSettingsResolver = new DomainSettingsResolver(
-            new MemoryDomainSettingsDAO(), Set.of(USER.getDomainPart().get()), Set.of(), new MapConfiguration(Map.of()));
+        // The test domain is not registered in the (in-memory) domain DAO, so the provisioner skips the
+        // (CardDav) address book step, keeping this an in-memory test. Auto-provisioning thus only creates
+        // the OpenPaaSUser.
         SaaSUserProvisioner userProvisioner = new SaaSUserProvisioner(openPaaSUserDAO,
-            new MemoryOpenPaaSDomainDAO(), null, domainSettingsResolver);
+            new MemoryOpenPaaSDomainDAO(), null);
         testee = new CalendarSettingUpdater(userConfigurationDAO, openPaaSUserDAO, userProvisioner, sessionProvider);
         openPaaSUserDAO.add(USER).block();
     }

--- a/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/SaaSUserSubscriptionHandlerTest.java
+++ b/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/SaaSUserSubscriptionHandlerTest.java
@@ -22,11 +22,8 @@ import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,8 +32,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.calendar.dav.CardDavClient;
 import com.linagora.calendar.dav.SabreDavExtension;
-import com.linagora.calendar.storage.DomainSettingsResolver;
-import com.linagora.calendar.storage.MemoryDomainSettingsDAO;
 import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
@@ -60,9 +55,7 @@ class SaaSUserSubscriptionHandlerTest {
         domainDAO = new MongoDBOpenPaaSDomainDAO(mongoDB);
         userDAO = new MongoDBOpenPaaSUserDAO(mongoDB, domainDAO);
         cardDavClient = new CardDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
-        DomainSettingsResolver domainSettingsResolver = new DomainSettingsResolver(
-            new MemoryDomainSettingsDAO(), Set.of(Domain.of("nonshared.tld")), Set.of(), new MapConfiguration(Map.of()));
-        testee = new SaaSUserSubscriptionHandler(new SaaSUserProvisioner(userDAO, domainDAO, cardDavClient, domainSettingsResolver));
+        testee = new SaaSUserSubscriptionHandler(new SaaSUserProvisioner(userDAO, domainDAO, cardDavClient));
         testDomain = createNewDomainWithAddressBook();
     }
 
@@ -177,7 +170,7 @@ class SaaSUserSubscriptionHandlerTest {
     }
 
     @Test
-    void shouldNotAddContactToAddressBookWhenNotSupportSharingForDomain() {
+    void shouldRegisterUserAsDomainMemberRegardlessOfUserSearchConfiguration() {
         OpenPaaSDomain nonSharedDomain = domainDAO.add(Domain.of("nonshared.tld")).block();
         cardDavClient.createDomainMembersAddressBook(nonSharedDomain.id()).block();
 
@@ -200,7 +193,7 @@ class SaaSUserSubscriptionHandlerTest {
         assertThat(user.username()).isEqualTo(Username.of(userEmail));
 
         String vcardContent = listContactDomainMembersAsVcard(nonSharedDomain);
-        assertThat(vcardContent).doesNotContain(userEmail);
+        assertThat(vcardContent).contains(userEmail);
     }
 
     private String listContactDomainMembersAsVcard(OpenPaaSDomain domain) {


### PR DESCRIPTION
Closes #904

## Problem

When a new user is created / provisioned through the SaaS flow (`SaaSUserProvisioner`, used both by the user subscription handler and the settings auto-provisioning), the user was only registered as a **domain member** (added to the `domain-members` CardDAV address book) when the domain's `UserSearchMode` was **not** `DISABLED`.

This meant users belonging to a domain with user search disabled were never registered as domain members, even though:

- **Search visibility is already enforced independently at query time** in `UserSearchProvider` and `ContactSearchProvider` (both short-circuit on `UserSearchMode.DISABLED`), so gating the membership registration on the search mode is redundant for search purposes.
- **The LDAP domain-members sync** (`LdapToDavDomainMembersSyncService`) already registers *every* member unconditionally, so the two provisioning paths were inconsistent.

## Fix

Register the provisioned user as a domain member regardless of the domain's user search mode. The `DomainSettingsResolver` dependency, only used for this gate, is removed from `SaaSUserProvisioner`.

## Tests

- `SaaSUserSubscriptionHandlerTest`: the former `shouldNotAddContactToAddressBookWhenNotSupportSharingForDomain` becomes `shouldRegisterUserAsDomainMemberRegardlessOfUserSearchConfiguration`, now asserting the user *is* added to the domain-members address book.
- `CalendarSettingUpdaterTest`: adjusted the in-memory setup (the test domain is simply not registered in the domain DAO, so the CardDAV step is skipped) to keep the auto-provisioning test hermetic.

---
*Generated automatically*
