### PR TITLE
ISSUE-934 Tolerate version conflicts on calendar event delete-by-query

### DIFF
--- a/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
+++ b/storage-opensearch/src/main/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchService.java
@@ -39,6 +39,7 @@ import org.apache.james.core.MailAddress;
 import org.apache.james.util.ReactorUtils;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Result;
 import org.opensearch.client.opensearch._types.Script;
@@ -50,6 +51,8 @@ import org.opensearch.client.opensearch._types.query_dsl.Operator;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.TermsQueryField;
+import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
+import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.UpdateRequest;
 
@@ -185,7 +188,7 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
             .build()
             .toQuery();
 
-        return indexer.deleteAllMatchingQuery(staleOccurrencesQuery, ROUTING_KEY.apply(calendarURL.base()))
+        return deleteByQuery(staleOccurrencesQuery, ROUTING_KEY.apply(calendarURL.base()))
             .onErrorResume(error -> Mono.error(CalendarSearchIndexingException.of("Failed to delete stale calendar occurrences",
                 calendarURL, fields.eventUid(), error)))
             .then();
@@ -237,7 +240,7 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
             .build()
             .toQuery();
 
-        return indexer.deleteAllMatchingQuery(query, ROUTING_KEY.apply(calendarURL.base()))
+        return deleteByQuery(query, ROUTING_KEY.apply(calendarURL.base()))
             .onErrorResume(error -> Mono.error(CalendarSearchIndexingException.of("Failed to delete calendar event",
                 calendarURL, eventUid, error)))
             .then();
