### PR TITLE
ISSUE-937 Make ErrorDetail type field compulsory

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -620,6 +620,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
+                  "type": "UnprocessableEntity",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc %s"
                 }
@@ -651,6 +652,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
+                  "type": "UnprocessableEntity",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc %s"
                 }
@@ -683,6 +685,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
+                  "type": "UnprocessableEntity",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc %s"
                 }
@@ -788,6 +791,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
+                  "type": "UnprocessableEntity",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc 2036-01-26T08:00:00Z"
                 }
@@ -829,6 +833,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
+                  "type": "UnprocessableEntity",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc 2036-01-26T09:30:00Z"
                 }
@@ -874,6 +879,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
+                  "type": "UnprocessableEntity",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc 2036-01-26T09:30:00Z"
                 }
@@ -914,6 +920,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "Missing or invalid request body"
                 }
@@ -943,6 +950,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "Missing or invalid request body"
                 }
@@ -969,6 +977,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "Missing or invalid request body"
                 }
@@ -999,6 +1008,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "'email' has invalid format: invalid-email"
                 }
@@ -1035,6 +1045,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "'additional_attendees' must not contain creator email"
                 }
@@ -1077,6 +1088,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "'additional_attendees' contains duplicate email: VANA@example.com"
                 }
@@ -1119,6 +1131,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "'additional_attendees' must not exceed 20 items"
                 }
@@ -1149,6 +1162,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "'eventTitle' must not be blank"
                 }
@@ -1179,6 +1193,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "'eventTitle' must not exceed 255 characters"
                 }
@@ -1210,6 +1225,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 400,
+                  "type": "BadRequest",
                   "message": "Bad Request",
                   "details": "'notes' must not exceed 2000 characters"
                 }
@@ -1259,6 +1275,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 404,
+                  "type": "NotFound",
                   "message": "Not Found",
                   "details": "Cannot find booking link with publicId %s"
                 }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -620,7 +620,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
-                  "type": "UnprocessableEntity",
+                  "type": "UnavailableBookingSlot",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc %s"
                 }
@@ -652,7 +652,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
-                  "type": "UnprocessableEntity",
+                  "type": "UnavailableBookingSlot",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc %s"
                 }
@@ -685,7 +685,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
-                  "type": "UnprocessableEntity",
+                  "type": "UnavailableBookingSlot",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc %s"
                 }
@@ -791,7 +791,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
-                  "type": "UnprocessableEntity",
+                  "type": "UnavailableBookingSlot",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc 2036-01-26T08:00:00Z"
                 }
@@ -833,7 +833,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
-                  "type": "UnprocessableEntity",
+                  "type": "UnavailableBookingSlot",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc 2036-01-26T09:30:00Z"
                 }
