### PR TITLE
ISSUE-932 Booking links: only allow calendars the user can write to

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
@@ -832,4 +832,28 @@ class BookingLinkCreateRouteTest {
 
         assertThat(bookingLinkProbe.listBookingLinks(delegate.username())).hasSize(1);
     }
+
+    @Test
+    void shouldReturn201WhenCalendarIsAdministrationDelegated() {
+        OpenPaaSUser delegate = newProvisionedUser();
+        CalendarURL ownerCalendar = CalendarURL.from(openPaaSUser.id());
+        davTestHelper.grantDelegation(openPaaSUser, ownerCalendar, delegate, "dav:administration");
+        CalendarURL delegatedCalendar = findMirrorCalendar(delegate);
+
+        given()
+            .auth().preemptive().basic(delegate.username().asString(), PASSWORD)
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true
+                }
+                """.formatted(delegatedCalendar.asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+
+        assertThat(bookingLinkProbe.listBookingLinks(delegate.username())).hasSize(1);
+    }
 }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
@@ -18,6 +18,8 @@
 
 package com.linagora.calendar.app.restapi.routes;
 
+import static com.linagora.calendar.dav.Fixture.awaitAtMost;
+import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.with;
 import static io.restassured.config.EncoderConfig.encoderConfig;
@@ -53,7 +55,9 @@ import com.linagora.calendar.app.TwakeCalendarConfiguration;
 import com.linagora.calendar.app.TwakeCalendarExtension;
 import com.linagora.calendar.app.TwakeCalendarGuiceServer;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
+import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.storage.CalendarURL;
@@ -96,19 +100,21 @@ class BookingLinkCreateRouteTest {
 
     private BookingLinkProbe bookingLinkProbe;
     private OpenPaaSUser openPaaSUser;
+    private CalendarDataProbe calendarDataProbe;
+    private CalDavClient calDavClient;
+    private DavTestHelper davTestHelper;
 
     @BeforeEach
-    void setUp(TwakeCalendarGuiceServer server) {
+    void setUp(TwakeCalendarGuiceServer server) throws Exception {
         openPaaSUser = sabreDavExtension.newTestUser();
-        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
+        calendarDataProbe = server.getProbe(CalendarDataProbe.class);
         calendarDataProbe.addDomain(openPaaSUser.username().getDomainPart().get());
         calendarDataProbe.addUserToRepository(openPaaSUser.username(), PASSWORD);
 
         bookingLinkProbe = server.getProbe(BookingLinkProbe.class);
 
-        PreemptiveBasicAuthScheme basicAuthScheme = new PreemptiveBasicAuthScheme();
-        basicAuthScheme.setUserName(openPaaSUser.username().asString());
-        basicAuthScheme.setPassword(PASSWORD);
+        calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        davTestHelper = new DavTestHelper(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
 
         RestAssured.requestSpecification = new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
@@ -116,8 +122,32 @@ class BookingLinkCreateRouteTest {
             .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
             .setPort(server.getProbe(RestApiServerProbe.class).getPort().getValue())
             .setBasePath("")
-            .setAuth(basicAuthScheme)
+            .setAuth(authScheme(openPaaSUser))
             .build();
+    }
+
+    private PreemptiveBasicAuthScheme authScheme(OpenPaaSUser user) {
+        PreemptiveBasicAuthScheme basicAuthScheme = new PreemptiveBasicAuthScheme();
+        basicAuthScheme.setUserName(user.username().asString());
+        basicAuthScheme.setPassword(PASSWORD);
+        return basicAuthScheme;
+    }
+
+    private OpenPaaSUser newProvisionedUser() {
+        OpenPaaSUser user = sabreDavExtension.newTestUser();
+        calendarDataProbe.addDomain(user.username().getDomainPart().get());
+        calendarDataProbe.addUserToRepository(user.username(), PASSWORD);
+        return user;
+    }
+
+    private CalendarURL findMirrorCalendar(OpenPaaSUser user) {
+        return awaitAtMost.until(() -> calDavClient.findUserCalendarList(user)
+            .map(response -> response.calendars()
+                .keySet()
+                .stream()
+                .filter(calendarURL -> !calendarURL.equals(CalendarURL.from(user.id())))
+                .findFirst())
+            .block(), Optional::isPresent).get();
     }
 
     @Test
@@ -753,5 +783,53 @@ class BookingLinkCreateRouteTest {
             .body("error.code", equalTo(400))
             .body("error.message", equalTo("Bad request"))
             .body("error.details", equalTo("Calendar not found or access denied: /calendars/nonexistentBase/nonexistentCalendar"));
+    }
+
+    @Test
+    void shouldReturn403WhenCalendarIsReadOnlyDelegated() {
+        OpenPaaSUser delegate = newProvisionedUser();
+        CalendarURL ownerCalendar = CalendarURL.from(openPaaSUser.id());
+        davTestHelper.grantDelegation(openPaaSUser, ownerCalendar, delegate, "dav:read");
+        CalendarURL delegatedCalendar = findMirrorCalendar(delegate);
+
+        given()
+            .auth().preemptive().basic(delegate.username().asString(), PASSWORD)
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true
+                }
+                """.formatted(delegatedCalendar.asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_FORBIDDEN);
+
+        assertThat(bookingLinkProbe.listBookingLinks(delegate.username())).isEmpty();
+    }
+
+    @Test
+    void shouldReturn201WhenCalendarIsReadWriteDelegated() {
+        OpenPaaSUser delegate = newProvisionedUser();
+        CalendarURL ownerCalendar = CalendarURL.from(openPaaSUser.id());
+        davTestHelper.grantDelegation(openPaaSUser, ownerCalendar, delegate, "dav:read-write");
+        CalendarURL delegatedCalendar = findMirrorCalendar(delegate);
+
+        given()
+            .auth().preemptive().basic(delegate.username().asString(), PASSWORD)
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true
+                }
+                """.formatted(delegatedCalendar.asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+
+        assertThat(bookingLinkProbe.listBookingLinks(delegate.username())).hasSize(1);
     }
 }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -1282,6 +1282,34 @@ class BookingLinkReservationRouteTest {
                 """.formatted(notFoundPublicId)));
     }
 
