### PR TITLE
fix(rest-api): reject user email without domain

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TwakeCalendarGuiceServerTest.java
@@ -1090,6 +1090,20 @@ class TwakeCalendarGuiceServerTest  {
     }
 
     @Test
+    void userByEmailEndpointShouldRejectEmailWithoutDomainPart(TwakeCalendarGuiceServer server) {
+        targetRestAPI(server);
+
+        given()
+            .auth().preemptive().basic(USERNAME.asString(), PASSWORD)
+            .queryParam("email", "user1")
+        .when()
+            .get("/api/users")
+        .then()
+            .statusCode(400)
+            .body("error.details", is("'email' query parameter must contain a domain part"));
+    }
+
+    @Test
     void userByEmailEndpointShouldProvisionMissingUsers(TwakeCalendarGuiceServer server) {
         targetRestAPI(server);
         Username username = Username.of("to-be-provisionned@linagora.com");

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/UsersRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/UsersRoute.java
@@ -23,6 +23,7 @@ import static com.linagora.calendar.restapi.routes.AvatarRoute.extractEmail;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
+import org.apache.james.core.Domain;
 import org.apache.james.core.Username;
 import org.apache.james.jmap.Endpoint;
 import org.apache.james.jmap.http.Authenticator;
@@ -84,12 +85,16 @@ public class UsersRoute extends CalendarRoute {
     @Override
     Mono<Void> handleRequest(HttpServerRequest request, HttpServerResponse response, MailboxSession session) {
         Username queryUsername = Username.of(extractEmail(request));
-        if (crossDomainAccess(session, queryUsername.getDomainPart().get())) {
+        if (queryUsername.getDomainPart().isEmpty()) {
+            return ErrorResponseHandler.handle(response, HttpResponseStatus.BAD_REQUEST, "'email' query parameter must contain a domain part");
+        }
+        Domain queryDomain = queryUsername.getDomainPart().get();
+        if (crossDomainAccess(session, queryDomain)) {
             return respondWithEmptyResult(response);
         }
         return userDAO.retrieve(queryUsername)
             .switchIfEmpty(provisionUser(queryUsername))
-            .flatMap(user -> Mono.zip(domainDAO.retrieve(user.username().getDomainPart().get()),
+            .flatMap(user -> Mono.zip(domainDAO.retrieve(queryDomain),
                     settingsResolver.resolveOrDefault(user.username()))
                 .map(tuple -> {
                     OpenPaaSDomain domain = tuple.getT1();


### PR DESCRIPTION
## Why
Previously, `UsersRoute` called `queryUsername.getDomainPart().get()` without checking whether the optional domain part was present. An email query value without a domain part could therefore trigger a `NoSuchElementException`. The route now responds with a clear client error instead.
