### PR TITLE
ISSUE-914 Enforce (and test) booking slot availability without availability rules

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -836,6 +836,70 @@ class BookingLinkReservationRouteTest {
     }
 
     @Test
+    void shouldReturnUnprocessableEntityWhenRequestedSlotIsBusyAndAvailabilityRulesAreEmpty(TwakeCalendarGuiceServer server) {
+        // Given: a booking link without availability rules. Such a link is "effectively open"
+        // (any 30-minute aligned slot is bookable), but busy intervals must still be honoured.
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(
+            CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
+            BookingLinkInsertRequest.ACTIVE, Optional.empty());
+        BookingLink inserted = server.getProbe(BookingLinkProbe.class)
+            .insert(openPaaSUser.username(), insertRequest);
+
+        // - Calendar already has an opaque busy event in range [09:30, 10:00] UTC.
+        String busyEventUid = UUID.randomUUID().toString();
+        davTestHelper.upsertCalendar(openPaaSUser, """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Twake//BookingReservationTest//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20360101T000000Z
+            DTSTART:20360126T093000Z
+            DTEND:20360126T100000Z
+            SUMMARY:busy-window
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(busyEventUid), busyEventUid);
+
+        // When: booking the exact busy slot on a link with no availability rules.
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body(bodyRequest("2036-01-26T09:30:00Z"))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
+            .contentType(JSON)
+            .body("error", jsonEquals("""
+                {
+                  "code": 422,
+                  "message": "Unprocessable Entity",
+                  "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc 2036-01-26T09:30:00Z"
+                }
+                """.formatted(inserted.publicId().value())));
+    }
+
+    @Test
+    void shouldCreateBookingWhenSlotIsFreeAndAvailabilityRulesAreEmpty(TwakeCalendarGuiceServer server) {
+        // Given: a booking link without availability rules and a free (non-busy) aligned slot.
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(
+            CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
+            BookingLinkInsertRequest.ACTIVE, Optional.empty());
+        BookingLink inserted = server.getProbe(BookingLinkProbe.class)
+            .insert(openPaaSUser.username(), insertRequest);
+
+        // When/Then: booking a free aligned slot succeeds (empty rules are effectively open).
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body(bodyRequest("2036-01-26T09:30:00Z"))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+    }
+
+    @Test
     void shouldReturnBadRequestWhenRequestBodyIsInvalidJson(TwakeCalendarGuiceServer server) {
         BookingLink inserted = insertActiveBookingLink(server);
 


### PR DESCRIPTION
Closes #914

## Context

The question raised by #914 was whether a hand-crafted `curl` could book an arbitrary date through a booking link. As established in the analysis on the issue, the slot is validated server-side: `BookingLinkReservationService.book()` calls `validateSlotAvailability()` before creating the event, and the requested `startUtc` must exactly match one of the server-computed `AvailabilitySlot`s.

## What this PR addresses

The remaining point flagged by the maintainer was the "empty availability rules" case:

> I am ok with this semantic but we need anyway to check availability.

Reviewing the code, this is already the case: `BookingLinkSlotsService.retrieveUnavailableTimeRanges()` always queries CalDAV busy intervals and subtracts them, **independently of whether availability rules are configured**. So a link with no availability rules is "effectively open" (any 30-minute aligned slot is bookable), but busy intervals are still honoured — a busy slot cannot be double-booked.

Since the behaviour is correct but was not covered by tests, this PR adds two regression tests on `BookingLinkReservationRouteTest`:

- `shouldReturnUnprocessableEntityWhenRequestedSlotIsBusyAndAvailabilityRulesAreEmpty`: booking a busy slot on a rules-less link is rejected with `422`.
- `shouldCreateBookingWhenSlotIsFreeAndAvailabilityRulesAreEmpty`: booking a free aligned slot on a rules-less link succeeds with `201`.

No separate GitHub issue seems warranted for the empty-rules case: availability (busy-interval) checking already applies, and these tests now guard that invariant.

Out of scope (tracked elsewhere): past / minimum-notice validation (#913) and rate-limiting the public endpoint (#622).

Tests pass locally (`Tests run: 2, Failures: 0`).

---
*Generated automatically*