+    @Test
+    void shouldReturnForbiddenWhenBookingLinkTargetsReadOnlyCalendar(TwakeCalendarGuiceServer server) {
+        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
+        Username delegateUsername = Username.fromLocalPartWithDomain("delegate-" + UUID.randomUUID(), Domain.of("open-paas.org"));
+        calendarDataProbe.addUser(delegateUsername, PASSWORD, "Delegate", "User");
+        OpenPaaSUser delegate = calendarDataProbe.getUser(delegateUsername);
+
+        // Owner delegates its calendar to the booking link owner in read-only mode.
+        CalendarURL ownerCalendar = CalendarURL.from(openPaaSUser.id());
+        davTestHelper.grantDelegation(openPaaSUser, ownerCalendar, delegate, "dav:read");
+        CalendarURL delegatedCalendar = CALMLY_AWAIT.until(() -> calDavClient.findUserCalendarList(delegate)
+            .map(response -> response.calendars().keySet().stream()
+                .filter(url -> !url.equals(CalendarURL.from(delegate.id())))
+                .findFirst())
+            .block(), Optional::isPresent).get();
+
+        BookingLink inserted = server.getProbe(BookingLinkProbe.class)
+            .insert(delegate.username(), new BookingLinkInsertRequest(delegatedCalendar, DURATION_30_MINUTES, AVAILABILITY_RULE));
+
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body(bodyRequest("2036-01-26T09:00:00Z"))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_FORBIDDEN);
+    }
+
     private BookingLink insertActiveBookingLink(TwakeCalendarGuiceServer server) {
         BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(
             CalendarURL.from(openPaaSUser.id()),

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
@@ -806,6 +806,38 @@ public class CalDavClient extends DavClient {
             });
     }
 
