### PR TITLE
ISSUE-899 Booking request acknowledgement email should give booking link details

### DIFF
--- a/app/src/main/resources/templates/event-booking-request-received/html.pug
+++ b/app/src/main/resources/templates/event-booking-request-received/html.pug
@@ -83,4 +83,12 @@ html
                                       else
                                         strong #{content.start.fullDateTime}&nbsp;#{translator.get('to')}&nbsp;#{content.end.fullDateTime}&nbsp;#{content.start.timezone}
                                         span .
+                                    p
+                                      strong #{translator.get('owner')}:&nbsp;
+                                      span(style='font-weight:500;') #{content.owner.cn}
+                                      span(style='color: #787878;') &nbsp;&lt;#{content.owner.email}&gt;
+                                    if (content.description)
+                                      p
+                                        strong #{translator.get('description')}:&nbsp;
+                                        span(style='white-space: pre-line;') #{content.description}
                                     p #{translator.get('organizer_notified')}

--- a/app/src/main/resources/templates/event-booking-request-received/translations/messages_en.properties
+++ b/app/src/main/resources/templates/event-booking-request-received/translations/messages_en.properties
@@ -3,4 +3,6 @@ request_received=Your booking request has been received
 registered_request_prefix=We have registered your booking request on
 from=from
 to=to
+owner=Owner
+description=Description
 organizer_notified=The organizer was notified about it and will validate it in a timely manner.

--- a/app/src/main/resources/templates/event-booking-request-received/translations/messages_fr.properties
+++ b/app/src/main/resources/templates/event-booking-request-received/translations/messages_fr.properties
@@ -3,4 +3,6 @@ request_received=Votre demande de réservation a été reçue
 registered_request_prefix=Nous avons enregistré votre demande de réservation le
 from=de
 to=à
+owner=Propriétaire
+description=Description
 organizer_notified=L'organisateur en a été informé et la validera dans les meilleurs délais.

--- a/app/src/main/resources/templates/event-booking-request-received/translations/messages_ru.properties
+++ b/app/src/main/resources/templates/event-booking-request-received/translations/messages_ru.properties
@@ -3,4 +3,6 @@ request_received=Ваш запрос бронирования получен
 registered_request_prefix=Мы зарегистрировали ваш запрос бронирования на
 from=с
 to=до
+owner=Владелец
+description=Описание
 organizer_notified=Организатор был уведомлен и подтвердит его в установленные сроки.

--- a/app/src/main/resources/templates/event-booking-request-received/translations/messages_vi.properties
+++ b/app/src/main/resources/templates/event-booking-request-received/translations/messages_vi.properties
@@ -3,4 +3,6 @@ request_received=Yêu cầu đặt lịch của bạn đã được ghi nhận
 registered_request_prefix=Chúng tôi đã ghi nhận yêu cầu đặt lịch của bạn vào
 from=từ
 to=đến
+owner=Chủ sở hữu
+description=Mô tả
 organizer_notified=Người tổ chức đã được thông báo và sẽ xác nhận yêu cầu trong thời gian phù hợp.

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -367,8 +367,12 @@ class BookingLinkReservationRouteTest {
 
     @Test
     void shouldSendAcknowledgementEmailToBookerWhenBookingCreated(TwakeCalendarGuiceServer server) {
-        // Given: an active booking link with an available slot.
-        BookingLink inserted = insertActiveBookingLink(server);
+        // Given: an active booking link with a description and an available slot.
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(
+            CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES, BookingLinkInsertRequest.ACTIVE,
+            Optional.of(AVAILABILITY_RULE), Optional.of("Intro call"), Optional.of("A short call to get to know each other"));
+        BookingLink inserted = server.getProbe(BookingLinkProbe.class)
+            .insert(openPaaSUser.username(), insertRequest);
         String slotStartUtc = getAvailableSlots(inserted.publicId()).getFirst();
 
         // When: an unauthenticated booker submits a booking request with custom content.
@@ -413,6 +417,10 @@ class BookingLinkReservationRouteTest {
                 .contains("We have registered your booking request on")
                 .contains("The organizer was notified about it and will validate it in a timely manner.")
                 .contains("<strong>Saturday, 26 January 2036");
+            softly.assertThat(html)
+                .contains(openPaaSUser.fullName())
+                .contains(openPaaSUser.username().asString())
+                .contains("A short call to get to know each other");
             softly.assertThat(html)
                 .doesNotContain("Please call via Zoom.");
         });

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkRequestAcknowledgementNotifier.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkRequestAcknowledgementNotifier.java
@@ -117,14 +117,25 @@ public class BookingLinkRequestAcknowledgementNotifier {
         String CONTENT = "content";
         String START = "start";
         String END = "end";
+        String OWNER = "owner";
+        String OWNER_NAME = "cn";
+        String OWNER_EMAIL = "email";
+        String DESCRIPTION = "description";
 
         static Map<String, Object> toPugModel(BookingCreated bookingCreated, Locale locale, ZoneId zoneId) {
             ZonedDateTime start = ZonedDateTime.ofInstant(bookingCreated.request().slotStartUtc(), zoneId);
             ZonedDateTime end = start.plus(bookingCreated.bookingLink().duration());
 
-            return ImmutableMap.of(CONTENT, ImmutableMap.of(
-                    START, new EventTimeModel(start).toPugModel(locale, zoneId),
-                    END, new EventTimeModel(end).toPugModel(locale, zoneId)));
+            ImmutableMap.Builder<String, Object> content = ImmutableMap.<String, Object>builder()
+                .put(START, new EventTimeModel(start).toPugModel(locale, zoneId))
+                .put(END, new EventTimeModel(end).toPugModel(locale, zoneId))
+                .put(OWNER, ImmutableMap.of(
+                    OWNER_NAME, bookingCreated.organizer().fullName(),
+                    OWNER_EMAIL, bookingCreated.organizer().username().asString()));
+            bookingCreated.bookingLink().description()
+                .ifPresent(description -> content.put(DESCRIPTION, description));
+
+            return ImmutableMap.of(CONTENT, content.build());
         }
     }
 }


### PR DESCRIPTION
Closes #899

The "Booking request received" acknowledgement email (sent to the booker when a reservation is registered on a non auto-accept booking link) previously only showed the requested time slot. It now also includes the booking link details requested in the issue:

- **Owner**: the booking link owner name and email address
- **Booking link description**: rendered only when the booking link has a description

## Changes
- `BookingLinkRequestAcknowledgementNotifier`: enriched the Pug model with `owner` (name + email, from the resolved organizer) and the optional booking link `description`.
- `event-booking-request-received/html.pug`: render the owner block and, when present, the description.
- Added `owner` / `description` translation keys for `en`, `fr`, `ru`, `vi`.
- Extended `BookingLinkReservationRouteTest#shouldSendAcknowledgementEmailToBookerWhenBookingCreated` to book a link carrying a description and assert the owner name, owner email and description appear in the email.

## Tests
`BookingLinkReservationRouteTest#shouldSendAcknowledgementEmailToBookerWhenBookingCreated` passes.

---
*Generated automatically*
