### PR TITLE
ISSUE-929 Reimport user display name from LDAP upon settings message

### DIFF
--- a/saas/saas-rabbitmq/src/main/java/com/linagora/calendar/saas/CalendarSettingUpdater.java
+++ b/saas/saas-rabbitmq/src/main/java/com/linagora/calendar/saas/CalendarSettingUpdater.java
@@ -77,12 +77,16 @@ public class CalendarSettingUpdater implements TWPSettingsUpdater {
 
     @Override
     public Mono<Void> updateSettings(TWPCommonSettingsMessage message) {
-        return message.languageSettings()
-            .map(incomingLanguageSetting -> resolveUsername(message)
-                .flatMap(session -> updateSetting(session, incomingLanguageSetting))
-                .then())
-            .orElse(Mono.empty())
+        Username username = Username.of(message.payload().email());
+        return resolveUser(username)
+            .flatMap(user -> updateLanguageSettingIfPresent(user, message))
             .doOnError(error -> LOGGER.error("Error occurred while updating calendar settings for user={} ", message.payload().email(), error));
+    }
+
+    private Mono<Void> updateLanguageSettingIfPresent(OpenPaaSUser user, TWPCommonSettingsMessage message) {
+        return message.languageSettings()
+            .map(incomingLanguageSetting -> updateSetting(sessionProvider.createSession(user.username()), incomingLanguageSetting))
+            .orElse(Mono.empty());
     }
 
     private Mono<Void> updateSetting(MailboxSession session, IncomingLanguageSetting incomingLanguageSetting) {
@@ -116,12 +120,10 @@ public class CalendarSettingUpdater implements TWPSettingsUpdater {
         return userConfigurationDAO.persistConfiguration(mergedConfiguration, session);
     }
 
-    private Mono<MailboxSession> resolveUsername(TWPCommonSettingsMessage message) {
-        Username username = Username.of(message.payload().email());
+    private Mono<OpenPaaSUser> resolveUser(Username username) {
         return openPaaSUserDAO.retrieve(username)
-            .switchIfEmpty(Mono.defer(() -> userProvisioner.provisionUser(username)))
-            .map(OpenPaaSUser::username)
-            .map(sessionProvider::createSession);
+            .flatMap(userProvisioner::reimportDisplayName)
+            .switchIfEmpty(Mono.defer(() -> userProvisioner.provisionUser(username)));
     }
 
     record StoredLanguageSetting(Locale locale, Optional<Long> version) {

--- a/saas/saas-rabbitmq/src/main/java/com/linagora/calendar/saas/SaaSUserProvisioner.java
+++ b/saas/saas-rabbitmq/src/main/java/com/linagora/calendar/saas/SaaSUserProvisioner.java
@@ -18,8 +18,11 @@
 
 package com.linagora.calendar.saas;
 
+import java.util.Objects;
+
 import jakarta.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.james.core.Username;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +35,8 @@ import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.UserNameResolver;
+import com.linagora.calendar.storage.UserNameResolver.UserNames;
 import com.linagora.calendar.storage.UserSearchMode;
 
 import reactor.core.publisher.Mono;
@@ -43,16 +48,19 @@ public class SaaSUserProvisioner {
     private final OpenPaaSDomainDAO domainDAO;
     private final CardDavClient cardDavClient;
     private final DomainSettingsResolver domainSettingsResolver;
+    private final UserNameResolver userNameResolver;
 
     @Inject
     public SaaSUserProvisioner(OpenPaaSUserDAO userDAO,
                                OpenPaaSDomainDAO domainDAO,
                                CardDavClient cardDavClient,
-                               DomainSettingsResolver domainSettingsResolver) {
+                               DomainSettingsResolver domainSettingsResolver,
+                               UserNameResolver userNameResolver) {
         this.userDAO = userDAO;
         this.domainDAO = domainDAO;
         this.cardDavClient = cardDavClient;
         this.domainSettingsResolver = domainSettingsResolver;
+        this.userNameResolver = userNameResolver;
     }
 
     public Mono<OpenPaaSUser> provisionUser(Username username) {
@@ -62,9 +70,30 @@ public class SaaSUserProvisioner {
 
     private Mono<OpenPaaSUser> registerUser(Username username) {
         return userDAO.retrieve(username)
-            .doOnNext(existingUser -> LOGGER.debug("User {} already exists, skipping registration", username.asString()))
-            .switchIfEmpty(userDAO.add(username)
+            .flatMap(this::reimportDisplayName)
+            .switchIfEmpty(userNameResolver.resolve(username)
+                .flatMap(names -> userDAO.add(username, names))
                 .doOnSuccess(created -> LOGGER.info("Registered user {} from SaaS subscription", username.asString())));
+    }
+
+    /**
+     * Reimports the display name (first and last name) of an already registered user from the
+     * user name resolver (typically LDAP), so a rename in the source directory is reflected on
+     * the calendar side upon the next {@code settings} message. See issue #929.
+     */
+    public Mono<OpenPaaSUser> reimportDisplayName(OpenPaaSUser user) {
+        return userNameResolver.resolve(user.username())
+            .flatMap(maybeNames -> maybeNames
+                .filter(names -> displayNameChanged(user, names))
+                .map(names -> userDAO.update(user.id(), user.username(), names.firstname(), names.lastname())
+                    .doOnSuccess(ignored -> LOGGER.info("Updated display name of user {}", user.username().asString()))
+                    .thenReturn(new OpenPaaSUser(user.username(), user.id(), names.firstname(), names.lastname())))
+                .orElseGet(() -> Mono.just(user)));
+    }
+
+    private boolean displayNameChanged(OpenPaaSUser user, UserNames names) {
+        return !Objects.equals(StringUtils.defaultString(user.firstname()), StringUtils.defaultString(names.firstname()))
+            || !Objects.equals(StringUtils.defaultString(user.lastname()), StringUtils.defaultString(names.lastname()));
     }
 
     private Mono<Void> addUserToDomainAddressBook(OpenPaaSUser user) {

--- a/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/CalendarSettingUpdaterTest.java
+++ b/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/CalendarSettingUpdaterTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.james.core.Username;
@@ -44,32 +45,53 @@ import com.linagora.calendar.storage.MemoryDomainSettingsDAO;
 import com.linagora.calendar.storage.MemoryOpenPaaSDomainDAO;
 import com.linagora.calendar.storage.MemoryOpenPaaSUserDAO;
 import com.linagora.calendar.storage.MemoryUserConfigurationDAO;
+import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.SimpleSessionProvider;
+import com.linagora.calendar.storage.UserNameResolver;
 import com.linagora.calendar.storage.configuration.ConfigurationEntry;
 import com.linagora.calendar.storage.configuration.EntryIdentifier;
 import com.linagora.calendar.storage.configuration.UserConfigurationDAO;
 import com.linagora.tmail.saas.rabbitmq.settings.TWPCommonSettingsMessage;
+
+import reactor.core.publisher.Mono;
 
 public class CalendarSettingUpdaterTest {
 
     private CalendarSettingUpdater testee;
     private OpenPaaSUserDAO openPaaSUserDAO;
     private UserConfigurationDAO userConfigurationDAO;
+    private MutableUserNameResolver userNameResolver;
     private final SimpleSessionProvider sessionProvider = new SimpleSessionProvider(new RandomMailboxSessionIdGenerator());
     private final Username USER = Username.of("tung@domain.tld");
 
+    /**
+     * Test double letting each test control the names the resolver (LDAP in production) returns for a user.
+     */
+    private static class MutableUserNameResolver implements UserNameResolver {
+        private final Map<Username, UserNames> names = new ConcurrentHashMap<>();
+
+        void register(Username username, UserNames userNames) {
+            names.put(username, userNames);
+        }
+
+        @Override
+        public Mono<Optional<UserNames>> resolve(Username username) {
+            return Mono.just(Optional.ofNullable(names.get(username)));
+        }
+    }
 
     @BeforeEach
     void setup() {
         openPaaSUserDAO = new MemoryOpenPaaSUserDAO();
         userConfigurationDAO = new MemoryUserConfigurationDAO(openPaaSUserDAO);
+        userNameResolver = new MutableUserNameResolver();
         // Disable user search for the test domain so the provisioner skips the (CardDav) address book step,
         // keeping this an in-memory test. Auto-provisioning thus only creates the OpenPaaSUser.
         DomainSettingsResolver domainSettingsResolver = new DomainSettingsResolver(
             new MemoryDomainSettingsDAO(), Set.of(USER.getDomainPart().get()), Set.of(), new MapConfiguration(Map.of()));
         SaaSUserProvisioner userProvisioner = new SaaSUserProvisioner(openPaaSUserDAO,
-            new MemoryOpenPaaSDomainDAO(), null, domainSettingsResolver);
+            new MemoryOpenPaaSDomainDAO(), null, domainSettingsResolver, userNameResolver);
         testee = new CalendarSettingUpdater(userConfigurationDAO, openPaaSUserDAO, userProvisioner, sessionProvider);
         openPaaSUserDAO.add(USER).block();
     }
@@ -329,6 +351,50 @@ public class CalendarSettingUpdaterTest {
             .containsExactlyInAnyOrder(timezone,
                 ConfigurationEntry.of(EntryIdentifier.LANGUAGE_IDENTIFIER, TextNode.valueOf("en")),
                 ConfigurationEntry.of(LANGUAGE_VERSION_IDENTIFIER, LongNode.valueOf(2)));
+    }
+
+    @Test
+    void shouldReimportDisplayNameFromResolverUponSettingsMessage() {
+        // Given: the resolver (LDAP in production) now reports a renamed handle
+        userNameResolver.register(USER, new UserNameResolver.UserNames("Tung", "Tran"));
+
+        // When: a settings message is received
+        testee.updateSettings(newMessage(2, "en")).block();
+
+        // Then: the registered user display name is updated
+        OpenPaaSUser user = openPaaSUserDAO.retrieve(USER).block();
+        assertThat(user.firstname()).isEqualTo("Tung");
+        assertThat(user.lastname()).isEqualTo("Tran");
+    }
+
+    @Test
+    void shouldReimportDisplayNameEvenWhenPayloadHasNoLanguage() {
+        // Given
+        userNameResolver.register(USER, new UserNameResolver.UserNames("Tung", "Tran"));
+        TWPCommonSettingsMessage message = new TWPCommonSettingsMessage("source", "nick", "req-1",
+            System.currentTimeMillis(), 10L, new TWPCommonSettingsMessage.Payload(USER.asString(), Optional.empty()));
+
+        // When
+        testee.updateSettings(message).block();
+
+        // Then
+        OpenPaaSUser user = openPaaSUserDAO.retrieve(USER).block();
+        assertThat(user.firstname()).isEqualTo("Tung");
+        assertThat(user.lastname()).isEqualTo("Tran");
+    }
+
+    @Test
+    void shouldNotChangeDisplayNameWhenResolverHasNoName() {
+        // Given: user already has a display name and the resolver returns nothing
+        openPaaSUserDAO.update(openPaaSUserDAO.retrieve(USER).block().id(), USER, "Tung", "Tran").block();
+
+        // When
+        testee.updateSettings(newMessage(2, "en")).block();
+
+        // Then: display name is left untouched
+        OpenPaaSUser user = openPaaSUserDAO.retrieve(USER).block();
+        assertThat(user.firstname()).isEqualTo("Tung");
+        assertThat(user.lastname()).isEqualTo("Tran");
     }
 
     private TWPCommonSettingsMessage newMessage(long version, String language) {

--- a/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/SaaSUserSubscriptionHandlerTest.java
+++ b/saas/saas-rabbitmq/src/test/java/com/linagora/calendar/saas/SaaSUserSubscriptionHandlerTest.java
@@ -39,6 +39,7 @@ import com.linagora.calendar.storage.DomainSettingsResolver;
 import com.linagora.calendar.storage.MemoryDomainSettingsDAO;
 import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.UserNameResolver;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
 import com.mongodb.reactivestreams.client.MongoDatabase;
@@ -62,7 +63,7 @@ class SaaSUserSubscriptionHandlerTest {
         cardDavClient = new CardDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
         DomainSettingsResolver domainSettingsResolver = new DomainSettingsResolver(
             new MemoryDomainSettingsDAO(), Set.of(Domain.of("nonshared.tld")), Set.of(), new MapConfiguration(Map.of()));
-        testee = new SaaSUserSubscriptionHandler(new SaaSUserProvisioner(userDAO, domainDAO, cardDavClient, domainSettingsResolver));
+        testee = new SaaSUserSubscriptionHandler(new SaaSUserProvisioner(userDAO, domainDAO, cardDavClient, domainSettingsResolver, new UserNameResolver.Noop()));
         testDomain = createNewDomainWithAddressBook();
     }
 


### PR DESCRIPTION
Closes #929

## Context

The issue asks to use the `first_name` / `last_name` payload of the `settings` exchange to update the display name of the registered user, and explicitly accepts *"a systematic reimport of the display name from the LDAP upon `settings` message"* as an alternative.

The shared `TWPCommonSettingsMessage.Payload` (from `tmail-backend`) only exposes `email` and `language`, and its deserializer ignores unknown JSON properties — so `first_name` / `last_name` are not available on the calendar side and cannot be read from this repository. This PR therefore implements the accepted LDAP-reimport approach.

## Changes

- `SaaSUserProvisioner`:
  - resolves first/last name via the `UserNameResolver` (LDAP in production, `Noop` otherwise) when provisioning a **new** user;
  - exposes `reimportDisplayName(OpenPaaSUser)` to refresh the stored display name of an **already registered** user, updating only when it actually changed.
- `CalendarSettingUpdater`: triggers the display-name reimport on **every** `settings` message, independently of whether a language setting is present.

## Tests

Added coverage in `CalendarSettingUpdaterTest` (reimport on rename, reimport even without a language payload, no-op when the resolver returns no name). Full module test suite is green and checkstyle passes.

---
*Generated automatically*