+    public Mono<Boolean> hasWriteAccess(Username user, CalendarURL calendarUrl) {
+        String uri = calendarUrl.asUri().toString();
+        String requestBody = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <d:propfind xmlns:d="DAV:">
+              <d:prop>
+                <d:current-user-privilege-set/>
+              </d:prop>
+            </d:propfind>""";
+
+        return httpClientWithImpersonation(user)
+            .headers(headers -> headers.add(HttpHeaderNames.CONTENT_TYPE, "application/xml")
+                .add("Depth", "0"))
+            .request(HttpMethod.valueOf("PROPFIND"))
+            .uri(uri)
+            .send(Mono.fromCallable(() -> Unpooled.wrappedBuffer(requestBody.getBytes(StandardCharsets.UTF_8))))
+            .responseSingle((response, content) -> {
+                int status = response.status().code();
+                return content.asByteArray()
+                    .switchIfEmpty(Mono.just(new byte[0]))
+                    .flatMap(bytes -> switch (status) {
+                        case 207 -> Mono.fromCallable(() -> XMLUtil.hasWritePrivilege(bytes));
+                        case HttpStatus.SC_UNAUTHORIZED, HttpStatus.SC_FORBIDDEN, HttpStatus.SC_NOT_FOUND -> Mono.just(false);
+                        default -> Mono.error(new DavClientException("""
+                            Unexpected response when checking write access for '%s'
+                            Status: %d
+                            Body: %s
+                            """.formatted(uri, status, new String(bytes, StandardCharsets.UTF_8))));
+                    });
+            });
+    }
+
     private Mono<SyncToken> parseSyncToken(String body, String uri) {
         return Mono.fromCallable(() -> OBJECT_MAPPER.readTree(body))
             .flatMap(jsonNode -> Mono.justOrEmpty(jsonNode.path(SYNC_TOKEN_PROPERTY).asText(null)))

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
@@ -806,7 +806,20 @@ public class CalDavClient extends DavClient {
             });
     }
 
-    public Mono<Boolean> hasWriteAccess(Username user, CalendarURL calendarUrl) {
+    /**
+     * Access level the (impersonated) user holds on a calendar, resolved in a single
+     * {@code PROPFIND} on {@code DAV:current-user-privilege-set}.
+     */
+    public enum CalendarAccess {
+        /** The calendar does not exist, or the user may not even see it. */
+        NOT_FOUND,
+        /** The calendar is visible to the user, but grants no write-like privilege. */
+        READ_ONLY,
+        /** The user holds a write-like privilege on the calendar. */
+        WRITABLE
+    }
+
+    public Mono<CalendarAccess> resolveCalendarAccess(Username user, CalendarURL calendarUrl) {
         String uri = calendarUrl.asUri().toString();
         String requestBody = """
             <?xml version="1.0" encoding="utf-8" ?>
@@ -827,10 +840,12 @@ public class CalDavClient extends DavClient {
                 return content.asByteArray()
                     .switchIfEmpty(Mono.just(new byte[0]))
                     .flatMap(bytes -> switch (status) {
-                        case 207 -> Mono.fromCallable(() -> XMLUtil.hasWritePrivilege(bytes));
-                        case HttpStatus.SC_UNAUTHORIZED, HttpStatus.SC_FORBIDDEN, HttpStatus.SC_NOT_FOUND -> Mono.just(false);
+                        case 207 -> Mono.fromCallable(() -> XMLUtil.hasWritePrivilege(bytes)
+                            ? CalendarAccess.WRITABLE
+                            : CalendarAccess.READ_ONLY);
+                        case HttpStatus.SC_UNAUTHORIZED, HttpStatus.SC_FORBIDDEN, HttpStatus.SC_NOT_FOUND -> Mono.just(CalendarAccess.NOT_FOUND);
                         default -> Mono.error(new DavClientException("""
-                            Unexpected response when checking write access for '%s'
+                            Unexpected response when resolving calendar access for '%s'
                             Status: %d
                             Body: %s
                             """.formatted(uri, status, new String(bytes, StandardCharsets.UTF_8))));

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/XMLUtil.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/XMLUtil.java
@@ -104,4 +104,20 @@ public class XMLUtil {
         }
         return eventIds.build();
     }
+
+    /**
+     * Parses a {@code PROPFIND} multistatus response requesting {@code DAV:current-user-privilege-set}
+     * and tells whether the current (impersonated) principal is granted a write-like privilege
+     * ({@code DAV:write}, {@code DAV:write-content} or {@code DAV:bind}) on the resource.
+     */
+    public static boolean hasWritePrivilege(byte[] xml) throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
+        Document doc = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder()
+            .parse(new java.io.ByteArrayInputStream(xml));
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        xpath.setNamespaceContext(new DavNamespaceContext());
+        String expression = "//*[local-name()='current-user-privilege-set']/*[local-name()='privilege']"
+            + "/*[local-name()='write' or local-name()='write-content' or local-name()='bind']";
+        NodeList nodes = (NodeList) xpath.evaluate(expression, doc, XPathConstants.NODESET);
+        return nodes.getLength() > 0;
+    }
 }

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
@@ -47,6 +47,7 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linagora.calendar.api.CalendarUtil;
+import com.linagora.calendar.dav.CalDavClient.CalendarAccess;
 import com.linagora.calendar.dav.CalDavClient.CalendarPropertiesUpdate;
 import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
 import com.linagora.calendar.dav.CalDavClient.NewCalendar;
@@ -1610,63 +1611,66 @@ public class CalDavClientTest {
     }
 
     @Test
-    void hasWriteAccessShouldReturnTrueForOwnCalendar() {
+    void resolveCalendarAccessShouldReturnWritableForOwnCalendar() {
         OpenPaaSUser user = createOpenPaaSUser();
         CalendarURL calendarURL = CalendarURL.from(user.id());
 
-        assertThat(testee.hasWriteAccess(user.username(), calendarURL).block()).isTrue();
+        assertThat(testee.resolveCalendarAccess(user.username(), calendarURL).block()).isEqualTo(CalendarAccess.WRITABLE);
     }
 
     @Test
-    void hasWriteAccessShouldReturnFalseForNonExistingCalendar() {
+    void resolveCalendarAccessShouldReturnNotFoundForNonExistingCalendar() {
         OpenPaaSUser user = createOpenPaaSUser();
         CalendarURL calendarURL = new CalendarURL(user.id(), new OpenPaaSId(UUID.randomUUID().toString()));
 
-        assertThat(testee.hasWriteAccess(user.username(), calendarURL).block()).isFalse();
+        assertThat(testee.resolveCalendarAccess(user.username(), calendarURL).block()).isEqualTo(CalendarAccess.NOT_FOUND);
     }
 
     @Test
-    void hasWriteAccessShouldReturnTrueForReadWriteDelegatedCalendar() {
+    void resolveCalendarAccessShouldReturnWritableForReadWriteDelegatedCalendar() {
         OpenPaaSUser owner = createOpenPaaSUser();
         OpenPaaSUser delegate = createOpenPaaSUser();
+        CalendarURL delegatedCalendar = shareCalendar(owner, delegate,
+            new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
+                Optional.empty(), Optional.of(true), Optional.empty()));
+
+        assertThat(testee.resolveCalendarAccess(delegate.username(), delegatedCalendar).block()).isEqualTo(CalendarAccess.WRITABLE);
+    }
+
+    @Test
+    void resolveCalendarAccessShouldReturnReadOnlyForReadOnlyDelegatedCalendar() {
+        OpenPaaSUser owner = createOpenPaaSUser();
+        OpenPaaSUser delegate = createOpenPaaSUser();
+        CalendarURL delegatedCalendar = shareCalendar(owner, delegate,
+            new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
+                Optional.of(true), Optional.empty(), Optional.empty()));
+
+        assertThat(testee.resolveCalendarAccess(delegate.username(), delegatedCalendar).block()).isEqualTo(CalendarAccess.READ_ONLY);
+    }
+
+    @Test
+    void resolveCalendarAccessShouldReturnWritableForAdministrationDelegatedCalendar() {
+        OpenPaaSUser owner = createOpenPaaSUser();
+        OpenPaaSUser delegate = createOpenPaaSUser();
+        CalendarURL delegatedCalendar = shareCalendar(owner, delegate,
+            new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
+                Optional.empty(), Optional.empty(), Optional.of(true)));
+
+        assertThat(testee.resolveCalendarAccess(delegate.username(), delegatedCalendar).block()).isEqualTo(CalendarAccess.WRITABLE);
+    }
+
+    private CalendarURL shareCalendar(OpenPaaSUser owner, OpenPaaSUser delegate, CalendarSharingUpdate.AddSharee sharee) {
         String calendarId = UUID.randomUUID().toString();
         testee.createNewCalendar(owner.username(), owner.id(), new NewCalendar(calendarId, "Shared calendar", "#0000FF", "")).block();
         CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
 
         testee.updateCalendarShares(owner.username(), calendarURL,
-            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
-                List.of(new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
-                    Optional.empty(), Optional.of(true), Optional.empty())),
-                List.of()))).block();
+            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(List.of(sharee), List.of()))).block();
 
