### PR TITLE
ISSUE-926 Ignore unknown fields when deserializing AMQP payloads

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmConsumer.java
@@ -42,6 +42,7 @@ import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.github.fge.lambdas.Throwing;
@@ -61,7 +62,8 @@ import reactor.rabbitmq.Receiver;
 import reactor.rabbitmq.Sender;
 
 public class EventAlarmConsumer implements Closeable, Startable {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private static final Logger LOGGER = LoggerFactory.getLogger(EventAlarmConsumer.class);
     private static final boolean REQUEUE_ON_NACK = true;
 

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventCalendarConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventCalendarConsumer.java
@@ -42,6 +42,7 @@ import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.github.fge.lambdas.Throwing;
@@ -60,7 +61,8 @@ import reactor.rabbitmq.Receiver;
 import reactor.rabbitmq.Sender;
 
 public class EventCalendarConsumer implements Closeable, Startable {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private static final Logger LOGGER = LoggerFactory.getLogger(EventCalendarConsumer.class);
     private static final boolean REQUEUE_ON_NACK = true;
 

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventEmailConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventEmailConsumer.java
@@ -41,6 +41,7 @@ import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.name.Named;
@@ -77,7 +78,8 @@ public class EventEmailConsumer implements Closeable, Startable {
     private static final boolean PUBLIC_AGENDA_EVENT = true;
     private static final Logger LOGGER = LoggerFactory.getLogger(EventEmailConsumer.class);
     private static final boolean REQUEUE_ON_NACK = true;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private final ReceiverProvider receiverProvider;
     private final EventMailHandler eventMailHandler;

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventResourceConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventResourceConsumer.java
@@ -42,6 +42,7 @@ import org.apache.james.util.ReactorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.github.fge.lambdas.Throwing;
@@ -60,7 +61,8 @@ import reactor.rabbitmq.Receiver;
 import reactor.rabbitmq.Sender;
 
 public class EventResourceConsumer implements Closeable, Startable {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private static final Logger LOGGER = LoggerFactory.getLogger(EventResourceConsumer.class);
     private static final boolean REQUEUE_ON_NACK = true;
 

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTO.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -56,7 +57,8 @@ public record ItipLocalDeliveryDTO(
     @JsonDeserialize(using = RecipientListDeserializer.class)
     @JsonProperty("recipients") List<String> recipients) {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     public static byte[] serialize(ItipLocalDeliveryDTO dto) {
         try {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTOTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryDTOTest.java
@@ -103,6 +103,39 @@ class ItipLocalDeliveryDTOTest {
     }
 
     @Test
+    // Sabre started adding a "connectedUser" field to the payload: unknown fields must be ignored.
+    void deserializeShouldIgnoreUnknownFields() {
+        byte[] payload = """
+            {
+                "sender": "mailto:sender@example.com",
+                "method": "REQUEST",
+                "uid": "uid-123",
+                "calendarId": "calendar-123",
+                "message": "BEGIN:VCALENDAR",
+                "hasChange": true,
+                "connectedUser": "mailto:connected@example.com",
+                "recipients": [
+                    "mailto:alice@example.com"
+                ]
+            }
+            """.getBytes(StandardCharsets.UTF_8);
+
+        ItipLocalDeliveryDTO actual = ItipLocalDeliveryDTO.deserialize(payload);
+
+        ItipLocalDeliveryDTO expected = new ItipLocalDeliveryDTO(
+            "mailto:sender@example.com",
+            "REQUEST",
+            "uid-123",
+            "calendar-123",
+            "BEGIN:VCALENDAR",
+            Optional.empty(),
+            true,
+            List.of("mailto:alice@example.com"));
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     void strippedRecipientShouldRemoveMailtoPrefix() {
         ItipLocalDeliveryDTO dto = dtoWithRecipient("mailto:alice@example.com");
 


### PR DESCRIPTION
Closes #926

## Problem

Sabre started adding a new `connectedUser` field to iTIP (and other) AMQP payloads. Consumers whose `ObjectMapper` did not disable `FAIL_ON_UNKNOWN_PROPERTIES` failed to deserialize these messages, e.g.:

```
UnrecognizedPropertyException: Unrecognized field "connectedUser"
  (class com.linagora.calendar.amqp.ItipLocalDeliveryDTO), not marked as ignorable
```

## Fix

Disable `FAIL_ON_UNKNOWN_PROPERTIES` on every deserializing AMQP `ObjectMapper` so extra fields we do not model are simply ignored. This makes all AMQP payload consumers forward-compatible with new fields emitted by Sabre.

Affected mappers (the others already had it disabled):
- `ItipLocalDeliveryDTO`
- `EventEmailConsumer`
- `EventCalendarConsumer`
- `EventAlarmConsumer`
- `EventResourceConsumer`

## Tests

Added `deserializeShouldIgnoreUnknownFields` reproducing the `connectedUser` payload from the issue. `calendar-amqp` deserialization tests pass.

---
*Generated automatically*
