### PR TITLE
ISSUE-909 Add logback-jackson dependency for JacksonJsonFormatter

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -181,6 +181,10 @@
         </dependency>
         <dependency>
             <groupId>com.linagora.tmail</groupId>
+            <artifactId>logback-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.linagora.tmail</groupId>
             <artifactId>logback-json-classic</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Closes #909

## Problem

At startup, Logback emits:

```
Could not create component [jsonFormatter] of type [ch.qos.logback.contrib.jackson.JacksonJsonFormatter]
java.lang.ClassNotFoundException: ch.qos.logback.contrib.jackson.JacksonJsonFormatter
```

The production `logback.xml` configures a `jsonFormatter` of type `ch.qos.logback.contrib.jackson.JacksonJsonFormatter`, but that class was not present on the `app` module runtime classpath. The application kept running but the error was noisy and Logback fell back to the default `JsonLayout` formatter.

## Fix

Add the `com.linagora.tmail:logback-jackson` dependency (version managed via the imported BOM) to the `app` module, which provides `JacksonJsonFormatter` and pulls in `logback-json-core`. Verified via `dependency:tree` that the artifact resolves.

---
*Generated automatically*