-        CalendarURL delegatedCalendar = testee.findUserCalendars(delegate.username(), delegate.id()).collectList().block().stream()
+        return testee.findUserCalendars(delegate.username(), delegate.id()).collectList().block().stream()
             .filter(url -> !url.calendarId().equals(delegate.id()))
             .findFirst()
             .orElseThrow();
-
-        assertThat(testee.hasWriteAccess(delegate.username(), delegatedCalendar).block()).isTrue();
-    }
-
-    @Test
-    void hasWriteAccessShouldReturnFalseForReadOnlyDelegatedCalendar() {
-        OpenPaaSUser owner = createOpenPaaSUser();
-        OpenPaaSUser delegate = createOpenPaaSUser();
-        String calendarId = UUID.randomUUID().toString();
-        testee.createNewCalendar(owner.username(), owner.id(), new NewCalendar(calendarId, "Shared calendar", "#0000FF", "")).block();
-        CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
-
-        testee.updateCalendarShares(owner.username(), calendarURL,
-            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
-                List.of(new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
-                    Optional.of(true), Optional.empty(), Optional.empty())),
-                List.of()))).block();
-
-        CalendarURL delegatedCalendar = testee.findUserCalendars(delegate.username(), delegate.id()).collectList().block().stream()
-            .filter(url -> !url.calendarId().equals(delegate.id()))
-            .findFirst()
-            .orElseThrow();
-
-        assertThat(testee.hasWriteAccess(delegate.username(), delegatedCalendar).block()).isFalse();
     }
 
     @Test

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
@@ -1610,6 +1610,66 @@ public class CalDavClientTest {
     }
 
     @Test
