### PR TITLE
ISSUE-832 feat(webadmin): add team calendar member route

### DIFF
--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import javax.net.ssl.SSLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.james.core.Username;
@@ -49,6 +50,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.CalendarUtil;
+import com.linagora.calendar.dav.dto.CalendarDetailsResponse;
 import com.linagora.calendar.dav.dto.CalendarListResponse;
 import com.linagora.calendar.dav.dto.CalendarReportJsonResponse;
 import com.linagora.calendar.dav.dto.CalendarReportXmlResponse;
@@ -128,8 +130,20 @@ public class CalDavClient extends DavClient {
                                 @JsonProperty("dav:read") Optional<Boolean> read,
                                 @JsonProperty("dav:read-write") Optional<Boolean> readWrite,
                                 @JsonProperty("dav:administration") Optional<Boolean> administration) {
+            public static AddSharee read(String davHref) {
+                return new AddSharee(davHref, Optional.of(true), Optional.empty(), Optional.empty());
+            }
+
+            public static AddSharee readWrite(String davHref) {
+                return new AddSharee(davHref, Optional.empty(), Optional.of(true), Optional.empty());
+            }
+
+            public static AddSharee administration(String davHref) {
+                return new AddSharee(davHref, Optional.empty(), Optional.empty(), Optional.of(true));
+            }
+
             public AddSharee {
-                Preconditions.checkArgument(StringUtils.startsWith(davHref, MAILTO_PREFIX),
+                Preconditions.checkArgument(Strings.CI.startsWith(davHref, MAILTO_PREFIX),
                     "'dav:href' must be a '" + MAILTO_PREFIX + "' URI");
                 Preconditions.checkArgument(read.isPresent() || readWrite.isPresent() || administration.isPresent(),
                     "One of 'dav:read', 'dav:read-write', 'dav:administration' must be provided");
@@ -138,7 +152,7 @@ public class CalDavClient extends DavClient {
 
         public record RemoveSharee(@JsonProperty("dav:href") String davHref) {
             public RemoveSharee {
-                Preconditions.checkArgument(StringUtils.startsWith(davHref, MAILTO_PREFIX),
+                Preconditions.checkArgument(Strings.CI.startsWith(davHref, MAILTO_PREFIX),
                     "'dav:href' must be a '" + MAILTO_PREFIX + "' URI");
             }
         }
@@ -270,6 +284,39 @@ public class CalDavClient extends DavClient {
                         %s
                         """.formatted(response.status().code(), userId.value(), errorBody))));
             });
+    }
+
+    public Mono<CalendarDetailsResponse> fetchCalendarDetails(Mono<HttpClient> httpClientPublisher,
+                                                              CalendarURL calendarURL,
+                                                              Map<String, String> queryParams) {
+        Preconditions.checkArgument(httpClientPublisher != null, "httpClientPublisher must not be null");
+        Preconditions.checkArgument(calendarURL != null, "calendarURL must not be null");
+        Preconditions.checkArgument(queryParams != null, "queryParams must not be null");
+
+        URIBuilder uriBuilder = new URIBuilder().setPath(calendarURL.asUri().getPath());
+        queryParams.forEach(uriBuilder::addParameter);
+
+        return httpClientPublisher.flatMap(client -> client
+            .headers(headers -> headers.add(HttpHeaderNames.ACCEPT, CONTENT_TYPE_JSON))
+            .request(HttpMethod.GET)
+            .uri(uriBuilder.toString())
+            .responseSingle((response, responseContent) -> switch (response.status().code()) {
+                case HttpStatus.SC_OK -> responseContent.asByteArray()
+                    .map(CalendarDetailsResponse::parse);
+                case HttpStatus.SC_NOT_FOUND -> Mono.error(new CalendarNotFoundException(calendarURL));
+                default -> responseBodyAsString(responseContent)
+                    .flatMap(errorBody -> Mono.error(new DavClientException("""
+                        Unexpected status code: %d while retrieving calendar '%s'
+                        Response body:
+                        %s
+                        """.formatted(response.status().code(), calendarURL.asUri(), errorBody))));
+            }));
+    }
+
+    public Mono<CalendarDetailsResponse> fetchCalendarDetails(OpenPaaSId domainId,
+                                                              CalendarURL calendarURL,
+                                                              Map<String, String> queryParams) {
+        return fetchCalendarDetails(httpClientWithTechnicalToken(domainId), calendarURL, queryParams);
     }
 
     public Flux<String> findUserCalendarEventIds(Username username, CalendarURL calendarURL) {
@@ -558,8 +605,18 @@ public class CalDavClient extends DavClient {
      * {@code {"share":{"set":[{"dav:href":"mailto:...","dav:read":true}],"remove":[{"dav:href":"mailto:..."}]}}}
      */
     public Mono<Void> updateCalendarShares(Username username, CalendarURL calendarURL, CalendarSharingUpdate sharingUpdate) {
+        return updateCalendarShares(Mono.just(httpClientWithImpersonation(username)), calendarURL, sharingUpdate);
+    }
+
+    public Mono<Void> updateCalendarShares(OpenPaaSId domainId, CalendarURL calendarURL, CalendarSharingUpdate sharingUpdate) {
+        return updateCalendarShares(httpClientWithTechnicalToken(domainId), calendarURL, sharingUpdate);
+    }
+
+    public Mono<Void> updateCalendarShares(Mono<HttpClient> httpClientPublisher,
+                                           CalendarURL calendarURL,
+                                           CalendarSharingUpdate sharingUpdate) {
         String uri = calendarURL.asUri() + ".json";
-        return httpClientWithImpersonation(username)
+        return httpClientPublisher.flatMap(client -> client
             .headers(headers -> headers.add(HttpHeaderNames.CONTENT_TYPE, JSON_CHARSET_UTF_8)
                 .add(HttpHeaderNames.ACCEPT, DEFAULT_JSON_ACCEPT))
             .request(HttpMethod.POST)
@@ -573,7 +630,7 @@ public class CalDavClient extends DavClient {
                         Unexpected status code: %d when updating shares of calendar '%s'
                         %s
                         """.formatted(response.status().code(), uri, errorBody))));
-            });
+            }));
     }
 
     /**

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/dto/CalendarDetailsResponse.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/dto/CalendarDetailsResponse.java
@@ -1,0 +1,70 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav.dto;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Streams;
+import com.linagora.calendar.dav.DavClientException;
+
+public record CalendarDetailsResponse(List<CalendarDetailsResponse.CalendarInvite> invites) {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static CalendarDetailsResponse parse(byte[] payload) {
+        try {
+            JsonNode inviteNode = OBJECT_MAPPER.readTree(payload).path("invite");
+            if (!inviteNode.isArray()) {
+                return new CalendarDetailsResponse(List.of());
+            }
+
+            List<CalendarInvite> invites = Streams.stream(inviteNode.elements())
+                .filter(node -> StringUtils.isNotBlank(node.path("href").asText(null)))
+                .map(CalendarDetailsResponse::parseInvite)
+                .toList();
+
+            return new CalendarDetailsResponse(invites);
+        } catch (Exception e) {
+            throw new DavClientException("Failed to parse calendar details response", e);
+        }
+    }
+
+    private static CalendarInvite parseInvite(JsonNode node) {
+        Optional<String> principal = Optional.ofNullable(node.path("principal").asText(null))
+            .filter(StringUtils::isNotBlank);
+        Optional<Integer> access = Optional.ofNullable(node.get("access"))
+            .filter(JsonNode::isInt)
+            .map(JsonNode::asInt);
+        return new CalendarInvite(node.path("href").asText(), principal, access);
+    }
+
+    public record CalendarInvite(String href,
+                                 Optional<String> principal,
+                                 Optional<Integer> access) {
+        public CalendarInvite {
+            Preconditions.checkArgument(StringUtils.isNotBlank(href), "'href' field is required");
+        }
+    }
+}

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
@@ -50,6 +51,7 @@ import com.linagora.calendar.dav.CalDavClient.CalendarPropertiesUpdate;
 import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
 import com.linagora.calendar.dav.CalDavClient.NewCalendar;
 import com.linagora.calendar.dav.FreeBusyQueryResponseObject.BusyInterval;
+import com.linagora.calendar.dav.dto.CalendarDetailsResponse;
 import com.linagora.calendar.dav.dto.CalendarReportJsonResponse;
 import com.linagora.calendar.dav.dto.CalendarReportXmlResponse;
 import com.linagora.calendar.dav.dto.CalendarReportXmlResponse.CalendarObject;
@@ -93,6 +95,14 @@ public class CalDavClientTest {
 
     private OpenPaaSUser createOpenPaaSUser() {
         return sabreDavExtension.newTestUser();
+    }
+
+    private OpenPaaSId retrieveDefaultDomainId() {
+        return sabreDavExtension.dockerSabreDavSetup()
+            .getOpenPaaSProvisioningService()
+            .getDomain()
+            .map(OpenPaaSDomain::id)
+            .block();
     }
 
     @Test
@@ -274,6 +284,29 @@ public class CalDavClientTest {
 
         assertThatThrownBy(() -> testee.findUserCalendars(user.username(), new OpenPaaSId("invalid")).collectList().block())
             .isInstanceOf(DavClientException.class);
+    }
+
+    @Test
+    void fetchCalendarDetailsShouldReturnCalendarDetails() {
+        OpenPaaSUser owner = createOpenPaaSUser();
+        OpenPaaSUser delegate = createOpenPaaSUser();
+        String calendarId = UUID.randomUUID().toString();
+        CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
+        String delegateMailto = "mailto:" + delegate.username().asString();
+        CalendarSharingUpdate sharingUpdate = new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
+            List.of(CalendarSharingUpdate.AddSharee.readWrite(delegateMailto)),
+            List.of()));
+
+        testee.createNewCalendar(owner.username(), owner.id(), new NewCalendar(calendarId, "Shared calendar", "#0000FF", "")).block();
+        testee.updateCalendarShares(owner.username(), calendarURL, sharingUpdate).block();
+
+        CalendarDetailsResponse response = testee.fetchCalendarDetails(retrieveDefaultDomainId(), calendarURL, Map.of("withRights", "true")).block();
+
+        assertThat(response.invites())
+            .anySatisfy(invite -> {
+                assertThat(invite.href()).isEqualTo(delegateMailto);
+                assertThat(invite.access()).contains(3);
+            });
     }
 
     @Test

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/dto/CalendarDetailsResponseTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/dto/CalendarDetailsResponseTest.java
@@ -1,0 +1,88 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.linagora.calendar.dav.DavClientException;
+import com.linagora.calendar.dav.dto.CalendarDetailsResponse.CalendarInvite;
+
+class CalendarDetailsResponseTest {
+
+    @Test
+    void parseShouldExtractInvites() {
+        CalendarDetailsResponse response = CalendarDetailsResponse.parse("""
+            {
+              "invite": [
+                {
+                  "href": "principals/team-calendars/team-calendar-id",
+                  "principal": "principals/team-calendars/team-calendar-id",
+                  "access": 1
+                },
+                {
+                  "href": "mailto:alice@linagora.com",
+                  "principal": "principals/users/alice-id",
+                  "access": 2
+                },
+                {
+                  "href": "mailto:bob@linagora.com",
+                  "principal": "principals/users/bob-id",
+                  "access": 3
+                }
+              ]
+            }
+            """.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(response.invites()).containsExactly(
+            new CalendarInvite("principals/team-calendars/team-calendar-id", Optional.of("principals/team-calendars/team-calendar-id"), Optional.of(1)),
+            new CalendarInvite("mailto:alice@linagora.com", Optional.of("principals/users/alice-id"), Optional.of(2)),
+            new CalendarInvite("mailto:bob@linagora.com", Optional.of("principals/users/bob-id"), Optional.of(3)));
+    }
+
+    @Test
+    void parseShouldReturnEmptyWhenInviteIsMissing() {
+        CalendarDetailsResponse response = CalendarDetailsResponse.parse("""
+            {"dav:name":"Team calendar"}
+            """.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(response.invites()).isEmpty();
+    }
+
+    @Test
+    void parseShouldReturnEmptyWhenInviteIsNotAnArray() {
+        CalendarDetailsResponse response = CalendarDetailsResponse.parse("""
+            {"invite":{}}
+            """.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(response.invites()).isEmpty();
+    }
+
+    @Test
+    void parseShouldThrowWhenPayloadIsInvalid() {
+        assertThatThrownBy(() -> CalendarDetailsResponse.parse("invalid".getBytes(StandardCharsets.UTF_8)))
+            .isInstanceOf(DavClientException.class)
+            .hasMessage("Failed to parse calendar details response");
+    }
+}

--- a/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
+++ b/calendar-dav/src/test/resources/docker-sabre-dav-setup.yml
@@ -47,7 +47,7 @@ services:
 
   sabre_dav:
     hostname: esn_sabre
-    image: linagora/esn-sabre:2.4.1
+    image: linagora/esn-sabre:2.4.3.2
     environment:
       - SABRE_ENV=dev
       - SABRE_MONGO_HOST=mongo

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/CalendarRoutesModule.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/CalendarRoutesModule.java
@@ -54,6 +54,7 @@ public class CalendarRoutesModule extends AbstractModule {
         routesMultibinder.addBinding().to(CalendarRoutes.class);
         routesMultibinder.addBinding().to(ResourceRoutes.class);
         routesMultibinder.addBinding().to(TeamCalendarRoutes.class);
+        routesMultibinder.addBinding().to(TeamCalendarMemberRoutes.class);
         routesMultibinder.addBinding().to(DomainAdminRoutes.class);
         routesMultibinder.addBinding().to(DomainRegisteredUsersRoutes.class);
         routesMultibinder.addBinding().to(DomainSettingsRoutes.class);

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/TeamCalendarMemberRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/TeamCalendarMemberRoutes.java
@@ -1,0 +1,223 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the    *
+ *  GNU Affero General Public License for more details.             *
+ ********************************************************************/
+
+package com.linagora.calendar.webadmin;
+
+import static org.apache.james.webadmin.Constants.SEPARATOR;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import jakarta.inject.Inject;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.webadmin.Constants;
+import org.apache.james.webadmin.Routes;
+import org.apache.james.webadmin.utils.ErrorResponder;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.eclipse.jetty.http.HttpStatus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.base.Preconditions;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.AddSharee;
+import com.linagora.calendar.dav.DavClientException;
+import com.linagora.calendar.storage.MailtoUri;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.TeamCalendarNotFoundException;
+import com.linagora.calendar.storage.exception.DomainNotFoundException;
+import com.linagora.calendar.storage.model.TeamCalendarId;
+import com.linagora.calendar.webadmin.service.TeamCalendarMemberService;
+import com.linagora.calendar.webadmin.service.TeamCalendarMemberService.TeamCalendarMember;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import spark.Request;
+import spark.Response;
+import spark.Service;
+
+public class TeamCalendarMemberRoutes implements Routes {
+    public static final String BASE_PATH = "domains";
+
+    private static final String DOMAIN_PARAM = ":domain";
+    private static final String TEAM_CALENDAR_ID_PARAM = ":teamCalendarId";
+    private static final String MEMBERS_PATH = BASE_PATH + SEPARATOR + DOMAIN_PARAM
+        + SEPARATOR + "team-calendars"
+        + SEPARATOR + TEAM_CALENDAR_ID_PARAM
+        + SEPARATOR + "members";
+    private static final Predicate<Optional<Boolean>> ENABLED_DAV_RIGHT = right -> right.orElse(false);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
+
+    public record TeamCalendarMemberResponse(String username, String role, String davRight) {
+        static TeamCalendarMemberResponse from(TeamCalendarMember member) {
+            return new TeamCalendarMemberResponse(member.username().asString(),
+                member.role().value(),
+                member.role().davRight());
+        }
+    }
+
+    private record TeamCalendarPathParameters(Domain domain, TeamCalendarId id) {
+    }
+
+    private final TeamCalendarService teamCalendarService;
+    private final TeamCalendarMemberService teamCalendarMemberService;
+    private final OpenPaaSUserDAO userDAO;
+    private final JsonTransformer jsonTransformer;
+
+    @Inject
+    public TeamCalendarMemberRoutes(TeamCalendarService teamCalendarService,
+                                    TeamCalendarMemberService teamCalendarMemberService,
+                                    OpenPaaSUserDAO userDAO,
+                                    JsonTransformer jsonTransformer) {
+        this.teamCalendarService = teamCalendarService;
+        this.teamCalendarMemberService = teamCalendarMemberService;
+        this.userDAO = userDAO;
+        this.jsonTransformer = jsonTransformer;
+    }
+
+    @Override
+    public String getBasePath() {
+        return BASE_PATH;
+    }
+
+    @Override
+    public void define(Service service) {
+        service.get(MEMBERS_PATH, this::list, jsonTransformer);
+        service.post(MEMBERS_PATH + SEPARATOR + "invitee", this::updateInvitees);
+    }
+
+    private List<TeamCalendarMemberResponse> list(Request request, Response response) {
+        List<TeamCalendarMemberResponse> members = Mono.fromCallable(() -> new TeamCalendarPathParameters(
+                parseDomain(request),
+                parseTeamCalendarId(request)))
+            .flatMapMany(parameters -> teamCalendarService.retrieve(parameters.domain(), parameters.id())
+                .flatMapMany(teamCalendar -> teamCalendarMemberService.list(teamCalendar.domainId(), teamCalendar.id())))
+            .map(TeamCalendarMemberResponse::from)
+            .collectList()
+            .onErrorMap(this::mapExceptionsErrors)
+            .block();
+        response.status(HttpStatus.OK_200);
+        return members;
+    }
+
+    private String updateInvitees(Request request, Response response) {
+        Mono.fromCallable(() -> new TeamCalendarPathParameters(
+                parseDomain(request),
+                parseTeamCalendarId(request)))
+            .flatMap(parameters -> {
+                CalendarSharingUpdate sharingUpdate = parseBody(request, CalendarSharingUpdate.class);
+                return teamCalendarService.retrieve(parameters.domain(), parameters.id())
+                    .flatMap(teamCalendar -> validateAddSharees(parameters.domain(), sharingUpdate.share().set())
+                        .then(teamCalendarMemberService.update(teamCalendar.domainId(), teamCalendar.id(), sharingUpdate)));
+            })
+            .onErrorMap(this::mapExceptionsErrors)
+            .block();
+        response.status(HttpStatus.NO_CONTENT_204);
+        return Constants.EMPTY_BODY;
+    }
+
+    private Mono<Void> validateAddSharees(Domain domain, List<AddSharee> sharees) {
+        return Flux.fromIterable(sharees)
+            .flatMap(sharee -> {
+                validateSingleDavRight(sharee);
+                Username username = parseMemberUsername(domain, sharee.davHref());
+                return userDAO.retrieve(username)
+                    .switchIfEmpty(Mono.error(() -> new IllegalArgumentException("Candidate member not found: " + username.asString())))
+                    .then();
+            })
+            .then();
+    }
+
+    private void validateSingleDavRight(AddSharee sharee) {
+        long enabledRights = Stream.of(sharee.read(), sharee.readWrite(), sharee.administration())
+            .filter(ENABLED_DAV_RIGHT)
+            .count();
+        Preconditions.checkArgument(enabledRights == 1, "Exactly one of 'dav:read', 'dav:read-write', 'dav:administration' must be true");
+    }
+
+    private Username parseMemberUsername(Domain domain, String davHref) {
+        Username username = Username.of(MailtoUri.stripMailtoPrefix(davHref));
+        Optional<Domain> memberDomain = username.getDomainPart();
+        Preconditions.checkArgument(memberDomain.isPresent(), "Member username must contain a domain");
+        Preconditions.checkArgument(domain.equals(memberDomain.get()), "Member must belong to domain: %s", domain.asString());
+        return username;
+    }
+
+    private Domain parseDomain(Request request) {
+        String domainName = request.params(DOMAIN_PARAM);
+        try {
+            return Domain.of(domainName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid domain: " + domainName, e);
+        }
+    }
+
+    private TeamCalendarId parseTeamCalendarId(Request request) {
+        return new TeamCalendarId(request.params(TEAM_CALENDAR_ID_PARAM));
+    }
+
+    private <T> T parseBody(Request request, Class<T> type) {
+        try {
+            return OBJECT_MAPPER.readValue(request.bodyAsBytes(), type);
+        } catch (Exception exception) {
+            String detail = Optional.ofNullable(ExceptionUtils.getRootCause(exception))
+                .map(Throwable::getMessage)
+                .orElse(exception.getMessage());
+            throw new IllegalArgumentException("Invalid request body: " + detail, exception);
+        }
+    }
+
+    private Throwable mapExceptionsErrors(Throwable error) {
+        if (error instanceof IllegalArgumentException exception) {
+            return ErrorResponder.builder()
+                .statusCode(HttpStatus.BAD_REQUEST_400)
+                .type(ErrorResponder.ErrorType.INVALID_ARGUMENT)
+                .message(exception.getMessage())
+                .cause(exception)
+                .haltError();
+        }
+        if (error instanceof DomainNotFoundException exception) {
+            return ErrorResponder.builder()
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .message(exception.getMessage())
+                .haltError();
+        }
+        if (error instanceof TeamCalendarNotFoundException exception) {
+            return ErrorResponder.builder()
+                .statusCode(HttpStatus.NOT_FOUND_404)
+                .type(ErrorResponder.ErrorType.NOT_FOUND)
+                .message("Team calendar does not exist: %s", exception.id().value())
+                .haltError();
+        }
+        if (error instanceof DavClientException exception) {
+            return ErrorResponder.builder()
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500)
+                .type(ErrorResponder.ErrorType.SERVER_ERROR)
+                .message("Error while calling the DAV server")
+                .cause(exception)
+                .haltError();
+        }
+        return error;
+    }
+}

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/TeamCalendarMemberService.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/TeamCalendarMemberService.java
@@ -1,0 +1,113 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.webadmin.service;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
+import com.linagora.calendar.dav.DavClientException;
+import com.linagora.calendar.dav.dto.CalendarDetailsResponse.CalendarInvite;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.MailtoUri;
+import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.model.TeamCalendarId;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class TeamCalendarMemberService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TeamCalendarMemberService.class);
+    private static final Map<String, String> WITH_RIGHTS = Map.of("withRights", "true");
+
+    public enum TeamCalendarRole {
+        VIEWER("viewer", "dav:read", 2),
+        MEMBER("member", "dav:read-write", 3),
+        MANAGER("manager", "dav:administration", 5);
+
+        private final String value;
+        private final String davRight;
+        private final int davAccess;
+
+        TeamCalendarRole(String value, String davRight, int davAccess) {
+            this.value = value;
+            this.davRight = davRight;
+            this.davAccess = davAccess;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public String davRight() {
+            return davRight;
+        }
+
+        public static TeamCalendarRole fromDavAccess(int davAccess) {
+            return Stream.of(values())
+                .filter(role -> role.davAccess == davAccess)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported DAV delegation access: " + davAccess));
+        }
+    }
+
+    public record TeamCalendarMember(Username username, TeamCalendarRole role) {
+    }
+
+    private final CalDavClient calDavClient;
+
+    @Inject
+    public TeamCalendarMemberService(CalDavClient calDavClient) {
+        this.calDavClient = calDavClient;
+    }
+
+    public Flux<TeamCalendarMember> list(OpenPaaSId domainId, TeamCalendarId teamCalendarId) {
+        CalendarURL calendarURL = toCalendarURL(teamCalendarId);
+        return calDavClient.fetchCalendarDetails(domainId, calendarURL, WITH_RIGHTS)
+            .doOnError(DavClientException.class,
+                error -> LOGGER.warn("Failed to fetch team calendar '{}' details from DAV", calendarURL.asUri(), error))
+            .flatMapMany(response -> Flux.fromIterable(response.invites()))
+            .filter(invite -> MailtoUri.hasMailtoPrefix(invite.href()))
+            .filter(invite -> invite.access().isPresent())
+            .map(TeamCalendarMemberService::toTeamCalendarMember);
+    }
+
+    public Mono<Void> update(OpenPaaSId domainId, TeamCalendarId teamCalendarId, CalendarSharingUpdate sharingUpdate) {
+        CalendarURL calendarURL = toCalendarURL(teamCalendarId);
+        return calDavClient.updateCalendarShares(domainId, calendarURL, sharingUpdate)
+            .doOnError(DavClientException.class,
+                error -> LOGGER.warn("Failed to update team calendar '{}' shares in DAV", calendarURL.asUri(), error));
+    }
+
+    private static CalendarURL toCalendarURL(TeamCalendarId teamCalendarId) {
+        return CalendarURL.from(teamCalendarId.asOpenPaaSId());
+    }
+
+    private static TeamCalendarMember toTeamCalendarMember(CalendarInvite invite) {
+        return new TeamCalendarMember(Username.of(MailtoUri.stripMailtoPrefix(invite.href())),
+            TeamCalendarRole.fromDavAccess(invite.access().get()));
+    }
+}

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/TeamCalendarMemberRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/TeamCalendarMemberRoutesTest.java
@@ -1,0 +1,801 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the    *
+ *  GNU Affero General Public License for more details.             *
+ ********************************************************************/
+
+package com.linagora.calendar.webadmin;
+
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Clock;
+import java.util.UUID;
+
+import javax.net.ssl.SSLException;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.webadmin.WebAdminServer;
+import org.apache.james.webadmin.utils.JsonTransformer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.dav.SabreDavProvisioningService;
+import com.linagora.calendar.storage.OpenPaaSDomain;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.TeamCalendarInsertRequest;
+import com.linagora.calendar.storage.model.TeamCalendar;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
+import com.linagora.calendar.storage.mongodb.MongoDBTeamCalendarRepository;
+import com.linagora.calendar.webadmin.service.TeamCalendarMemberService;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import net.javacrumbs.jsonunit.core.Option;
+
+class TeamCalendarMemberRoutesTest {
+    private static final Domain DOMAIN = Domain.of(SabreDavProvisioningService.DOMAIN);
+
+    @RegisterExtension
+    static SabreDavExtension sabreDavExtension = SabreDavExtension.shared();
+
+    private WebAdminServer webAdminServer;
+    private OpenPaaSDomain domain;
+    private MongoDBTeamCalendarRepository teamCalendarRepository;
+
+    @BeforeEach
+    void setUp() throws SSLException {
+        MongoDBOpenPaaSDomainDAO domainDAO = new MongoDBOpenPaaSDomainDAO(sabreDavExtension.dockerSabreDavSetup().getMongoDB());
+        OpenPaaSUserDAO userDAO = new MongoDBOpenPaaSUserDAO(sabreDavExtension.dockerSabreDavSetup().getMongoDB(), domainDAO);
+        domain = sabreDavExtension.dockerSabreDavSetup()
+            .getOpenPaaSProvisioningService()
+            .createDomainIfAbsent(DOMAIN)
+            .block();
+        teamCalendarRepository = new MongoDBTeamCalendarRepository(sabreDavExtension.dockerSabreDavSetup().getMongoDB(), Clock.systemUTC());
+
+        CalDavClient calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        TeamCalendarService teamCalendarService = new TeamCalendarService(domainDAO, teamCalendarRepository);
+        TeamCalendarMemberService teamCalendarMemberService = new TeamCalendarMemberService(calDavClient);
+
+        webAdminServer = WebAdminUtils.createWebAdminServer(
+                new TeamCalendarMemberRoutes(teamCalendarService, teamCalendarMemberService, userDAO, new JsonTransformer()))
+            .start();
+
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer)
+            .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        webAdminServer.destroy();
+    }
+
+    @Test
+    void listShouldReturnTeamCalendarMembers() {
+        // Given a team calendar with one member for each supported DAV right.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser viewer = sabreDavExtension.newTestUser();
+        OpenPaaSUser member = sabreDavExtension.newTestUser();
+        OpenPaaSUser manager = sabreDavExtension.newTestUser();
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${viewer}", "dav:read": true},
+                      {"dav:href": "mailto:${member}", "dav:read-write": true},
+                      {"dav:href": "mailto:${manager}", "dav:administration": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${viewer}", viewer.username().asString())
+                .replace("${member}", member.username().asString())
+                .replace("${manager}", manager.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+
+        // When the WebAdmin route lists the team calendar members.
+        String response = when()
+            .get("/domains/{domain}/team-calendars/{teamCalendarId}/members", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .extract()
+            .body()
+            .asString();
+
+        // Then the response exposes both the member role and the DAV right.
+        assertThatJson(response)
+            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .isEqualTo("""
+                [
+                  {
+                    "username": "${viewer}",
+                    "role": "viewer",
+                    "davRight": "dav:read"
+                  },
+                  {
+                    "username": "${member}",
+                    "role": "member",
+                    "davRight": "dav:read-write"
+                  },
+                  {
+                    "username": "${manager}",
+                    "role": "manager",
+                    "davRight": "dav:administration"
+                  }
+                ]
+                """
+                .replace("${viewer}", viewer.username().asString())
+                .replace("${member}", member.username().asString())
+                .replace("${manager}", manager.username().asString()));
+    }
+
+    @Test
+    void inviteeShouldSupportAddNewMemberRequest() {
+        // Given a team calendar already shared with one member.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser existingMember = sabreDavExtension.newTestUser();
+        OpenPaaSUser newMember = sabreDavExtension.newTestUser();
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${existingMember}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${existingMember}", existingMember.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+
+        // When the WebAdmin route receives a set-only invitee update.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${newMember}", "dav:read-write": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${newMember}", newMember.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+
+        // Then the existing member remains and the new member is appended.
+        String response = when()
+            .get("/domains/{domain}/team-calendars/{teamCalendarId}/members", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .isEqualTo("""
+                [
+                  {
+                    "username": "${existingMember}",
+                    "role": "viewer",
+                    "davRight": "dav:read"
+                  },
+                  {
+                    "username": "${newMember}",
+                    "role": "member",
+                    "davRight": "dav:read-write"
+                  }
+                ]
+                """
+                .replace("${existingMember}", existingMember.username().asString())
+                .replace("${newMember}", newMember.username().asString()));
+    }
+
+    @Test
+    void inviteeShouldSupportRemoveMemberRequest() {
+        // Given a team calendar already shared with two members.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser kept = sabreDavExtension.newTestUser();
+        OpenPaaSUser removed = sabreDavExtension.newTestUser();
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${kept}", "dav:read-write": true},
+                      {"dav:href": "mailto:${removed}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${kept}", kept.username().asString())
+                .replace("${removed}", removed.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+
+        // When the WebAdmin route receives a remove-only invitee update.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "remove": [
+                      {"dav:href": "mailto:${removed}"}
+                    ]
+                  }
+                }
+                """
+                .replace("${removed}", removed.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+
+        // Then only the untouched member remains.
+        String response = when()
+            .get("/domains/{domain}/team-calendars/{teamCalendarId}/members", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                [
+                  {
+                    "username": "${kept}",
+                    "role": "member",
+                    "davRight": "dav:read-write"
+                  }
+                ]
+                """
+                .replace("${kept}", kept.username().asString()));
+    }
+
+    @Test
+    void inviteeShouldSupportIdempotentRemoveMemberRequest() {
+        // Given a team calendar already shared with one member.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser removed = sabreDavExtension.newTestUser();
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${removed}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${removed}", removed.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "remove": [
+                      {"dav:href": "mailto:${removed}"}
+                    ]
+                  }
+                }
+                """
+                .replace("${removed}", removed.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+
+        // When the same remove-only invitee update is retried.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "remove": [
+                      {"dav:href": "mailto:${removed}"}
+                    ]
+                  }
+                }
+                """
+                .replace("${removed}", removed.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    void inviteeShouldSupportSetAndRemoveInTheSameRequest() {
+        // Given a team calendar already shared with two members.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser viewer = sabreDavExtension.newTestUser();
+        OpenPaaSUser member = sabreDavExtension.newTestUser();
+        OpenPaaSUser removed = sabreDavExtension.newTestUser();
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${member}", "dav:read-write": true},
+                      {"dav:href": "mailto:${removed}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${member}", member.username().asString())
+                .replace("${removed}", removed.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+
+        // When one request adds a new member and removes an existing member.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${viewer}", "dav:read": true}
+                    ],
+                    "remove": [
+                      {"dav:href": "mailto:${removed}"}
+                    ]
+                  }
+                }
+                """
+                .replace("${viewer}", viewer.username().asString())
+                .replace("${removed}", removed.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(204);
+
+        // Then the previous untouched member remains and the removed member is gone.
+        String response = when()
+            .get("/domains/{domain}/team-calendars/{teamCalendarId}/members", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .isEqualTo("""
+                [
+                  {
+                    "username": "${viewer}",
+                    "role": "viewer",
+                    "davRight": "dav:read"
+                  },
+                  {
+                    "username": "${member}",
+                    "role": "member",
+                    "davRight": "dav:read-write"
+                  }
+                ]
+                """
+                .replace("${viewer}", viewer.username().asString())
+                .replace("${member}", member.username().asString()));
+    }
+
+    @Test
+    void listShouldReturn404WhenDomainDoesNotExist() {
+        // Given a valid team calendar and a missing requested domain.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        String notFoundDomain = "missing.org";
+
+        // When listing members, then the WebAdmin route reports the missing domain.
+        when()
+            .get("/domains/{domain}/team-calendars/{teamCalendarId}/members", notFoundDomain, teamCalendar.id().value())
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is(notFoundDomain + " does not exist"));
+    }
+
+    @Test
+    void listShouldReturn400WhenDomainIsInvalid() {
+        // Given a valid team calendar and an invalid domain path parameter.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        String invalidDomain = "invalid@domain";
+
+        // When listing members, then the WebAdmin route rejects the domain syntax.
+        when()
+            .get("/domains/{domain}/team-calendars/{teamCalendarId}/members", invalidDomain, teamCalendar.id().value())
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Invalid domain: " + invalidDomain));
+    }
+
+    @Test
+    void listShouldReturn404WhenTeamCalendarDoesNotExist() {
+        // When listing members for an unknown team calendar, then the route returns not found.
+        String unknownTeamCalendarId = "64f1c2000000000000000000";
+
+        when()
+            .get("/domains/{domain}/team-calendars/{teamCalendarId}/members", DOMAIN.asString(), unknownTeamCalendarId)
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is("Team calendar does not exist: " + unknownTeamCalendarId));
+    }
+
+    @Test
+    void listShouldReturn404WhenTeamCalendarIdIsInvalid() {
+        // When listing members with an invalid team calendar id, then the route returns not found.
+        String invalidTeamCalendarId = "not-an-object-id";
+
+        when()
+            .get("/domains/{domain}/team-calendars/{teamCalendarId}/members", DOMAIN.asString(), invalidTeamCalendarId)
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is("Team calendar does not exist: " + invalidTeamCalendarId));
+    }
+
+    @Test
+    void listShouldReturn404WhenTeamCalendarDoesNotBelongToDomain() {
+        // Given a team calendar owned by another domain.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        Domain otherDomain = Domain.of("other.org");
+        createDomain(otherDomain);
+
+        // When listing members through the wrong domain, then the route hides the team calendar.
+        when()
+            .get("/domains/{domain}/team-calendars/{teamCalendarId}/members", otherDomain.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is("Team calendar does not exist: " + teamCalendar.id().value()));
+    }
+
+    @Test
+    void inviteeShouldReturn404WhenDomainDoesNotExist() {
+        // Given a valid update payload targeting a missing domain.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser member = sabreDavExtension.newTestUser();
+        String notFoundDomain = "missing.org";
+
+        // When updating invitees, then the WebAdmin route reports the missing domain.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${member}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${member}", member.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", notFoundDomain, teamCalendar.id().value())
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is(notFoundDomain + " does not exist"));
+    }
+
+    @Test
+    void inviteeShouldReturn400WhenDomainIsInvalid() {
+        // Given a valid update payload and an invalid domain path parameter.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser member = sabreDavExtension.newTestUser();
+        String invalidDomain = "invalid@domain";
+
+        // When updating invitees, then the WebAdmin route rejects the domain syntax.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${member}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${member}", member.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", invalidDomain, teamCalendar.id().value())
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Invalid domain: " + invalidDomain));
+    }
+
+    @Test
+    void inviteeShouldReturn404WhenTeamCalendarDoesNotExist() {
+        // Given a valid update payload for an unknown team calendar.
+        OpenPaaSUser member = sabreDavExtension.newTestUser();
+        String unknownTeamCalendarId = "64f1c2000000000000000000";
+
+        // When updating invitees, then the WebAdmin route returns not found.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${member}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${member}", member.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), unknownTeamCalendarId)
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is("Team calendar does not exist: " + unknownTeamCalendarId));
+    }
+
+    @Test
+    void inviteeShouldReturn404WhenTeamCalendarIdIsInvalid() {
+        // Given a valid update payload and an invalid team calendar id.
+        OpenPaaSUser member = sabreDavExtension.newTestUser();
+        String invalidTeamCalendarId = "not-an-object-id";
+
+        // When updating invitees, then the WebAdmin route returns not found.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${member}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${member}", member.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), invalidTeamCalendarId)
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is("Team calendar does not exist: " + invalidTeamCalendarId));
+    }
+
+    @Test
+    void inviteeShouldReturn404WhenTeamCalendarDoesNotBelongToDomain() {
+        // Given a team calendar owned by a different domain than the request.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        Domain otherDomain = Domain.of("other.org");
+        createDomain(otherDomain);
+        OpenPaaSUser member = sabreDavExtension.newTestUser();
+
+        // When updating invitees, then the route hides the team calendar.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${member}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${member}", member.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", otherDomain.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(404)
+            .body("type", is("notFound"))
+            .body("message", is("Team calendar does not exist: " + teamCalendar.id().value()));
+    }
+
+    @Test
+    void inviteeShouldReturn400WhenMemberDoesNotBelongToDomain() {
+        // Given an update payload for a member from another domain.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        Domain otherDomain = Domain.of("other.org");
+        OpenPaaSUser otherDomainUser = createUser(otherDomain);
+
+        // When updating invitees, then the WebAdmin route rejects the member.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:${member}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${member}", otherDomainUser.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Member must belong to domain: " + DOMAIN.asString()));
+    }
+
+    @Test
+    void inviteeShouldReturn400WhenMemberUsernameHasNoDomainPart() {
+        // Given an update payload for a member username without domain part.
+        TeamCalendar teamCalendar = createTeamCalendar();
+
+        // When updating invitees, then the WebAdmin route rejects the member username.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:member-without-domain", "dav:read": true}
+                    ]
+                  }
+                }
+                """)
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Member username must contain a domain"));
+    }
+
+    @Test
+    void inviteeShouldReturn400WhenMemberDoesNotExist() {
+        // Given an update payload for a same-domain member missing from OpenPaaS.
+        TeamCalendar teamCalendar = createTeamCalendar();
+
+        // When updating invitees, then the WebAdmin route reports the missing member.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {"dav:href": "mailto:missing@${domain}", "dav:read": true}
+                    ]
+                  }
+                }
+                """
+                .replace("${domain}", DOMAIN.asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Candidate member not found: missing@" + DOMAIN.asString()));
+    }
+
+    @Test
+    void inviteeShouldReturn400WhenMemberHasConflictingDavRights() {
+        // Given an update payload enabling more than one DAV right for one member.
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser member = sabreDavExtension.newTestUser();
+
+        // When updating invitees, then the WebAdmin route rejects the ambiguous role.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "share": {
+                    "set": [
+                      {
+                        "dav:href": "mailto:${member}",
+                        "dav:read": true,
+                        "dav:administration": true
+                      }
+                    ]
+                  }
+                }
+                """
+                .replace("${member}", member.username().asString()))
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"))
+            .body("message", is("Exactly one of 'dav:read', 'dav:read-write', 'dav:administration' must be true"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', textBlock = """
+        not-json | Invalid request body:
+        {} | Invalid request body:
+        {"share":{"set":[{"dav:href":"http://member@open-paas.org","dav:read":true}]}} | Invalid request body:
+        """)
+    void inviteeShouldReturn400WhenPayloadIsInvalid(String body, String expectedMessage) {
+        // Given a malformed or semantically invalid invitee update payload.
+        TeamCalendar teamCalendar = createTeamCalendar();
+
+        // When updating invitees, then the WebAdmin route rejects the payload.
+        given()
+            .contentType(ContentType.JSON)
+            .body(body)
+        .when()
+            .post("/domains/{domain}/team-calendars/{teamCalendarId}/members/invitee", DOMAIN.asString(), teamCalendar.id().value())
+        .then()
+            .statusCode(400)
+            .body("type", is("InvalidArgument"))
+            .body("message", containsString(expectedMessage));
+    }
+
+    private TeamCalendar createTeamCalendar() {
+        return teamCalendarRepository.create(new TeamCalendarInsertRequest(domain, "team-" + UUID.randomUUID(), "Team calendar"))
+            .block();
+    }
+
+    private OpenPaaSDomain createDomain(Domain domain) {
+        return sabreDavExtension.dockerSabreDavSetup()
+            .getOpenPaaSProvisioningService()
+            .createDomainIfAbsent(domain)
+            .block();
+    }
+
+    private OpenPaaSUser createUser(Domain domain) {
+        createDomain(domain);
+        return sabreDavExtension.dockerSabreDavSetup()
+            .getOpenPaaSProvisioningService()
+            .createUser(Username.fromLocalPartWithDomain("user_" + UUID.randomUUID(), domain))
+            .block();
+    }
+}

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/service/TeamCalendarMemberServiceTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/service/TeamCalendarMemberServiceTest.java
@@ -1,0 +1,144 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the    *
+ *  GNU Affero General Public License for more details.             *
+ ********************************************************************/
+
+package com.linagora.calendar.webadmin.service;
+
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.net.ssl.SSLException;
+
+import org.apache.james.core.Domain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.AddSharee;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.RemoveSharee;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.Share;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.dav.SabreDavProvisioningService;
+import com.linagora.calendar.dav.dto.CalendarDetailsResponse;
+import com.linagora.calendar.dav.dto.CalendarDetailsResponse.CalendarInvite;
+import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSDomain;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.TeamCalendarInsertRequest;
+import com.linagora.calendar.storage.model.TeamCalendar;
+import com.linagora.calendar.storage.mongodb.MongoDBTeamCalendarRepository;
+import com.linagora.calendar.webadmin.service.TeamCalendarMemberService.TeamCalendarMember;
+import com.linagora.calendar.webadmin.service.TeamCalendarMemberService.TeamCalendarRole;
+
+class TeamCalendarMemberServiceTest {
+    private static final Map<String, String> WITH_RIGHTS = Map.of("withRights", "true");
+
+    @RegisterExtension
+    static SabreDavExtension sabreDavExtension = SabreDavExtension.shared();
+
+    private OpenPaaSDomain domain;
+    private MongoDBTeamCalendarRepository teamCalendarRepository;
+    private CalDavClient calDavClient;
+    private TeamCalendarMemberService testee;
+
+    @BeforeEach
+    void setUp() throws SSLException {
+        domain = sabreDavExtension.dockerSabreDavSetup()
+            .getOpenPaaSProvisioningService()
+            .createDomainIfAbsent(Domain.of(SabreDavProvisioningService.DOMAIN))
+            .block();
+        teamCalendarRepository = new MongoDBTeamCalendarRepository(sabreDavExtension.dockerSabreDavSetup().getMongoDB(), Clock.systemUTC());
+        calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        testee = new TeamCalendarMemberService(calDavClient);
+    }
+
+    @Test
+    void listShouldMapDavInvitesToTeamCalendarMembers() {
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser viewer = sabreDavExtension.newTestUser(Optional.of("viewer_"));
+        OpenPaaSUser member = sabreDavExtension.newTestUser(Optional.of("member_"));
+        OpenPaaSUser manager = sabreDavExtension.newTestUser(Optional.of("manager_"));
+
+        testee.update(domain.id(), teamCalendar.id(), sharingUpdate(viewer, member, manager, List.of())).block();
+
+        List<TeamCalendarMember> members = testee.list(domain.id(), teamCalendar.id()).collectList().block();
+
+        assertThat(members).containsExactlyInAnyOrder(
+            new TeamCalendarMember(viewer.username(), TeamCalendarRole.VIEWER),
+            new TeamCalendarMember(member.username(), TeamCalendarRole.MEMBER),
+            new TeamCalendarMember(manager.username(), TeamCalendarRole.MANAGER));
+    }
+
+    @Test
+    void updateShouldSupportSetAndRemoveInTheSameRequest() {
+        TeamCalendar teamCalendar = createTeamCalendar();
+        OpenPaaSUser viewer = sabreDavExtension.newTestUser(Optional.of("viewer_"));
+        OpenPaaSUser member = sabreDavExtension.newTestUser(Optional.of("member_"));
+        OpenPaaSUser manager = sabreDavExtension.newTestUser(Optional.of("manager_"));
+        OpenPaaSUser removed = sabreDavExtension.newTestUser(Optional.of("removed_"));
+
+        testee.update(domain.id(), teamCalendar.id(), sharingUpdate(removed, member, manager, List.of())).block();
+
+        CalendarSharingUpdate update = sharingUpdate(viewer, member, manager, List.of(removed));
+        testee.update(domain.id(), teamCalendar.id(), update).block();
+
+        List<String> memberHrefs = calDavClient.fetchCalendarDetails(domain.id(), CalendarURL.from(teamCalendar.id().asOpenPaaSId()), WITH_RIGHTS)
+            .flatMapIterable(CalendarDetailsResponse::invites)
+            .map(CalendarInvite::href)
+            .filter(href -> href.startsWith("mailto:"))
+            .collectList()
+            .block();
+
+        assertThat(memberHrefs).containsExactlyInAnyOrder(
+            mailto(viewer),
+            mailto(member),
+            mailto(manager));
+    }
+
+    private TeamCalendar createTeamCalendar() {
+        return teamCalendarRepository.create(new TeamCalendarInsertRequest(
+                domain,
+                "team-" + UUID.randomUUID(),
+                "Team calendar"))
+            .block();
+    }
+
+    private CalendarSharingUpdate sharingUpdate(OpenPaaSUser viewer,
+                                                OpenPaaSUser member,
+                                                OpenPaaSUser manager,
+                                                List<OpenPaaSUser> removedUsers) {
+        return new CalendarSharingUpdate(new Share(
+            List.of(
+                AddSharee.read(mailto(viewer)),
+                AddSharee.readWrite(mailto(member)),
+                AddSharee.administration(mailto(manager))),
+            removedUsers.stream()
+                .map(user -> new RemoveSharee(mailto(user)))
+                .toList()));
+    }
+
+    private String mailto(OpenPaaSUser user) {
+        return "mailto:" + user.username().asString();
+    }
+}

--- a/docs/apis/webadmin.md
+++ b/docs/apis/webadmin.md
@@ -674,6 +674,69 @@ Status codes:
 - `400` when the domain name is invalid
 - `404` when the domain does not exist
 
+### Listing team calendar members
+
+```
+GET /domains/linagora.com/team-calendars/64f1c2.../members
+```
+
+Returns the Team Calendar members derived from DAV sharing rights:
+
+```json
+[
+  {
+    "username": "alice@linagora.com",
+    "role": "viewer",
+    "davRight": "dav:read"
+  },
+  {
+    "username": "bob@linagora.com",
+    "role": "manager",
+    "davRight": "dav:administration"
+  }
+]
+```
+
+Role mapping:
+- `viewer`: `dav:read`
+- `member`: `dav:read-write`
+- `manager`: `dav:administration`
+
+Status codes:
+- `200` on success
+- `400` when the domain name is invalid
+- `404` when the domain or team calendar does not exist
+- `500` when the DAV server cannot be reached or rejects the read operation
+
+### Adding / removing team calendar members
+
+```
+POST /domains/linagora.com/team-calendars/64f1c2.../members/invitee
+{
+  "share": {
+    "set": [
+      {"dav:href": "mailto:alice@linagora.com", "dav:read": true},
+      {"dav:href": "mailto:bob@linagora.com", "dav:read-write": true},
+      {"dav:href": "mailto:cedric@linagora.com", "dav:administration": true}
+    ],
+    "remove": [
+      {"dav:href": "mailto:david@linagora.com"}
+    ]
+  }
+}
+```
+
+Each set entry grants or updates the right for the given user; each remove entry revokes
+the sharing for the given user.
+This is a partial update: `set` grants or updates member rights, while `remove` revokes them. Omitted members are left
+unchanged.
+
+Status codes:
+- `204`: the sharees were updated
+- `400`: invalid domain name, malformed request body,candidate member is invalid or unknown...
+- `404`: the domain or team calendar does not exist
+- `500`: the DAV server cannot be reached or rejects the update operation
+
 ## Domain registered users routes
 
 Domain-scoped mirror of the `/registeredUsers` routes, allowing multi-tenant safe access.

--- a/storage-api/src/main/java/com/linagora/calendar/storage/MailtoUri.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/MailtoUri.java
@@ -18,17 +18,31 @@
 
 package com.linagora.calendar.storage;
 
-import com.linagora.calendar.storage.model.TeamCalendarId;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
-public class TeamCalendarNotFoundException extends RuntimeException {
-    private final TeamCalendarId id;
+import com.google.common.base.Preconditions;
 
-    public TeamCalendarNotFoundException(TeamCalendarId id) {
-        super("Team calendar not found: " + id.value());
-        this.id = id;
+public final class MailtoUri {
+    private static final String MAILTO_PREFIX = "mailto:";
+
+    public static boolean hasMailtoPrefix(String value) {
+        if (value == null) {
+            return false;
+        }
+        return Strings.CI.startsWith(StringUtils.strip(value.trim(), "<>"), MAILTO_PREFIX);
     }
 
-    public TeamCalendarId id() {
-        return id;
+    public static String stripMailtoPrefix(String value) {
+        Preconditions.checkNotNull(value, "value must not be null");
+
+        String sanitized = StringUtils.strip(value.trim(), "<>");
+        if (hasMailtoPrefix(sanitized)) {
+            sanitized = sanitized.substring(MAILTO_PREFIX.length());
+        }
+        return StringUtils.strip(sanitized, "<>");
+    }
+
+    private MailtoUri() {
     }
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/model/TeamCalendar.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/model/TeamCalendar.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.storage.OpenPaaSDomain;
+import com.linagora.calendar.storage.OpenPaaSId;
 
 public record TeamCalendar(TeamCalendarId id,
                            OpenPaaSDomain domain,
@@ -39,5 +40,9 @@ public record TeamCalendar(TeamCalendarId id,
         Preconditions.checkArgument(!StringUtils.isBlank(displayName), "team calendar displayName must not be empty");
         Preconditions.checkNotNull(creation, "creation must not be null");
         Preconditions.checkNotNull(updated, "updated must not be null");
+    }
+
+    public OpenPaaSId domainId() {
+        return domain.id();
     }
 }

--- a/storage-api/src/test/java/com/linagora/calendar/storage/MailtoUriTest.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/MailtoUriTest.java
@@ -18,17 +18,39 @@
 
 package com.linagora.calendar.storage;
 
-import com.linagora.calendar.storage.model.TeamCalendarId;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class TeamCalendarNotFoundException extends RuntimeException {
-    private final TeamCalendarId id;
+import org.junit.jupiter.api.Test;
 
-    public TeamCalendarNotFoundException(TeamCalendarId id) {
-        super("Team calendar not found: " + id.value());
-        this.id = id;
+class MailtoUriTest {
+
+    @Test
+    void stripMailtoPrefixShouldSanitizeMalformedMailtoAddress() {
+        assertThat(MailtoUri.stripMailtoPrefix(" mailto:<alice@linagora.com> "))
+            .isEqualTo("alice@linagora.com");
     }
 
-    public TeamCalendarId id() {
-        return id;
+    @Test
+    void stripMailtoPrefixShouldSanitizeTrailingAngleBracket() {
+        assertThat(MailtoUri.stripMailtoPrefix("mailto:alice@linagora.com>"))
+            .isEqualTo("alice@linagora.com");
+    }
+
+    @Test
+    void stripMailtoPrefixShouldBeCaseInsensitive() {
+        assertThat(MailtoUri.stripMailtoPrefix("MAILTO:alice@linagora.com"))
+            .isEqualTo("alice@linagora.com");
+    }
+
+    @Test
+    void stripMailtoPrefixShouldKeepPlainAddress() {
+        assertThat(MailtoUri.stripMailtoPrefix("alice@linagora.com"))
+            .isEqualTo("alice@linagora.com");
+    }
+
+    @Test
+    void hasMailtoPrefixShouldBeCaseInsensitiveAndSanitizeAddress() {
+        assertThat(MailtoUri.hasMailtoPrefix(" <MAILTO:alice@linagora.com> "))
+            .isTrue();
     }
 }


### PR DESCRIPTION
Part 1 of 
- https://github.com/linagora/twake-calendar-side-service/issues/832

Team Calendar members are sourced from esn-sabre DAV sharing rather than side-service MongoDB. This adds the required DAV-backed service layer needed by future WebAdmin member CRUD routes.