@@ -306,7 +309,7 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
     public Mono<Void> deleteAll(OpenPaaSId baseCalendarId) {
         Preconditions.checkArgument(baseCalendarId != null, "baseCalendarId can not be null");
 
-        return indexer.deleteAllMatchingQuery(baseCalendarIdQuery(baseCalendarId), ROUTING_KEY.apply(baseCalendarId))
+        return deleteByQuery(baseCalendarIdQuery(baseCalendarId), ROUTING_KEY.apply(baseCalendarId))
             .onErrorResume(error -> Mono.error(CalendarSearchIndexingException.of("Failed to delete calendar events",
                 baseCalendarId, error)))
             .then();
@@ -463,6 +466,39 @@ public class OpensearchCalendarSearchService implements CalendarSearchService {
 
         return toReactor(opensearchAsyncClient.update(request, ObjectNode.class))
             .map(updateResponse -> (WriteResponseBase) updateResponse);
+    }
+
+    // A delete-by-query runs in two phases: it first snapshots the documents matching the query, then bulk
+    // deletes them using the sequence numbers captured during the snapshot. When a concurrent (or reordered)
+    // message re-indexes one of those documents in between, its sequence number changes and the bulk delete
+    // is rejected with a version conflict (HTTP 409), aborting the whole operation (see issue #934).
+    // We ask OpenSearch to proceed past conflicts rather than abort, then retry so the documents that were
+    // concurrently rewritten are still removed. Retries are bounded; residual conflicts are left for a later
+    // message to clean up rather than looping indefinitely against a document under sustained writes.
+    private Mono<Void> deleteByQuery(Query query, RoutingKey routingKey) {
+        return deleteByQuery(query, routingKey, MAX_RETRY_ON_CONFLICT);
+    }
+
+    private Mono<Void> deleteByQuery(Query query, RoutingKey routingKey, int remainingRetries) {
+        DeleteByQueryRequest request = new DeleteByQueryRequest.Builder()
+            .index(configuration.writeAliasName().getValue())
+            .query(query)
+            .routing(routingKey.asString())
+            .conflicts(Conflicts.Proceed)
+            .refresh(true)
+            .build();
+
+        return Mono.defer(Throwing.supplier(() -> toReactor(opensearchAsyncClient.deleteByQuery(request))))
+            .flatMap(response -> {
+                if (hasVersionConflict(response) && remainingRetries > 0) {
+                    return deleteByQuery(query, routingKey, remainingRetries - 1);
+                }
+                return Mono.<Void>empty();
+            });
+    }
+
+    private boolean hasVersionConflict(DeleteByQueryResponse response) {
+        return response.versionConflicts() != null && response.versionConflicts() > 0;
     }
 
     private static <T> Mono<T> toReactor(CompletableFuture<T> async) {

--- a/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchServiceTest.java
+++ b/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchServiceTest.java
@@ -18,6 +18,7 @@
 
 package com.linagora.calendar.storage.opensearch;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.List;
@@ -43,6 +44,8 @@ import com.linagora.calendar.storage.eventsearch.CalendarEvents;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchService;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchServiceContract;
 import com.linagora.calendar.storage.eventsearch.EventSearchQuery;
+
+import reactor.core.publisher.Flux;
 
 public class OpensearchCalendarSearchServiceTest implements CalendarSearchServiceContract {
     @RegisterExtension
@@ -213,5 +216,27 @@ public class OpensearchCalendarSearchServiceTest implements CalendarSearchServic
             .collectList().block();
 
         assertThat(searchResults).hasSize(0);
+    }
+
+    @Test
+    void deleteShouldNotFailWhenEventIsConcurrentlyReindexed() {
+        // Reproduces issue #934: a delete-by-query racing with concurrent re-indexing of the same event used to
+        // abort with a version conflict (HTTP 409). The delete must now proceed past the conflict rather than fail.
+        EventFields event = EventFields.builder()
+            .uid(generateEventUid())
+            .summary("concurrent")
+            .calendarURL(generateCalendarURL())
+            .build();
+
+        CalendarEvents events = CalendarEvents.of(event);
+
+        Flux<Void> reindexing = Flux.range(0, 300)
+            .flatMap(i -> testee().reindex(events), 8);
+
+        Flux<Void> deleting = Flux.range(0, 100)
+            .concatMap(i -> testee().delete(event.calendarURL(), event.uid()));
+
+        assertThatCode(() -> Flux.merge(reindexing, deleting).blockLast())
+            .doesNotThrowAnyException();
     }
 }

--- a/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchServiceTest.java
+++ b/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchServiceTest.java
@@ -238,5 +238,17 @@ public class OpensearchCalendarSearchServiceTest implements CalendarSearchServic
 
         assertThatCode(() -> Flux.merge(reindexing, deleting).blockLast())
             .doesNotThrowAnyException();
+
+        // Whether the event survives the race depends on which operation ran last, so delete it once more now
+        // that no writer competes, and check the document is effectively gone.
+        testee().delete(event.calendarURL(), event.uid()).block();
+
+        EventSearchQuery query = simpleQuery("concurrent", event.calendarURL());
+        CALMLY_AWAIT.untilAsserted(() -> {
+            List<EventFields> searchResults = testee().search(query)
+                .collectList().block();
+
+            assertThat(searchResults).hasSize(0);
+        });
     }
 }


### PR DESCRIPTION
Closes #934

## Problem

`EventIndexerConsumer` logs `Failed to delete eventUid ... from calendarURL ...` with an OpenSearch `409 Conflict` / `version_conflict_engine_exception`.

An OpenSearch `_delete_by_query` runs in two phases: it first snapshots the documents matching the query, then bulk-deletes them using the sequence numbers captured during the snapshot. When a concurrent (or reordered) message re-indexes one of those documents in between, its sequence number changes, so the bulk delete is rejected with a version conflict (HTTP 409) and the whole delete aborts. The event is therefore left in the search index and the failure is only logged as a `WARN`.

## Fix

`OpensearchCalendarSearchService` now issues the delete-by-query with `conflicts=proceed` instead of aborting, and retries a bounded number of times while version conflicts remain, so the concurrently-rewritten documents are still removed. Residual conflicts (a document under sustained writes) are left for a later message to clean up rather than looping indefinitely.

This applies to all three delete paths: `delete`, `deleteAll` and stale-occurrence pruning.

## Test

Added `deleteShouldNotFailWhenEventIsConcurrentlyReindexed`, which interleaves continuous re-indexing with deletes of the same event. It reliably reproduces the exact `version_conflict_engine_exception` from the issue (verified: the test fails with `conflicts=abort`) and passes with the fix.

---
*Generated automatically*