@@ -879,7 +879,7 @@ class BookingLinkReservationRouteTest {
             .body("error", jsonEquals("""
                 {
                   "code": 422,
-                  "type": "UnprocessableEntity",
+                  "type": "UnavailableBookingSlot",
                   "message": "Unprocessable Entity",
                   "details": "Requested slot is not available for booking link with publicId %s, slotStartUtc 2036-01-26T09:30:00Z"
                 }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -389,6 +389,7 @@ class BookingLinkSlotsRouteTest {
                 {
                     "error": {
                         "code": 400,
+                        "type": "BadRequest",
                         "message": "Bad Request",
                         "details": "Invalid query parameter 'timeZone': Invalid/Zone"
                     }
@@ -673,6 +674,7 @@ class BookingLinkSlotsRouteTest {
                 {
                     "error": {
                         "code": 400,
+                        "type": "BadRequest",
                         "message": "Bad Request",
                         "details": "Requested range is too large, max is %s days"
                     }
@@ -760,6 +762,7 @@ class BookingLinkSlotsRouteTest {
                 {
                     "error": {
                         "code": 400,
+                        "type": "BadRequest",
                         "message": "Bad Request",
                         "details": "Missing or invalid query parameter 'from'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
                     }
@@ -789,6 +792,7 @@ class BookingLinkSlotsRouteTest {
                 {
                     "error": {
                         "code": 400,
+                        "type": "BadRequest",
                         "message": "Bad Request",
                         "details": "Missing or invalid query parameter 'to'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
                     }
@@ -819,6 +823,7 @@ class BookingLinkSlotsRouteTest {
                 {
                     "error": {
                         "code": 400,
+                        "type": "BadRequest",
                         "message": "Bad Request",
                         "details": "Missing or invalid query parameter 'from'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
                     }
@@ -849,6 +854,7 @@ class BookingLinkSlotsRouteTest {
                 {
                     "error": {
                         "code": 400,
+                        "type": "BadRequest",
                         "message": "Bad Request",
                         "details": "Missing or invalid query parameter 'to'. Expected ISO-8601 instant format, e.g. 2007-12-03T10:15:30.00Z"
                     }
@@ -879,6 +885,7 @@ class BookingLinkSlotsRouteTest {
                 {
                     "error": {
                         "code": 400,
+                        "type": "BadRequest",
                         "message": "Bad Request",
                         "details": "'to' must be after 'from'"
                     }
@@ -907,6 +914,7 @@ class BookingLinkSlotsRouteTest {
                 {
                     "error": {
                         "code": 404,
+                        "type": "NotFound",
                         "message": "Not Found",
                         "details": "Cannot find booking link with publicId %s"
                     }
@@ -938,6 +946,7 @@ class BookingLinkSlotsRouteTest {
                 {
                     "error": {
                         "code": 404,
+                        "type": "NotFound",
                         "message": "Not Found",
                         "details": "Cannot find booking link with publicId %s"
                     }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/CheckTechnicalUserTokenRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/CheckTechnicalUserTokenRouteTest.java
@@ -175,6 +175,7 @@ class CheckTechnicalUserTokenRouteTest {
                 {
                     "error": {
                         "code": 404,
+                        "type": "NotFound",
                         "message": "Not found",
                         "details": "Token not found or expired"
                     }
@@ -201,6 +202,7 @@ class CheckTechnicalUserTokenRouteTest {
                 {
                     "error": {
                         "code": 404,
+                        "type": "NotFound",
                         "message": "Not found",
                         "details": "Token not found or expired"
                     }
@@ -224,6 +226,7 @@ class CheckTechnicalUserTokenRouteTest {
                 {
                     "error": {
                         "code": 404,
+                        "type": "NotFound",
                         "message": "Not found",
                         "details": "Token not found or expired"
                     }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/DownloadCalendarRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/DownloadCalendarRouteTest.java
@@ -186,6 +186,7 @@ class DownloadCalendarRouteTest {
             {
                 "error": {
                     "code": 403,
+                    "type": "Forbidden",
                     "message": "Forbidden",
                     "details": "Token validation failed"
                 }
@@ -216,6 +217,7 @@ class DownloadCalendarRouteTest {
         {
             "error": {
                 "code": 403,
+                "type": "Forbidden",
                 "message": "Forbidden",
                 "details": "Token validation failed"
             }
@@ -250,6 +252,7 @@ class DownloadCalendarRouteTest {
         {
             "error": {
                 "code": 400,
+                "type": "BadRequest",
                 "message": "Bad Request",
                 "details": "Invalid token: only letters, digits, hyphen, and underscore are allowed."
             }
@@ -293,6 +296,7 @@ class DownloadCalendarRouteTest {
         {
             "error": {
                 "code": 403,
+                "type": "Forbidden",
                 "message": "Forbidden",
                 "details": "Token validation failed"
             }
@@ -326,6 +330,7 @@ class DownloadCalendarRouteTest {
                 {
                     "error": {
                         "code": 503,
+                        "type": "ServiceUnavailable",
                         "message": "Service Unavailable",
                         "details": "Service Unavailable"
                     }
@@ -538,6 +543,7 @@ class DownloadCalendarRouteTest {
                 {
                     "error": {
                         "code": 404,
+                        "type": "NotFound",
                         "message": "Not Found",
                         "details": "${json-unit.ignore}"
                     }
@@ -728,6 +734,7 @@ class DownloadCalendarRouteTest {
                 {
                     "error": {
                         "code": 404,
+                        "type": "NotFound",
                         "message": "Not Found",
                         "details": "${json-unit.ignore}"
                     }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
@@ -542,6 +542,7 @@ class EventParticipationRouteTest {
                 {
                     "error": {
                         "code": 401,
+                        "type": "Unauthorized",
                         "message": "Unauthorized",
                         "details": "JWT is missing or invalid"
                     }
@@ -571,6 +572,7 @@ class EventParticipationRouteTest {
             {
                 "error": {
                     "code": 404,
+                    "type": "NotFound",
                     "message": "Not found",
                     "details": "${json-unit.ignore}"
                 }
@@ -615,6 +617,7 @@ class EventParticipationRouteTest {
             {
                 "error": {
                     "code": 404,
+                    "type": "NotFound",
                     "message": "Not found",
                     "details": "${json-unit.ignore}"
                 }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/UserConfigurationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/UserConfigurationRouteTest.java
@@ -338,6 +338,7 @@ class UserConfigurationRouteTest {
             {
                  "error": {
                      "code": 400,
+                     "type": "BadRequest",
                      "message": "Bad request",
                      "details": "Invalid request body"
                  }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/ErrorResponse.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/ErrorResponse.java
@@ -18,9 +18,6 @@
 
 package com.linagora.calendar.restapi;
 
-import java.util.Optional;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -29,20 +26,20 @@ public record ErrorResponse(@JsonProperty("error") ErrorDetail error) {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
         .registerModule(new Jdk8Module());
 
-    public static ErrorResponse of(int code, String message, String details) {
-        return new ErrorResponse(new ErrorDetail(code, Optional.empty(), message, details));
+    public static ErrorResponse of(int code, ErrorType type, String message, String details) {
+        return of(code, type.asString(), message, details);
     }
 
     public static ErrorResponse of(int code, String type, String message, String details) {
-        return new ErrorResponse(new ErrorDetail(code, Optional.of(type), message, details));
+        return new ErrorResponse(new ErrorDetail(code, type, message, details));
     }
 
     public static ErrorResponse of(IllegalArgumentException illegalArgumentException) {
-        return new ErrorResponse(new ErrorDetail(400, Optional.empty(), "Bad request", illegalArgumentException.getMessage()));
+        return of(400, ErrorType.BAD_REQUEST, "Bad request", illegalArgumentException.getMessage());
     }
 
     public record ErrorDetail(@JsonProperty("code") int code,
-                              @JsonInclude(JsonInclude.Include.NON_ABSENT) @JsonProperty("type") Optional<String> type,
+                              @JsonProperty("type") String type,
                               @JsonProperty("message") String message,
                               @JsonProperty("details") String details) {
     }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/ErrorType.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/ErrorType.java
@@ -18,8 +18,29 @@
 
 package com.linagora.calendar.restapi;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
+
 public enum ErrorType {
+    BAD_REQUEST("BadRequest"),
+    UNAUTHORIZED("Unauthorized"),
+    FORBIDDEN("Forbidden"),
+    NOT_FOUND("NotFound"),
+    UNPROCESSABLE_ENTITY("UnprocessableEntity"),
+    SERVICE_UNAVAILABLE("ServiceUnavailable"),
+    SERVER_ERROR("ServerError"),
     INACTIVE_BOOKING_LINK("InactiveBookingLink");
+
+    public static ErrorType fromStatus(HttpResponseStatus status) {
+        return switch (status.code()) {
+            case 400 -> BAD_REQUEST;
+            case 401 -> UNAUTHORIZED;
+            case 403 -> FORBIDDEN;
+            case 404 -> NOT_FOUND;
+            case 422 -> UNPROCESSABLE_ENTITY;
+            case 503 -> SERVICE_UNAVAILABLE;
+            default -> SERVER_ERROR;
+        };
+    }
 
     private final String value;
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/ErrorType.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/ErrorType.java
@@ -28,7 +28,8 @@ public enum ErrorType {
     UNPROCESSABLE_ENTITY("UnprocessableEntity"),
     SERVICE_UNAVAILABLE("ServiceUnavailable"),
     SERVER_ERROR("ServerError"),
-    INACTIVE_BOOKING_LINK("InactiveBookingLink");
+    INACTIVE_BOOKING_LINK("InactiveBookingLink"),
+    UNAVAILABLE_BOOKING_SLOT("UnavailableBookingSlot");
 
     public static ErrorType fromStatus(HttpResponseStatus status) {
         return switch (status.code()) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationRoute.java
@@ -101,7 +101,7 @@ public class BookingLinkReservationRoute extends PublicRoute {
             }
             case SlotNotAvailableException slotNotAvailableException -> {
                 LOGGER.warn("Requested slot is unavailable (likely busy) for [{}]: {}", request.uri(), slotNotAvailableException.getMessage());
-                yield ErrorResponseHandler.handle(response, HttpResponseStatus.UNPROCESSABLE_ENTITY, slotNotAvailableException);
+                yield ErrorResponseHandler.handle(response, HttpResponseStatus.UNPROCESSABLE_ENTITY, ErrorType.UNAVAILABLE_BOOKING_SLOT, slotNotAvailableException);
             }
             case BookingLinkReservationException bookingLinkReservationException -> {
                 LOGGER.error("Booking operation failed for [{}]", request.uri(), bookingLinkReservationException);

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CheckTechnicalUserTokenRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/CheckTechnicalUserTokenRoute.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableMap;
 import com.linagora.calendar.restapi.ErrorResponse;
+import com.linagora.calendar.restapi.ErrorType;
 import com.linagora.calendar.restapi.RestApiConstants;
 import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.TechnicalTokenService;
@@ -107,7 +108,7 @@ public class CheckTechnicalUserTokenRoute implements JMAPRoutes {
     Mono<Void> doOnError(HttpServerResponse response) {
         return response.status(HttpResponseStatus.NOT_FOUND)
             .headers(JSON_HEADER)
-            .sendByteArray(Mono.fromCallable(() -> ErrorResponse.of(404, "Not found", "Token not found or expired")
+            .sendByteArray(Mono.fromCallable(() -> ErrorResponse.of(404, ErrorType.NOT_FOUND, "Not found", "Token not found or expired")
                 .serializeAsBytes()))
             .then();
     }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/DownloadCalendarRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/DownloadCalendarRoute.java
@@ -44,6 +44,7 @@ import com.google.common.base.Preconditions;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.CalendarNotFoundException;
 import com.linagora.calendar.restapi.ErrorResponse;
+import com.linagora.calendar.restapi.ErrorType;
 import com.linagora.calendar.restapi.ForbiddenException;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -181,7 +182,7 @@ public class DownloadCalendarRoute implements JMAPRoutes {
     Mono<Void> doOnError(HttpServerResponse response) {
         return response.status(HttpResponseStatus.SERVICE_UNAVAILABLE)
             .header("Content-Type", CONTENT_TYPE_JSON)
-            .sendByteArray(Mono.fromCallable(() -> ErrorResponse.of(503, "Service Unavailable", "Service Unavailable").serializeAsBytes()))
+            .sendByteArray(Mono.fromCallable(() -> ErrorResponse.of(503, ErrorType.SERVICE_UNAVAILABLE, "Service Unavailable", "Service Unavailable").serializeAsBytes()))
             .then();
     }
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ErrorResponseHandler.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ErrorResponseHandler.java
@@ -40,7 +40,8 @@ public class ErrorResponseHandler {
     public static Mono<Void> handle(HttpServerResponse response,
                                     HttpResponseStatus status,
                                     String message) {
-        return handle(response, status, ErrorResponse.of(status.code(), status.reasonPhrase(), message));
+        return handle(response, status,
+            ErrorResponse.of(status.code(), ErrorType.fromStatus(status), status.reasonPhrase(), message));
     }
 
     public static Mono<Void> handle(HttpServerResponse response,

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EventParticipationRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EventParticipationRoute.java
@@ -45,6 +45,7 @@ import com.linagora.calendar.dav.CalendarEventNotFoundException;
 import com.linagora.calendar.dav.CalendarEventUpdatePatch.AttendeePartStatusUpdatePatch;
 import com.linagora.calendar.dav.dto.VCalendarDto;
 import com.linagora.calendar.restapi.ErrorResponse;
+import com.linagora.calendar.restapi.ErrorType;
 import com.linagora.calendar.restapi.routes.response.EventParticipationResponse;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
@@ -182,6 +183,7 @@ public class EventParticipationRoute extends PublicRoute {
             .headers(JSON_HEADER)
             .sendByteArray(Mono.fromCallable(() -> ErrorResponse.of(
                 401,
+                ErrorType.UNAUTHORIZED,
                 "Unauthorized",
                 "JWT is missing or invalid").serializeAsBytes()))
             .then();
@@ -190,7 +192,7 @@ public class EventParticipationRoute extends PublicRoute {
     private Mono<Void> doNotFound(HttpServerResponse response, CalendarEventNotFoundException exception) {
         return response.status(HttpResponseStatus.NOT_FOUND)
             .headers(JSON_HEADER)
-            .sendByteArray(Mono.fromCallable(() -> ErrorResponse.of(404, "Not found", exception.getMessage())
+            .sendByteArray(Mono.fromCallable(() -> ErrorResponse.of(404, ErrorType.NOT_FOUND, "Not found", exception.getMessage())
                 .serializeAsBytes()))
             .then();
     }
@@ -198,7 +200,7 @@ public class EventParticipationRoute extends PublicRoute {
     private Mono<Void> doOnError(HttpServerResponse response, Exception exception) {
         return response.status(HttpResponseStatus.BAD_REQUEST)
             .headers(JSON_HEADER)
-            .sendByteArray(Mono.fromCallable(() -> ErrorResponse.of(500, "Server Error", exception.getMessage())
+            .sendByteArray(Mono.fromCallable(() -> ErrorResponse.of(500, ErrorType.SERVER_ERROR, "Server Error", exception.getMessage())
                 .serializeAsBytes()))
             .then();
     }

--- a/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/ErrorResponseTest.java
+++ b/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/ErrorResponseTest.java
@@ -1,0 +1,79 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+public class ErrorResponseTest {
+
+    @Test
+    void serializeShouldAlwaysExposeTypeField() {
+        String json = new String(ErrorResponse.of(404, ErrorType.NOT_FOUND, "Not found", "Token not found or expired")
+            .serializeAsBytes(), StandardCharsets.UTF_8);
+
+        assertThatJson(json).isEqualTo("""
+            {
+                "error": {
+                    "code": 404,
+                    "type": "NotFound",
+                    "message": "Not found",
+                    "details": "Token not found or expired"
+                }
+            }""");
+    }
+
+    @Test
+    void ofIllegalArgumentExceptionShouldExposeBadRequestType() {
+        String json = new String(ErrorResponse.of(new IllegalArgumentException("boom"))
+            .serializeAsBytes(), StandardCharsets.UTF_8);
+
+        assertThatJson(json).isEqualTo("""
+            {
+                "error": {
+                    "code": 400,
+                    "type": "BadRequest",
+                    "message": "Bad request",
+                    "details": "boom"
+                }
+            }""");
+    }
+
+    @Test
+    void fromStatusShouldFallBackToServerErrorForUnmappedStatus() {
+        String json = new String(ErrorResponse.of(500, ErrorType.fromStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR),
+                "Internal Server Error", "boom")
+            .serializeAsBytes(), StandardCharsets.UTF_8);
+
+        assertThatJson(json).isEqualTo("""
+            {
+                "error": {
+                    "code": 500,
+                    "type": "ServerError",
+                    "message": "Internal Server Error",
+                    "details": "boom"
+                }
+            }""");
+    }
+}

--- a/docs/apis/errorTypes.md
+++ b/docs/apis/errorTypes.md
@@ -1,7 +1,16 @@
 # Error types
 
-Possible values of the `error.type` field in error responses.
+The `error.type` field is always present in error responses. It exposes a
+machine-readable category for the error, allowing clients to react on a stable
+token rather than parsing the human-readable `message` or `details` fields.
 
-| Type                  | Status | Cause                    |
-|-----------------------|--------|--------------------------|
-| `InactiveBookingLink` | 400    | Booking link is inactive |
+| Type                  | Status | Cause                                          |
+|-----------------------|--------|------------------------------------------------|
+| `BadRequest`          | 400    | Malformed or invalid request                   |
+| `Unauthorized`        | 401    | Missing or invalid authentication              |
+| `Forbidden`           | 403    | Authenticated but not allowed                  |
+| `NotFound`            | 404    | Requested resource does not exist              |
+| `UnprocessableEntity` | 422    | Request understood but cannot be processed     |
+| `ServiceUnavailable`  | 503    | Service temporarily unavailable                |
+| `ServerError`         | 500    | Unexpected server-side error                   |
+| `InactiveBookingLink` | 400    | Booking link is inactive                       |

--- a/docs/apis/errorTypes.md
+++ b/docs/apis/errorTypes.md
@@ -13,4 +13,5 @@ token rather than parsing the human-readable `message` or `details` fields.
 | `UnprocessableEntity` | 422    | Request understood but cannot be processed     |
 | `ServiceUnavailable`  | 503    | Service temporarily unavailable                |
 | `ServerError`         | 500    | Unexpected server-side error                   |
-| `InactiveBookingLink` | 400    | Booking link is inactive                       |
+| `InactiveBookingLink`    | 400    | Booking link is inactive                    |
+| `UnavailableBookingSlot` | 422    | Requested booking slot is unavailable       |


### PR DESCRIPTION
Closes #937

The `error.type` field of error responses was optional (`Option<String>`) and only populated for the `InactiveBookingLink` case. This makes it a **compulsory `String`**, so every error response exposes a stable, machine-readable category clients can rely on instead of parsing `message`/`details`.

## Changes

- `ErrorResponse.ErrorDetail.type` is now a mandatory `String` (drops `Optional` and `@JsonInclude(NON_ABSENT)`).
- New `ErrorType` values covering the standard statuses: `BadRequest`, `Unauthorized`, `Forbidden`, `NotFound`, `UnprocessableEntity`, `ServiceUnavailable`, `ServerError` (alongside the existing `InactiveBookingLink`), plus `ErrorType.fromStatus(...)` used by the generic `ErrorResponseHandler` to derive a type from the HTTP status.
- A type is now assigned at every error production site (`CheckTechnicalUserTokenRoute`, `DownloadCalendarRoute`, `EventParticipationRoute`, `ErrorResponseHandler`, `ErrorResponse.of(IllegalArgumentException)`).
- Documented the possible values in `docs/apis/errorTypes.md`.
- Updated the impacted route integration tests and added a dedicated `ErrorResponseTest`.

---
*Generated automatically*