+    void hasWriteAccessShouldReturnTrueForOwnCalendar() {
+        OpenPaaSUser user = createOpenPaaSUser();
+        CalendarURL calendarURL = CalendarURL.from(user.id());
+
+        assertThat(testee.hasWriteAccess(user.username(), calendarURL).block()).isTrue();
+    }
+
+    @Test
+    void hasWriteAccessShouldReturnFalseForNonExistingCalendar() {
+        OpenPaaSUser user = createOpenPaaSUser();
+        CalendarURL calendarURL = new CalendarURL(user.id(), new OpenPaaSId(UUID.randomUUID().toString()));
+
+        assertThat(testee.hasWriteAccess(user.username(), calendarURL).block()).isFalse();
+    }
+
+    @Test
+    void hasWriteAccessShouldReturnTrueForReadWriteDelegatedCalendar() {
+        OpenPaaSUser owner = createOpenPaaSUser();
+        OpenPaaSUser delegate = createOpenPaaSUser();
+        String calendarId = UUID.randomUUID().toString();
+        testee.createNewCalendar(owner.username(), owner.id(), new NewCalendar(calendarId, "Shared calendar", "#0000FF", "")).block();
+        CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
+
+        testee.updateCalendarShares(owner.username(), calendarURL,
+            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
+                List.of(new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
+                    Optional.empty(), Optional.of(true), Optional.empty())),
+                List.of()))).block();
+
+        CalendarURL delegatedCalendar = testee.findUserCalendars(delegate.username(), delegate.id()).collectList().block().stream()
+            .filter(url -> !url.calendarId().equals(delegate.id()))
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(testee.hasWriteAccess(delegate.username(), delegatedCalendar).block()).isTrue();
+    }
+
+    @Test
+    void hasWriteAccessShouldReturnFalseForReadOnlyDelegatedCalendar() {
+        OpenPaaSUser owner = createOpenPaaSUser();
+        OpenPaaSUser delegate = createOpenPaaSUser();
+        String calendarId = UUID.randomUUID().toString();
+        testee.createNewCalendar(owner.username(), owner.id(), new NewCalendar(calendarId, "Shared calendar", "#0000FF", "")).block();
+        CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
+
+        testee.updateCalendarShares(owner.username(), calendarURL,
+            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
+                List.of(new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
+                    Optional.of(true), Optional.empty(), Optional.empty())),
+                List.of()))).block();
+
+        CalendarURL delegatedCalendar = testee.findUserCalendars(delegate.username(), delegate.id()).collectList().block().stream()
+            .filter(url -> !url.calendarId().equals(delegate.id()))
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(testee.hasWriteAccess(delegate.username(), delegatedCalendar).block()).isFalse();
+    }
+
+    @Test
     void updateCalendarSharesShouldThrowWhenCalendarDoesNotExist() {
         OpenPaaSUser owner = createOpenPaaSUser();
         OpenPaaSUser delegate = createOpenPaaSUser();

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/CalendarRestApiServer.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/CalendarRestApiServer.java
@@ -19,6 +19,7 @@
 package com.linagora.calendar.restapi;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
@@ -88,6 +89,10 @@ public class CalendarRestApiServer implements Startable  {
                     if (e instanceof UnauthorizedException) {
                         LOGGER.info("Wrong authentication", e);
                         return response.status(UNAUTHORIZED).send();
+                    }
+                    if (e instanceof ForbiddenException) {
+                        LOGGER.info("Forbidden request {} {}", request.method(), request.uri(), e);
+                        return response.status(FORBIDDEN).send();
                     }
                     if (e instanceof NotFoundException) {
                         return response.status(NOT_FOUND).send();

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
@@ -146,19 +146,11 @@ public class BookingLinkCreateRoute extends CalendarRoute {
     }
 
     private Mono<Void> validateCalendarAccess(CalendarURL calendarURL, MailboxSession session) {
-        return calDavClient.calendarExists(session.getUser(), calendarURL)
-            .flatMap(exists -> {
-                if (exists) {
-                    return Mono.empty();
-                }
-                return Mono.error(new IllegalArgumentException("Calendar not found or access denied: " + calendarURL.asUri()));
-            })
-            .then(calDavClient.hasWriteAccess(session.getUser(), calendarURL))
-            .flatMap(hasWriteAccess -> {
-                if (hasWriteAccess) {
-                    return Mono.empty();
-                }
-                return Mono.error(new ForbiddenException("User does not have write access to calendar: " + calendarURL.asUri()));
+        return calDavClient.resolveCalendarAccess(session.getUser(), calendarURL)
+            .flatMap(access -> switch (access) {
+                case WRITABLE -> Mono.<Void>empty();
+                case READ_ONLY -> Mono.error(new ForbiddenException("User does not have write access to calendar: " + calendarURL.asUri()));
+                case NOT_FOUND -> Mono.error(new IllegalArgumentException("Calendar not found or access denied: " + calendarURL.asUri()));
             });
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
@@ -46,6 +46,7 @@ import com.google.common.base.Strings;
 import com.linagora.calendar.api.booking.AvailabilityRule;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.restapi.ForbiddenException;
 import com.linagora.calendar.restapi.routes.dto.AvailabilityRuleDTO;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
@@ -151,6 +152,13 @@ public class BookingLinkCreateRoute extends CalendarRoute {
                     return Mono.empty();
                 }
                 return Mono.error(new IllegalArgumentException("Calendar not found or access denied: " + calendarURL.asUri()));
+            })
+            .then(calDavClient.hasWriteAccess(session.getUser(), calendarURL))
+            .flatMap(hasWriteAccess -> {
+                if (hasWriteAccess) {
+                    return Mono.empty();
+                }
+                return Mono.error(new ForbiddenException("User does not have write access to calendar: " + calendarURL.asUri()));
             });
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
@@ -114,19 +114,11 @@ public class BookingLinkPatchRoute extends CalendarRoute {
     }
 
     private Mono<Void> validateCalendarAccess(CalendarURL calendarURL, MailboxSession session) {
-        return calDavClient.calendarExists(session.getUser(), calendarURL)
-            .flatMap(exists -> {
-                if (exists) {
-                    return Mono.empty();
-                }
-                return Mono.error(new IllegalArgumentException("Calendar not found or access denied: " + calendarURL.asUri()));
-            })
-            .then(calDavClient.hasWriteAccess(session.getUser(), calendarURL))
-            .flatMap(hasWriteAccess -> {
-                if (hasWriteAccess) {
-                    return Mono.empty();
-                }
-                return Mono.error(new ForbiddenException("User does not have write access to calendar: " + calendarURL.asUri()));
+        return calDavClient.resolveCalendarAccess(session.getUser(), calendarURL)
+            .flatMap(access -> switch (access) {
+                case WRITABLE -> Mono.<Void>empty();
+                case READ_ONLY -> Mono.error(new ForbiddenException("User does not have write access to calendar: " + calendarURL.asUri()));
+                case NOT_FOUND -> Mono.error(new IllegalArgumentException("Calendar not found or access denied: " + calendarURL.asUri()));
             });
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.restapi.ForbiddenException;
 import com.linagora.calendar.restapi.routes.dto.AvailabilityRuleDTO;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
@@ -119,6 +120,13 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                     return Mono.empty();
                 }
                 return Mono.error(new IllegalArgumentException("Calendar not found or access denied: " + calendarURL.asUri()));
+            })
+            .then(calDavClient.hasWriteAccess(session.getUser(), calendarURL))
+            .flatMap(hasWriteAccess -> {
+                if (hasWriteAccess) {
+                    return Mono.empty();
+                }
+                return Mono.error(new ForbiddenException("User does not have write access to calendar: " + calendarURL.asUri()));
             });
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationRoute.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.BookedEventTokenSigner;
 import com.linagora.calendar.restapi.ErrorType;
+import com.linagora.calendar.restapi.ForbiddenException;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationException.SlotNotAvailableException;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest.BookingAttendee;
@@ -102,6 +103,10 @@ public class BookingLinkReservationRoute extends PublicRoute {
             case SlotNotAvailableException slotNotAvailableException -> {
                 LOGGER.warn("Requested slot is unavailable (likely busy) for [{}]: {}", request.uri(), slotNotAvailableException.getMessage());
                 yield ErrorResponseHandler.handle(response, HttpResponseStatus.UNPROCESSABLE_ENTITY, ErrorType.UNAVAILABLE_BOOKING_SLOT, slotNotAvailableException);
+            }
+            case ForbiddenException forbiddenException -> {
+                LOGGER.warn("Booking rejected, owner lacks write access for [{}]: {}", request.uri(), forbiddenException.getMessage());
+                yield ErrorResponseHandler.handle(response, HttpResponseStatus.FORBIDDEN, forbiddenException);
             }
             case BookingLinkReservationException bookingLinkReservationException -> {
                 LOGGER.error("Booking operation failed for [{}]", request.uri(), bookingLinkReservationException);

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.BookedEventTokenSigner.BookedEvent;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.CalDavClient.CalendarAccess;
 import com.linagora.calendar.restapi.ForbiddenException;
 import com.linagora.calendar.restapi.RestApiConfiguration;
 import com.linagora.calendar.restapi.routes.BookingLinkEventIcsBuilder.BuildResult;
@@ -80,9 +81,9 @@ public class BookingLinkReservationService {
     }
 
     private Mono<Void> validateCalendarWriteAccess(BookingLink bookingLink) {
-        return calDavClient.hasWriteAccess(bookingLink.username(), bookingLink.calendarUrl())
-            .flatMap(hasWriteAccess -> {
-                if (hasWriteAccess) {
+        return calDavClient.resolveCalendarAccess(bookingLink.username(), bookingLink.calendarUrl())
+            .flatMap(access -> {
+                if (access == CalendarAccess.WRITABLE) {
                     return Mono.empty();
                 }
                 return Mono.error(new ForbiddenException("Booking link owner no longer has write access to calendar: "

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.BookedEventTokenSigner.BookedEvent;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.AvailabilitySlot;
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.restapi.ForbiddenException;
 import com.linagora.calendar.restapi.RestApiConfiguration;
 import com.linagora.calendar.restapi.routes.BookingLinkEventIcsBuilder.BuildResult;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest.BookingAttendee;
@@ -73,8 +74,20 @@ public class BookingLinkReservationService {
 
     public Mono<BookedEvent> book(BookingLinkPublicId publicId, BookingRequest request) {
         return bookingLinkSlotsService.getBookingLink(publicId)
-            .flatMap(bookingLink -> validateSlotAvailability(bookingLink, request.slotStartUtc())
+            .flatMap(bookingLink -> validateCalendarWriteAccess(bookingLink)
+                .then(validateSlotAvailability(bookingLink, request.slotStartUtc()))
                 .then(createBooking(bookingLink, request)));
+    }
+
+    private Mono<Void> validateCalendarWriteAccess(BookingLink bookingLink) {
+        return calDavClient.hasWriteAccess(bookingLink.username(), bookingLink.calendarUrl())
+            .flatMap(hasWriteAccess -> {
+                if (hasWriteAccess) {
+                    return Mono.empty();
+                }
+                return Mono.error(new ForbiddenException("Booking link owner no longer has write access to calendar: "
+                    + bookingLink.calendarUrl().asUri()));
+            });
     }
 
     private Mono<Void> validateSlotAvailability(BookingLink bookingLink, Instant startUtc) {

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
@@ -369,6 +369,13 @@ public class BookingLinkUserRoutes implements Routes {
                     return Mono.empty();
                 }
                 return Mono.error(badRequest("Calendar not found or access denied: " + calendarURL.asUri(), null));
+            })
+            .then(calDavClient.hasWriteAccess(username, calendarURL))
+            .flatMap(hasWriteAccess -> {
+                if (hasWriteAccess) {
+                    return Mono.empty();
+                }
+                return Mono.error(forbidden("User does not have write access to calendar: " + calendarURL.asUri()));
             });
     }
 
@@ -420,6 +427,14 @@ public class BookingLinkUserRoutes implements Routes {
             .map(Throwable::getMessage)
             .orElse(e.getMessage());
         return badRequest("Invalid request body: %s".formatted(detail), e);
+    }
+
+    private HaltException forbidden(String message) {
+        return ErrorResponder.builder()
+            .statusCode(HttpStatus.FORBIDDEN_403)
+            .type(ErrorResponder.ErrorType.WRONG_STATE)
+            .message(StringUtils.defaultString(message, "Forbidden"))
+            .haltError();
     }
 
     private HaltException badRequest(String message, Exception cause) {

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
@@ -363,19 +363,11 @@ public class BookingLinkUserRoutes implements Routes {
     }
 
     private Mono<Void> validateCalendarAccess(Username username, CalendarURL calendarURL) {
-        return calDavClient.calendarExists(username, calendarURL)
-            .flatMap(exists -> {
-                if (exists) {
-                    return Mono.empty();
-                }
-                return Mono.error(badRequest("Calendar not found or access denied: " + calendarURL.asUri(), null));
-            })
-            .then(calDavClient.hasWriteAccess(username, calendarURL))
-            .flatMap(hasWriteAccess -> {
-                if (hasWriteAccess) {
-                    return Mono.empty();
-                }
-                return Mono.error(forbidden("User does not have write access to calendar: " + calendarURL.asUri()));
+        return calDavClient.resolveCalendarAccess(username, calendarURL)
+            .flatMap(access -> switch (access) {
+                case WRITABLE -> Mono.<Void>empty();
+                case READ_ONLY -> Mono.error(forbidden("User does not have write access to calendar: " + calendarURL.asUri()));
+                case NOT_FOUND -> Mono.error(badRequest("Calendar not found or access denied: " + calendarURL.asUri(), null));
             });
     }
 

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
@@ -296,6 +296,26 @@ public class BookingLinkUserRoutesTest {
             .statusCode(201);
     }
 
+    @Test
+    void createShouldReturn201WhenCalendarIsAdministrationDelegated() {
+        CalendarURL ownerCalendar = CalendarURL.from(otherUser.id());
+        davTestHelper.grantDelegation(otherUser, ownerCalendar, user, "dav:administration");
+        CalendarURL delegatedCalendar = findMirrorCalendar(user);
+
+        given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true
+                }
+                """.formatted(delegatedCalendar.asUri().toString()))
+        .when()
+            .post("/users/{username}/booking-links", user.username().asString())
+        .then()
+            .statusCode(201);
+    }
+
     private CalendarURL findMirrorCalendar(OpenPaaSUser user) {
         return Fixture.awaitAtMost.until(() -> calDavClient.findUserCalendarList(user)
             .map(response -> response.calendars()

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
@@ -47,6 +47,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.linagora.calendar.api.booking.AvailabilityRule.WeeklyAvailabilityRule;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.DavTestHelper;
+import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSUser;
@@ -69,6 +71,8 @@ public class BookingLinkUserRoutesTest {
 
     private WebAdminServer webAdminServer;
     private MongoDBBookingLinkDAO bookingLinkDAO;
+    private CalDavClient calDavClient;
+    private DavTestHelper davTestHelper;
     private OpenPaaSUser user;
     private OpenPaaSUser otherUser;
 
@@ -77,7 +81,8 @@ public class BookingLinkUserRoutesTest {
         MongoDatabase mongoDB = sabreDavExtension.dockerSabreDavSetup().getMongoDB();
         MongoDBOpenPaaSDomainDAO domainDAO = new MongoDBOpenPaaSDomainDAO(mongoDB);
         OpenPaaSUserDAO userDAO = new MongoDBOpenPaaSUserDAO(mongoDB, domainDAO);
-        CalDavClient calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+        davTestHelper = new DavTestHelper(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
         bookingLinkDAO = new MongoDBBookingLinkDAO(mongoDB, Clock.system(UTC));
 
         user = sabreDavExtension.newTestUser();
@@ -247,6 +252,58 @@ public class BookingLinkUserRoutesTest {
             .post("/users/{username}/booking-links", user.username().asString())
         .then()
             .statusCode(400);
+    }
+
+    @Test
+    void createShouldReturn403WhenCalendarIsReadOnlyDelegated() {
+        CalendarURL ownerCalendar = CalendarURL.from(otherUser.id());
+        davTestHelper.grantDelegation(otherUser, ownerCalendar, user, "dav:read");
+        CalendarURL delegatedCalendar = findMirrorCalendar(user);
+
+        given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true
+                }
+                """.formatted(delegatedCalendar.asUri().toString()))
+        .when()
+            .post("/users/{username}/booking-links", user.username().asString())
+        .then()
+            .statusCode(403);
+
+        assertThat(bookingLinkDAO.findByUsername(user.username()).collectList().block()).isEmpty();
+    }
+
+    @Test
+    void createShouldReturn201WhenCalendarIsReadWriteDelegated() {
+        CalendarURL ownerCalendar = CalendarURL.from(otherUser.id());
+        davTestHelper.grantDelegation(otherUser, ownerCalendar, user, "dav:read-write");
+        CalendarURL delegatedCalendar = findMirrorCalendar(user);
+
+        given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true
+                }
+                """.formatted(delegatedCalendar.asUri().toString()))
+        .when()
+            .post("/users/{username}/booking-links", user.username().asString())
+        .then()
+            .statusCode(201);
+    }
+
+    private CalendarURL findMirrorCalendar(OpenPaaSUser user) {
+        return Fixture.awaitAtMost.until(() -> calDavClient.findUserCalendarList(user)
+            .map(response -> response.calendars()
+                .keySet()
+                .stream()
+                .filter(calendarURL -> !calendarURL.equals(CalendarURL.from(user.id())))
+                .findFirst())
+            .block(), Optional::isPresent).get();
     }
 
     @Test


### PR DESCRIPTION
Closes #932

## What

A booking link could be created (or patched) on a calendar the user only has **read** access to — a read-only delegated calendar. The failure only surfaced later, when a reservation tried to create the event on the CalDAV server and got rejected (`403`), leaving the booker with a confusing error.

## Changes

- Add `CalDavClient#hasWriteAccess`, which performs a `PROPFIND` on `DAV:current-user-privilege-set` and checks for a write-like privilege (`DAV:write` / `write-content` / `bind`).
- **Create / patch booking link** (REST `POST|PATCH /api/booking-links` and the webadmin user API): reject with **403** when the target calendar is not writable by the user.
- **Reserve a slot** (`POST /api/booking-links/{id}/book`): reject with **403** when the booking link owner no longer has write access to the calendar, instead of failing with a `500` at event-creation time.
- Map `ForbiddenException` to a `403` response in the REST API server and the reservation route.

## Tests

- `CalDavClientTest`: `hasWriteAccess` for own / non-existing / read-write delegated / read-only delegated calendars.
- `BookingLinkCreateRouteTest` and webadmin `BookingLinkUserRoutesTest`: 403 on read-only delegated, 201 on read-write delegated.
- `BookingLinkReservationRouteTest`: 403 when reserving on a read-only calendar.

All new tests pass against the SabreDAV integration setup; compilation and checkstyle are clean.

---
*Generated automatically*
