### PR TITLE
ISSUE-941 Fix flaky deleteShouldNotFailWhenEventIsConcurrentlyReindexed

### DIFF
--- a/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchServiceTest.java
+++ b/storage-opensearch/src/test/java/com/linagora/calendar/storage/opensearch/OpensearchCalendarSearchServiceTest.java
@@ -240,11 +240,13 @@ public class OpensearchCalendarSearchServiceTest implements CalendarSearchServic
             .doesNotThrowAnyException();
 
         // Whether the event survives the race depends on which operation ran last, so delete it once more now
-        // that no writer competes, and check the document is effectively gone.
-        testee().delete(event.calendarURL(), event.uid()).block();
-
+        // that no writer competes, and check the document is effectively gone. The delete is retried: it is a
+        // delete-by-query, whose search phase only sees documents already refreshed, so a document written by
+        // the very last re-indexing may still be invisible to the first delete attempt.
         EventSearchQuery query = simpleQuery("concurrent", event.calendarURL());
         CALMLY_AWAIT.untilAsserted(() -> {
+            testee().delete(event.calendarURL(), event.uid()).block();
+
             List<EventFields> searchResults = testee().search(query)
                 .collectList().block();
 


### PR DESCRIPTION
Closes #941

## Diagnosis

`deleteShouldNotFailWhenEventIsConcurrentlyReindexed` races 300 re-indexings against 100 deletes, then performs one final `delete()` and asserts the event is no longer searchable.

That final delete is a **delete-by-query**. Its search phase only matches documents that OpenSearch has already refreshed — and `reindex()` indexes without a refresh policy, so the document written by the very last re-indexing may still be invisible when the final delete runs. Nothing gets deleted, the periodic refresh then makes the document searchable, and the `CALMLY_AWAIT` block fails with `Expected size: 0 but was: 1`.

Note that `DeleteByQueryRequest.refresh(true)` does not help here: it refreshes *after* the deletes, not before the search phase.

## Fix

Move the final delete inside the awaitility block so it is retried until the search returns nothing. Once the document becomes searchable, the next delete attempt removes it — no writer competes at that point, so this converges immediately.

This is a test-only change: the production behaviour (a delete may miss a not-yet-refreshed document, left for a later message to clean up) is unchanged and already documented in `OpensearchCalendarSearchService`.

## Validation

`OpensearchCalendarSearchServiceTest#deleteShouldNotFailWhenEventIsConcurrentlyReindexed` run 3 consecutive times: green.

---
*Generated automatically*
