### PR TITLE
ISSUE-923 Booking link event invitation do not have blue bar

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -366,6 +366,34 @@ class BookingLinkReservationRouteTest {
     }
 
     @Test
+    void proposalEmailShouldCarryARequestIcs(TwakeCalendarGuiceServer server) {
+        BookingLink inserted = insertActiveBookingLink(server);
+        String slotStartUtc = getAvailableSlots(inserted.publicId()).getFirst();
+
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body("""
+                {
+                  "startUtc": "%s",
+                  "creator": {
+                    "name": "BOB",
+                    "email": "creator@example.com"
+                  },
+                  "eventTitle": "30-min intro call"
+                }
+                """.formatted(slotStartUtc))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+
+        String message = messageForRecipient(awaitBookingEmails(), openPaaSUser.username().asString());
+
+        assertThat(getIcs(message))
+            .contains("METHOD:REQUEST");
+    }
+
+    @Test
     void shouldSendAcknowledgementEmailToBookerWhenBookingCreated(TwakeCalendarGuiceServer server) {
         // Given: an active booking link with a description and an available slot.
         BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(
@@ -1399,6 +1427,16 @@ class BookingLinkReservationRouteTest {
         assertThat(matcher.find()).isTrue();
         String base64Html = matcher.group(1).replaceAll("\\s+", "");
         return new String(Base64.getDecoder().decode(base64Html), StandardCharsets.UTF_8);
+    }
+
+    private String getIcs(String message) {
+        Pattern icsPattern = Pattern.compile(
+            "Content-Type: text/calendar[^\\r\\n]*\\r?\\n(?:[^\\r\\n]+\\r?\\n)*\\r?\\n([A-Za-z0-9+/=\\r\\n]+?)\\r?\\n---=Part",
+            Pattern.DOTALL);
+        Matcher matcher = icsPattern.matcher(message);
+        assertThat(matcher.find()).isTrue();
+        String base64Ics = matcher.group(1).replaceAll("\\s+", "");
+        return new String(Base64.getDecoder().decode(base64Ics), StandardCharsets.UTF_8);
     }
 
     private List<String> extractParticipationActionLinks(String html) {

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventMailHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventMailHandler.java
@@ -21,6 +21,7 @@ package com.linagora.calendar.amqp;
 import static com.linagora.calendar.amqp.EventFieldConverter.extractCalendarURL;
 import static com.linagora.calendar.smtp.template.MimeAttachment.ATTACHMENT_DISPOSITION_TYPE;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +51,7 @@ import com.linagora.calendar.amqp.model.CalendarEventInviteNotificationEmail;
 import com.linagora.calendar.amqp.model.CalendarEventNotificationEmail;
 import com.linagora.calendar.amqp.model.CalendarEventReplyNotificationEmail;
 import com.linagora.calendar.amqp.model.CalendarEventUpdateNotificationEmail;
+import com.linagora.calendar.api.CalendarUtil;
 import com.linagora.calendar.api.EventParticipationActionLinkFactory;
 import com.linagora.calendar.api.EventParticipationActionLinkFactory.ActionLinks;
 import com.linagora.calendar.smtp.Mail;
@@ -69,6 +71,7 @@ import com.linagora.calendar.storage.event.EventFields;
 import com.linagora.calendar.storage.event.EventParseUtils;
 import com.linagora.calendar.storage.model.ResourceId;
 
+import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.property.Method;
 import net.fortuna.ical4j.model.property.Uid;
 import net.fortuna.ical4j.model.property.immutable.ImmutableMethod;
@@ -127,7 +130,8 @@ public class EventMailHandler {
     interface EventMessageGenerator {
         Mono<Message> generate(ResolvedSettings resolvedSettings);
 
-        static List<MimeAttachment> createAttachments(byte[] calendarAsBytes, Method method) {
+        static List<MimeAttachment> createAttachments(Calendar calendar, Method method) {
+            byte[] calendarAsBytes = CalendarUtil.withMethod(calendar, method).toString().getBytes(StandardCharsets.UTF_8);
             return List.of(
                 MimeAttachment.builder()
                     .contentType(ContentType.of("text/calendar; charset=UTF-8; method=" + method.getValue()))
@@ -177,8 +181,7 @@ public class EventMailHandler {
         }
 
         private Mono<Message> generateInvitationMessage(ResolvedSettings resolvedSettings, MessageGenerator messageGenerator) {
-            byte[] calendarAsBytes = event.base().eventAsBytes();
-            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(calendarAsBytes, ImmutableMethod.REQUEST);
+            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(event.base().event(), ImmutableMethod.REQUEST);
             MailAddress fromAddress = event.base().senderEmail();
 
             return EventMessageGenerator.generateActionLinks(participationActionLinkFactory, event.base())
@@ -207,8 +210,7 @@ public class EventMailHandler {
         }
 
         private Mono<Message> generateUpdateMessage(ResolvedSettings resolvedSettings, MessageGenerator messageGenerator) {
-            byte[] calendarAsBytes = event.base().eventAsBytes();
-            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(calendarAsBytes, ImmutableMethod.REQUEST);
+            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(event.base().event(), ImmutableMethod.REQUEST);
 
             MailAddress fromAddress = event.base().senderEmail();
 
@@ -238,8 +240,7 @@ public class EventMailHandler {
         }
 
         private Mono<Message> generateCancelMessage(ResolvedSettings resolvedSettings, MessageGenerator messageGenerator) {
-            byte[] calendarAsBytes = event.base().eventAsBytes();
-            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(calendarAsBytes, ImmutableMethod.CANCEL);
+            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(event.base().event(), ImmutableMethod.CANCEL);
 
             MailAddress fromAddress = event.base().senderEmail();
             return messageGenerator.generate(recipientUser, fromAddress,
@@ -277,7 +278,7 @@ public class EventMailHandler {
                 .translator(messageGenerator.getI18nTranslator())
                 .eventInCalendarLink(eventInCalendarLinkFactory);
 
-            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(event.base().eventAsBytes(), ImmutableMethod.REPLY);
+            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(event.base().event(), ImmutableMethod.REPLY);
 
             MailAddress fromAddress = event.base().senderEmail();
 
@@ -319,8 +320,7 @@ public class EventMailHandler {
                 .eventInCalendarLink(eventInCalendarLinkFactory)
                 .buildAsMap();
 
-            byte[] calendarAsBytes = event.base().eventAsBytes();
-            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(calendarAsBytes, ImmutableMethod.COUNTER);
+            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(event.base().event(), ImmutableMethod.COUNTER);
 
             MailAddress fromAddress = event.base().senderEmail();
             return messageGenerator.generate(recipientUser, fromAddress, model, attachments);
@@ -346,8 +346,7 @@ public class EventMailHandler {
         }
 
         private Mono<Message> generateBookingConfirmedMessage(ResolvedSettings resolvedSettings, MessageGenerator messageGenerator) {
-            byte[] calendarAsBytes = event.base().eventAsBytes();
-            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(calendarAsBytes, ImmutableMethod.REQUEST);
+            List<MimeAttachment> attachments = EventMessageGenerator.createAttachments(event.base().event(), ImmutableMethod.REQUEST);
             MailAddress fromAddress = event.base().senderEmail();
 
             return Mono.fromCallable(() -> toBookingConfirmedPugModel(resolvedSettings, messageGenerator))

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventNotificationEmail.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventNotificationEmail.java
@@ -20,7 +20,6 @@ package com.linagora.calendar.amqp.model;
 
 import static com.linagora.calendar.storage.event.EventParseUtils.DuplicateAttendeePolicy.KEEP_FIRST;
 
-import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -102,10 +101,6 @@ public record CalendarEventNotificationEmail(MailAddress senderEmail,
         return people.stream()
             .collect(ImmutableMap.toImmutableMap(person -> person.email().asString(),
                 this::toPugModel));
-    }
-
-    public byte[] eventAsBytes() {
-        return event().toString().getBytes(StandardCharsets.UTF_8);
     }
 
     public VEvent getFirstVEvent() {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
@@ -294,6 +294,8 @@ public class EventPublicAgendaEmailConsumerTest {
             .contains("Content-Type: application/ics")
             .contains("filename=\"meeting.ics\"")
             .doesNotContain("Public agenda event notification.");
+        assertThat(extractDecodedPart(message, "text/calendar; charset=UTF-8; method=REQUEST"))
+            .contains("METHOD:REQUEST");
         assertThat(smtpMailsResponse.getString("[0].from")).isEqualTo(organizer.username().asString());
         assertThat(smtpMailsResponse.getString("[0].recipients[0].address")).isEqualTo(attendee.username().asString());
     }

--- a/calendar-api/src/main/java/com/linagora/calendar/api/CalendarUtil.java
+++ b/calendar-api/src/main/java/com/linagora/calendar/api/CalendarUtil.java
@@ -38,9 +38,11 @@ import net.fortuna.ical4j.data.ContentHandlerContext;
 import net.fortuna.ical4j.data.ParserException;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;
+import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.TimeZoneRegistry;
 import net.fortuna.ical4j.model.TimeZoneRegistryImpl;
 import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.Method;
 import net.fortuna.ical4j.util.CompatibilityHints;
 import net.fortuna.ical4j.util.MapTimeZoneCache;
 
@@ -91,6 +93,20 @@ public class CalendarUtil {
         } catch (ParserException e) {
             throw new RuntimeException("Error while parsing ICal object", e);
         }
+    }
+
+    /**
+     * Returns a copy of the given calendar carrying the supplied iTIP METHOD.
+     *
+     * <p>Calendar objects stored on the CalDAV server must not carry a METHOD property, thus it needs to be
+     * added back when the very same calendar is turned into an iTIP message (eg a {@code text/calendar} MIME part).
+     * Mail clients rely on it to display the event invitation widget.
+     */
+    public static Calendar withMethod(Calendar calendar, Method method) {
+        Calendar copiedCalendar = calendar.copy();
+        copiedCalendar.removeAll(Property.METHOD);
+        copiedCalendar.add(method);
+        return copiedCalendar;
     }
 
     public static Calendar withSingleVEvent(Calendar template, VEvent vevent) {

--- a/calendar-api/src/test/java/com/linagora/calendar/api/CalendarUtilTest.java
+++ b/calendar-api/src/test/java/com/linagora/calendar/api/CalendarUtilTest.java
@@ -1,0 +1,69 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.property.immutable.ImmutableMethod;
+
+class CalendarUtilTest {
+
+    private static final String ICS_WITHOUT_METHOD = """
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        PRODID:-//Twake Calendar//Public Booking//EN
+        BEGIN:VEVENT
+        UID:8e4d5652-3525-4511-b660-1873ba3df559
+        DTSTAMP:20260707T094407Z
+        DTSTART:20260710T150000Z
+        SUMMARY:Test
+        END:VEVENT
+        END:VCALENDAR
+        """;
+
+    @Test
+    void withMethodShouldAddMethodWhenMissing() {
+        Calendar calendar = CalendarUtil.parseIcs(ICS_WITHOUT_METHOD);
+
+        assertThat(CalendarUtil.withMethod(calendar, ImmutableMethod.REQUEST).toString())
+            .contains("METHOD:REQUEST");
+    }
+
+    @Test
+    void withMethodShouldOverrideExistingMethod() {
+        Calendar calendar = CalendarUtil.withMethod(CalendarUtil.parseIcs(ICS_WITHOUT_METHOD), ImmutableMethod.REQUEST);
+
+        assertThat(CalendarUtil.withMethod(calendar, ImmutableMethod.CANCEL).toString())
+            .contains("METHOD:CANCEL")
+            .doesNotContain("METHOD:REQUEST");
+    }
+
+    @Test
+    void withMethodShouldNotMutateSuppliedCalendar() {
+        Calendar calendar = CalendarUtil.parseIcs(ICS_WITHOUT_METHOD);
+
+        CalendarUtil.withMethod(calendar, ImmutableMethod.REQUEST);
+
+        assertThat(calendar.toString())
+            .doesNotContain("METHOD:");
+    }
+}

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookedEventCancelled.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookedEventCancelled.java
@@ -33,9 +33,9 @@ import com.linagora.calendar.storage.event.EventParseUtils;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.component.VEvent;
-import net.fortuna.ical4j.model.property.Method;
 import net.fortuna.ical4j.model.property.Sequence;
 import net.fortuna.ical4j.model.property.Status;
+import net.fortuna.ical4j.model.property.immutable.ImmutableMethod;
 
 /**
  * Parsed view of a booked event that has just been cancelled by its booker.
@@ -84,9 +84,8 @@ public record BookedEventCancelled(OpenPaaSUser organizer,
         cancelledEvent.removeAll(Property.STATUS);
         cancelledEvent.add(new Status(Status.VALUE_CANCELLED));
 
-        Calendar cancelCalendar = CalendarUtil.withSingleVEvent(calendarData, cancelledEvent);
-        cancelCalendar.removeAll(Property.METHOD);
-        cancelCalendar.add(new Method(Method.VALUE_CANCEL));
+        Calendar cancelCalendar = CalendarUtil.withMethod(CalendarUtil.withSingleVEvent(calendarData, cancelledEvent),
+            ImmutableMethod.CANCEL);
 
         return cancelCalendar.toString().getBytes(StandardCharsets.UTF_8);
     }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilder.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilder.java
@@ -33,6 +33,7 @@ import org.apache.james.util.FunctionalUtils;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.linagora.calendar.api.CalendarUtil;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest.BookingAttendee;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
@@ -52,6 +53,7 @@ import net.fortuna.ical4j.model.property.Clazz;
 import net.fortuna.ical4j.model.property.Description;
 import net.fortuna.ical4j.model.property.DtStamp;
 import net.fortuna.ical4j.model.property.DtStart;
+import net.fortuna.ical4j.model.property.Method;
 import net.fortuna.ical4j.model.property.Organizer;
 import net.fortuna.ical4j.model.property.Summary;
 import net.fortuna.ical4j.model.property.Transp;
@@ -191,6 +193,10 @@ public class BookingLinkEventIcsBuilder {
 
         public byte[] icsBytes() {
             return calendar.toString().getBytes(StandardCharsets.UTF_8);
+        }
+
+        public byte[] icsBytes(Method method) {
+            return CalendarUtil.withMethod(calendar, method).toString().getBytes(StandardCharsets.UTF_8);
         }
 
         public String eventIdAsString() {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/PublicAgendaProposalNotifier.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/PublicAgendaProposalNotifier.java
@@ -117,14 +117,15 @@ public class PublicAgendaProposalNotifier {
                                           BookingCreated bookingCreated,
                                           ActionLinks actionLinks,
                                           MessageGenerator messageGenerator) {
+        byte[] invitationIcs = bookingCreated.eventIcsResult().icsBytes(ImmutableMethod.REQUEST);
         List<MimeAttachment> attachments = List.of(
             MimeAttachment.builder()
                 .contentType(ContentType.of(CALENDAR_CONTENT_TYPE_PREFIX + ImmutableMethod.REQUEST.getValue()))
-                .content(bookingCreated.eventIcsResult().icsBytes())
+                .content(invitationIcs)
                 .build(),
             MimeAttachment.builder()
                 .contentType(ContentType.of(ICS_CONTENT_TYPE))
-                .content(bookingCreated.eventIcsResult().icsBytes())
+                .content(invitationIcs)
                 .dispositionType(ATTACHMENT_DISPOSITION_TYPE)
                 .fileName(ICS_FILENAME)
                 .build());

--- a/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilderTest.java
+++ b/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilderTest.java
@@ -39,6 +39,7 @@ import com.linagora.calendar.restapi.routes.BookingLinkReservationService.Bookin
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 
 import net.fortuna.ical4j.model.property.Uid;
+import net.fortuna.ical4j.model.property.immutable.ImmutableMethod;
 import net.fortuna.ical4j.util.UidGenerator;
 
 public class BookingLinkEventIcsBuilderTest {
@@ -263,4 +264,33 @@ public class BookingLinkEventIcsBuilderTest {
             .contains("ATTENDEE;RSVP=TRUE;ROLE=CHAIR;CUTYPE=INDIVIDUAL;PARTSTAT=ACCEPTED;CN=Alice Owner:mailto:owner@example.com");
     }
 
+    @Test
+    void icsBytesShouldNotCarryAMethodByDefault() {
+        BookingLinkEventIcsBuilder testee = new BookingLinkEventIcsBuilder(FIXED_CLOCK, () -> VISIO_URL, FIXED_UID_GENERATOR);
+
+        BuildResult result = testee.build(bookingRequest(), OWNER, Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID);
+
+        assertThat(new String(result.icsBytes(), StandardCharsets.UTF_8))
+            .doesNotContain("METHOD:");
+    }
+
+    @Test
+    void icsBytesShouldCarrySuppliedMethod() {
+        BookingLinkEventIcsBuilder testee = new BookingLinkEventIcsBuilder(FIXED_CLOCK, () -> VISIO_URL, FIXED_UID_GENERATOR);
+
+        BuildResult result = testee.build(bookingRequest(), OWNER, Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID);
+
+        assertThat(new String(result.icsBytes(ImmutableMethod.REQUEST), StandardCharsets.UTF_8))
+            .contains("METHOD:REQUEST");
+    }
+
+    private BookingRequest bookingRequest() {
+        return new BookingRequest(
+            Instant.parse("2036-01-26T09:30:00Z"),
+            BookingAttendee.from("BOB", "creator@example.com"),
+            List.of(),
+            "eventTitle",
+            false,
+            null);
+    }
 }


### PR DESCRIPTION
Closes #923

## Diagnosis

When Bob books Alice through a booking link, Alice receives the event proposal email built by `PublicAgendaProposalNotifier`. That email attaches the ICS produced by `BookingLinkEventIcsBuilder`, i.e. the very calendar object that gets `PUT` on the CalDAV server — and a stored calendar object must not carry a `METHOD` property.

The MIME part was declared as `text/calendar; charset=UTF-8; method=REQUEST`, but the ICS body itself had no `METHOD:REQUEST` line, which is what mail clients read to decide whether the mail is an iTIP invitation. Hence no blue bar.

The very same problem affects the `event-booking-confirmed` email emitted by `EventMailHandler` when the booking is auto-accepted: it forwards the calendar received over AMQP as-is.

## Fix

Add `CalendarUtil.withMethod(calendar, method)`, returning a copy of the calendar carrying the supplied iTIP `METHOD`, and use it whenever a calendar is turned into a `text/calendar` MIME part:

- `PublicAgendaProposalNotifier` (proposal email to the booking link owner) via the new `BuildResult.icsBytes(Method)`,
- `EventMailHandler.EventMessageGenerator.createAttachments` (invite, update, cancel, reply, counter and booking confirmed emails). For the regular iTIP flows the calendar already carries the METHOD Sabre put in it, so this is a no-op there.

`BookedEventCancelled` now reuses that helper rather than open-coding it.

The stored calendar object is left untouched: `BuildResult.icsBytes()` (used for the CalDAV import) still produces a METHOD-less ICS.

## Tests

- `CalendarUtilTest`: the helper adds, overrides, and does not mutate its input.
- `BookingLinkEventIcsBuilderTest`: the ICS pushed to DAV has no METHOD, the one asked with a METHOD has it.
- `BookingLinkReservationRouteTest#proposalEmailShouldCarryARequestIcs`: end-to-end, the ICS attached to the organizer email contains `METHOD:REQUEST`. Verified to fail before the fix.
- `EventPublicAgendaEmailConsumerTest`: decoded `text/calendar` part of the booking confirmed email contains `METHOD:REQUEST`.

---
*Generated automatically*
