### PR TITLE
ISSUE-945 WS notification upon booking link changes

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -61,6 +62,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.calendar.app.AppTestHelper;
+import com.linagora.calendar.app.BookingLinkProbe;
 import com.linagora.calendar.app.TwakeCalendarConfiguration;
 import com.linagora.calendar.app.TwakeCalendarExtension;
 import com.linagora.calendar.app.TwakeCalendarGuiceServer;
@@ -82,6 +84,8 @@ import com.linagora.calendar.storage.MailboxSessionUtil;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.UsernameRegistrationKey;
+import com.linagora.calendar.storage.booking.BookingLink;
+import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
 import com.linagora.calendar.storage.model.Upload;
 import com.linagora.calendar.storage.model.UploadedMimeType;
 import com.linagora.calendar.storage.redis.DockerRedisExtension;
@@ -144,8 +148,11 @@ class WebsocketRouteTest {
             .enableRedis(),
         AppTestHelper.OIDC_BY_PASS_MODULE,
         DavModuleTestHelper.FROM_SABRE_EXTENSION.apply(sabreDavExtension),
-        binder -> Multibinder.newSetBinder(binder, GuiceProbe.class)
-            .addBinding().to(EventBusProbe.class),
+        binder -> {
+            Multibinder<GuiceProbe> probes = Multibinder.newSetBinder(binder, GuiceProbe.class);
+            probes.addBinding().to(EventBusProbe.class);
+            probes.addBinding().to(BookingLinkProbe.class);
+        },
         new AbstractModule() {
             @Provides
             @Singleton
@@ -216,6 +223,78 @@ class WebsocketRouteTest {
                 {
                     "registered": [ "%s"]
                 }""".formatted(registerCalendarURL));
+    }
+
+    @Test
+    void websocketShouldReceiveBookingLinkStateChangedUponBookingLinkCreation(TwakeCalendarGuiceServer guiceServer) {
+        String ticket = generateTicket(bob);
+        BlockingQueue<String> messages = new LinkedBlockingQueue<>();
+        webSocket = connectWebSocket(restApiPort, ticket, messages);
+
+        guiceServer.getProbe(BookingLinkProbe.class)
+            .insert(bob.username(), bookingLinkInsertRequest(bob));
+
+        assertThatJson(awaitMessage(messages, msg -> msg.contains("bookingLinkStateChanged")))
+            .isEqualTo("{\"bookingLinkStateChanged\": true}");
+    }
+
+    @Test
+    void websocketShouldReceiveBookingLinkStateChangedUponBookingLinkDeletion(TwakeCalendarGuiceServer guiceServer) {
+        BookingLinkProbe bookingLinkProbe = guiceServer.getProbe(BookingLinkProbe.class);
+        BookingLink bookingLink = bookingLinkProbe.insert(bob.username(), bookingLinkInsertRequest(bob));
+
+        String ticket = generateTicket(bob);
+        BlockingQueue<String> messages = new LinkedBlockingQueue<>();
+        webSocket = connectWebSocket(restApiPort, ticket, messages);
+
+        bookingLinkProbe.deleteBookingLink(bob.username(), bookingLink.publicId());
+
+        assertThatJson(awaitMessage(messages, msg -> msg.contains("bookingLinkStateChanged")))
+            .isEqualTo("{\"bookingLinkStateChanged\": true}");
+    }
+
+    @Test
+    void websocketShouldReceiveBookingLinkStateChangedUponBookingLinkUpdate(TwakeCalendarGuiceServer guiceServer) {
+        BookingLink bookingLink = guiceServer.getProbe(BookingLinkProbe.class)
+            .insert(bob.username(), bookingLinkInsertRequest(bob));
+
+        String ticket = generateTicket(bob);
+        BlockingQueue<String> messages = new LinkedBlockingQueue<>();
+        webSocket = connectWebSocket(restApiPort, ticket, messages);
+
+        given()
+            .auth().preemptive().basic(bob.username().asString(), PASSWORD)
+            .port(restApiPort)
+            .contentType("application/json")
+            .body("""
+                { "name": "Renamed" }
+                """)
+        .when()
+            .patch("/api/booking-links/" + bookingLink.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        assertThatJson(awaitMessage(messages, msg -> msg.contains("bookingLinkStateChanged")))
+            .isEqualTo("{\"bookingLinkStateChanged\": true}");
+    }
+
+    @Test
+    void websocketShouldNotReceiveBookingLinkStateChangedOfOtherUsers(TwakeCalendarGuiceServer guiceServer) {
+        String ticket = generateTicket(bob);
+        BlockingQueue<String> messages = new LinkedBlockingQueue<>();
+        webSocket = connectWebSocket(restApiPort, ticket, messages);
+
+        guiceServer.getProbe(BookingLinkProbe.class)
+            .insert(alice.username(), bookingLinkInsertRequest(alice));
+
+        NEGATIVE_AWAIT.untilAsserted(() -> {
+            List<String> received = new ArrayList<>();
+            messages.drainTo(received);
+
+            assertThat(received)
+                .as("Should not receive booking link notifications of other users")
+                .noneSatisfy(msg -> assertThat(msg).contains("bookingLinkStateChanged"));
+        });
     }
 
     @Test
@@ -2430,6 +2509,15 @@ class WebsocketRouteTest {
             .extract()
             .jsonPath()
             .getString("importId");
+    }
+
+    private BookingLinkInsertRequest bookingLinkInsertRequest(OpenPaaSUser user) {
+        return new BookingLinkInsertRequest(CalendarURL.from(user.id()),
+            Duration.ofMinutes(30),
+            BookingLinkInsertRequest.ACTIVE,
+            Optional.empty(),
+            Optional.of("Intro call"),
+            Optional.empty());
     }
 
     private String importIcsIntoCalendar(TwakeCalendarGuiceServer guiceServer,

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
@@ -279,6 +279,27 @@ class WebsocketRouteTest {
     }
 
     @Test
+    void websocketShouldReceiveBookingLinkStateChangedUponBookingLinkPublicIdReset(TwakeCalendarGuiceServer guiceServer) {
+        BookingLink bookingLink = guiceServer.getProbe(BookingLinkProbe.class)
+            .insert(bob.username(), bookingLinkInsertRequest(bob));
+
+        String ticket = generateTicket(bob);
+        BlockingQueue<String> messages = new LinkedBlockingQueue<>();
+        webSocket = connectWebSocket(restApiPort, ticket, messages);
+
+        given()
+            .auth().preemptive().basic(bob.username().asString(), PASSWORD)
+            .port(restApiPort)
+        .when()
+            .post("/api/booking-links/" + bookingLink.publicId().value() + "/reset")
+        .then()
+            .statusCode(HttpStatus.SC_OK);
+
+        assertThatJson(awaitMessage(messages, msg -> msg.contains("bookingLinkStateChanged")))
+            .isEqualTo("{\"bookingLinkStateChanged\": true}");
+    }
+
+    @Test
     void websocketShouldNotReceiveBookingLinkStateChangedOfOtherUsers(TwakeCalendarGuiceServer guiceServer) {
         String ticket = generateTicket(bob);
         BlockingQueue<String> messages = new LinkedBlockingQueue<>();

--- a/calendar-redis/src/main/java/org/apache/james/events/CalendarEventSerializer.java
+++ b/calendar-redis/src/main/java/org/apache/james/events/CalendarEventSerializer.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.github.fge.lambdas.Throwing;
+import com.linagora.calendar.storage.BookingLinkStateChangedEvent;
 import com.linagora.calendar.storage.CalendarChangeEvent;
 import com.linagora.calendar.storage.CalendarListChangedEvent;
 import com.linagora.calendar.storage.CalendarListChangedEvent.ChangeType;
@@ -50,9 +51,22 @@ public class CalendarEventSerializer implements EventSerializer {
         @JsonSubTypes.Type(value = CalendarChangeDTO.class),
         @JsonSubTypes.Type(value = CalendarListChangedDTO.class),
         @JsonSubTypes.Type(value = ImportEventDTO.class),
-        @JsonSubTypes.Type(value = AlarmEventDTO.class)
+        @JsonSubTypes.Type(value = AlarmEventDTO.class),
+        @JsonSubTypes.Type(value = BookingLinkStateChangedDTO.class)
     })
     interface EventDTO {
+    }
+
+    record BookingLinkStateChangedDTO(String eventId, String username) implements EventDTO {
+        public static BookingLinkStateChangedDTO from(BookingLinkStateChangedEvent event) {
+            return new BookingLinkStateChangedDTO(event.getEventId().getId().toString(),
+                event.getUsername().asString());
+        }
+
+        public BookingLinkStateChangedEvent asEvent() {
+            return new BookingLinkStateChangedEvent(Event.EventId.of(this.eventId()),
+                Username.of(this.username()));
+        }
     }
 
     record CalendarChangeDTO(String eventId, String username, String calendarUrl) implements EventDTO {
@@ -178,6 +192,7 @@ public class CalendarEventSerializer implements EventSerializer {
             case CalendarListChangedEvent calendarListChangedEvent -> CalendarListChangedDTO.from(calendarListChangedEvent);
             case ImportEvent importEvent -> ImportEventDTO.from(importEvent);
             case EventBusAlarmEvent alarmEvent -> AlarmEventDTO.from(alarmEvent);
+            case BookingLinkStateChangedEvent bookingLinkStateChangedEvent -> BookingLinkStateChangedDTO.from(bookingLinkStateChangedEvent);
             default -> null;
         });
     }
@@ -188,6 +203,7 @@ public class CalendarEventSerializer implements EventSerializer {
             case CalendarListChangedDTO calendarListChangedDTO -> calendarListChangedDTO.asEvent();
             case ImportEventDTO importEventDTO -> importEventDTO.asEvent();
             case AlarmEventDTO alarmEventDTO -> alarmEventDTO.asEvent();
+            case BookingLinkStateChangedDTO bookingLinkStateChangedDTO -> bookingLinkStateChangedDTO.asEvent();
             default -> null;
         });
     }

--- a/calendar-redis/src/test/java/org/apache/james/events/CalendarEventSerializerTest.java
+++ b/calendar-redis/src/test/java/org/apache/james/events/CalendarEventSerializerTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import com.linagora.calendar.storage.BookingLinkStateChangedEvent;
 import com.linagora.calendar.storage.CalendarChangeEvent;
 import com.linagora.calendar.storage.CalendarListChangedEvent;
 import com.linagora.calendar.storage.CalendarURL;
@@ -105,6 +106,18 @@ public class CalendarEventSerializerTest {
         CalendarURL.deserialize("baseId/calendarId"),
         CalendarListChangedEvent.ChangeType.UPDATED);
 
+    public static final String BOOKING_LINK_STATE_CHANGED_JSON = """
+        {
+            "type": "CalendarEventSerializer$BookingLinkStateChangedDTO",
+            "eventId": "cccccccc-dddd-eeee-ffff-000000000000",
+            "username": "bookinguser"
+        }
+        """;
+
+    public static final BookingLinkStateChangedEvent BOOKING_LINK_STATE_CHANGED_EVENT = new BookingLinkStateChangedEvent(
+        Event.EventId.of("cccccccc-dddd-eeee-ffff-000000000000"),
+        Username.of("bookinguser"));
+
     private final CalendarEventSerializer serializer = new CalendarEventSerializer();
 
     @Test
@@ -153,5 +166,17 @@ public class CalendarEventSerializerTest {
     void shouldDeserializeJsonToCalendarListChangedEvent() {
         Event event = serializer.asEvent(CALENDAR_LIST_CHANGED_JSON).event();
         assertThat(event).isEqualTo(CALENDAR_LIST_CHANGED_EVENT);
+    }
+
+    @Test
+    void shouldSerializeBookingLinkStateChangedEvent() {
+        String json = serializer.toJson(BOOKING_LINK_STATE_CHANGED_EVENT).json();
+        assertThatJson(json).isEqualTo(BOOKING_LINK_STATE_CHANGED_JSON);
+    }
+
+    @Test
+    void shouldDeserializeJsonToBookingLinkStateChangedEvent() {
+        Event event = serializer.asEvent(BOOKING_LINK_STATE_CHANGED_JSON).event();
+        assertThat(event).isEqualTo(BOOKING_LINK_STATE_CHANGED_EVENT);
     }
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/DefaultWebSocketNotificationListener.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/DefaultWebSocketNotificationListener.java
@@ -29,6 +29,7 @@ import org.reactivestreams.Publisher;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linagora.calendar.storage.BookingLinkStateChangedEvent;
 import com.linagora.calendar.storage.CalendarListChangedEvent;
 import com.linagora.calendar.storage.CalendarListChangedEvent.ChangeType;
 import com.linagora.calendar.storage.CalendarURL;
@@ -42,13 +43,17 @@ public record DefaultWebSocketNotificationListener(Sinks.Many<WebsocketRoute.Web
 
     @Override
     public boolean isHandling(Event event) {
-        return event instanceof CalendarListChangedEvent;
+        return event instanceof CalendarListChangedEvent
+            || event instanceof BookingLinkStateChangedEvent;
     }
 
     @Override
     public Publisher<Void> reactiveEvent(Event event) {
         if (event instanceof CalendarListChangedEvent calendarListChangedEvent) {
             return handleCalendarListChange(calendarListChangedEvent);
+        }
+        if (event instanceof BookingLinkStateChangedEvent) {
+            return Mono.fromRunnable(() -> emit(new BookingLinkStateChangedMessage())).then();
         }
         return Mono.empty();
     }
@@ -61,6 +66,16 @@ public record DefaultWebSocketNotificationListener(Sinks.Many<WebsocketRoute.Web
     private void emit(WebsocketRoute.WebsocketMessage message) {
         synchronized (outbound) {
             outbound.emitNext(message, Sinks.EmitFailureHandler.FAIL_FAST);
+        }
+    }
+
+    public record BookingLinkStateChangedMessage() implements WebsocketRoute.WebsocketMessage {
+
+        static final String PAYLOAD = "{\"bookingLinkStateChanged\":true}";
+
+        @Override
+        public WebSocketFrame asWebSocketFrame() {
+            return new TextWebSocketFrame(PAYLOAD);
         }
     }
 

--- a/docs/apis/websocket.md
+++ b/docs/apis/websocket.md
@@ -9,6 +9,7 @@ This includes:
 - Calendar import events (ICS)
 - Address Book import events (vCard)
 - Display alarm notifications
+- Booking link changes
 
 ## 1. Endpoint 
 
@@ -163,6 +164,28 @@ Subscription behavior:
 - Subscriber renames subscribed calendar metadata (for example display name) → subscriber receives `updated`
 - Subscriber deletes subscribed calendar from their list → subscriber receives `deleted`
 - Owner hides/restricts source shared calendar so subscriber loses visibility → subscriber receives `deleted`
+
+#### Booking link push
+
+Whenever one of the booking links owned by the connected user is created, updated, deleted, or has its public id
+reset, the server pushes a payload-less notification:
+
+```json
+{
+  "bookingLinkStateChanged": true
+}
+```
+
+Upon reception, the client re-fetches `GET /api/booking-links`. No delta is carried, so a dropped message is
+recovered by the next one, and no ordering has to be maintained. This subscription requires no `register` request:
+it relies on the same default subscription as `calendarList`.
+
+Notes:
+- Notifications are also emitted when an administrator mutates the booking links of the user through webadmin.
+- A burst of mutations produces one notification each: clients are expected to debounce before re-fetching.
+- Notifications may be spurious, for instance when deleting an already deleted booking link.
+- Booking an appointment through `POST /api/booking-links/{id}/book` does not change the booking link itself,
+  hence emits no such notification. The resulting calendar change is notified through the calendar event push.
 
 #### Calendar Event push
 

--- a/storage-api/src/main/java/com/linagora/calendar/storage/BookingLinkStateChangedEvent.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/BookingLinkStateChangedEvent.java
@@ -1,0 +1,49 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage;
+
+import org.apache.james.core.Username;
+import org.apache.james.events.Event;
+
+/**
+ * Signals that the booking links owned by {@code username} changed, without telling how.
+ * Clients are expected to re-fetch the full booking link list upon reception, which makes
+ * the notification tolerant to message drops and to out of order delivery.
+ */
+public record BookingLinkStateChangedEvent(Event.EventId eventId, Username username) implements Event {
+
+    public static BookingLinkStateChangedEvent of(Username username) {
+        return new BookingLinkStateChangedEvent(Event.EventId.random(), username);
+    }
+
+    @Override
+    public Username getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isNoop() {
+        return false;
+    }
+
+    @Override
+    public EventId getEventId() {
+        return eventId;
+    }
+}

--- a/storage-api/src/main/java/com/linagora/calendar/storage/MemoryStorageModule.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/MemoryStorageModule.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 
 import org.apache.james.core.Domain;
 import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.events.EventBus;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
 import org.apache.james.utils.PropertiesProvider;
@@ -33,6 +34,7 @@ import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.EventBusBookingLinkDAO;
 import com.linagora.calendar.storage.booking.MemoryBookingLinkDAO;
 import com.linagora.calendar.storage.configuration.UserConfigurationDAO;
 import com.linagora.calendar.storage.eventsearch.CalendarSearchService;
@@ -80,13 +82,18 @@ public class MemoryStorageModule extends AbstractModule {
         bind(TeamCalendarRepository.class).to(MemoryTeamCalendarRepository.class);
 
         bind(MemoryBookingLinkDAO.class).in(Scopes.SINGLETON);
-        bind(BookingLinkDAO.class).to(MemoryBookingLinkDAO.class);
 
         bind(MemoryTicketStore.class).in(Scopes.SINGLETON);
         bind(TicketStore.class).to(MemoryTicketStore.class);
 
         bind(MemoryDomainSettingsDAO.class).in(Scopes.SINGLETON);
         bind(DomainSettingsDAO.class).to(MemoryDomainSettingsDAO.class);
+    }
+
+    @Provides
+    @Singleton
+    BookingLinkDAO bookingLinkDAO(MemoryBookingLinkDAO delegate, EventBus eventBus) {
+        return new EventBusBookingLinkDAO(delegate, eventBus);
     }
 
     @Provides

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/EventBusBookingLinkDAO.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/EventBusBookingLinkDAO.java
@@ -1,0 +1,88 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage.booking;
+
+import org.apache.james.core.Username;
+import org.apache.james.events.EventBus;
+
+import com.linagora.calendar.storage.BookingLinkStateChangedEvent;
+import com.linagora.calendar.storage.UsernameRegistrationKey;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Notifies the booking link owner of any mutation of his booking links.
+ * <p>
+ * The event is always keyed on the owner rather than on the writer, so that an administrator
+ * acting on behalf of a user still notifies that user.
+ */
+public class EventBusBookingLinkDAO implements BookingLinkDAO {
+    private final BookingLinkDAO delegate;
+    private final EventBus eventBus;
+
+    public EventBusBookingLinkDAO(BookingLinkDAO delegate, EventBus eventBus) {
+        this.delegate = delegate;
+        this.eventBus = eventBus;
+    }
+
+    @Override
+    public Mono<BookingLink> insert(Username username, BookingLinkInsertRequest request) {
+        return delegate.insert(username, request)
+            .flatMap(bookingLink -> notifyOwner(username).thenReturn(bookingLink));
+    }
+
+    @Override
+    public Mono<BookingLink> findByPublicId(BookingLinkPublicId publicId) {
+        return delegate.findByPublicId(publicId);
+    }
+
+    @Override
+    public Mono<BookingLink> findByPublicId(Username username, BookingLinkPublicId publicId) {
+        return delegate.findByPublicId(username, publicId);
+    }
+
+    @Override
+    public Flux<BookingLink> findByUsername(Username username) {
+        return delegate.findByUsername(username);
+    }
+
+    @Override
+    public Mono<BookingLink> update(Username username, BookingLinkPublicId publicId, BookingLinkPatchRequest request) {
+        return delegate.update(username, publicId, request)
+            .flatMap(bookingLink -> notifyOwner(username).thenReturn(bookingLink));
+    }
+
+    @Override
+    public Mono<BookingLinkPublicId> resetPublicId(Username username, BookingLinkPublicId publicId) {
+        return delegate.resetPublicId(username, publicId)
+            .flatMap(newPublicId -> notifyOwner(username).thenReturn(newPublicId));
+    }
+
+    @Override
+    public Mono<Void> delete(Username username, BookingLinkPublicId publicId) {
+        return delegate.delete(username, publicId)
+            .then(notifyOwner(username));
+    }
+
+    private Mono<Void> notifyOwner(Username username) {
+        return Mono.from(eventBus.dispatch(BookingLinkStateChangedEvent.of(username),
+            new UsernameRegistrationKey(username)));
+    }
+}

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBStorageModule.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBStorageModule.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import org.apache.james.core.Domain;
 import org.apache.james.core.healthcheck.HealthCheck;
 import org.apache.james.domainlist.api.DomainList;
+import org.apache.james.events.EventBus;
 import org.apache.james.metrics.api.MetricFactory;
 import org.apache.james.utils.InitializationOperation;
 import org.apache.james.utils.InitilizationOperationBuilder;
@@ -47,6 +48,7 @@ import com.linagora.calendar.storage.ResourceDAO;
 import com.linagora.calendar.storage.TeamCalendarRepository;
 import com.linagora.calendar.storage.UploadedFileDAO;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.EventBusBookingLinkDAO;
 import com.linagora.calendar.storage.configuration.UserConfigurationDAO;
 import com.linagora.calendar.storage.secretlink.SecretLinkStore;
 import com.linagora.tmail.james.jmap.ticket.TicketStore;
@@ -88,7 +90,6 @@ public class MongoDBStorageModule extends AbstractModule {
         bind(TicketStore.class).to(MongoDBTicketDAO.class);
 
         bind(MongoDBBookingLinkDAO.class).in(Scopes.SINGLETON);
-        bind(BookingLinkDAO.class).to(MongoDBBookingLinkDAO.class);
 
         bind(MongoDBDomainSettingsDAO.class).in(Scopes.SINGLETON);
         bind(DomainSettingsDAO.class).to(MongoDBDomainSettingsDAO.class);
@@ -96,6 +97,12 @@ public class MongoDBStorageModule extends AbstractModule {
         Multibinder.newSetBinder(binder(), HealthCheck.class)
             .addBinding()
             .to(MongoDBHealthCheck.class);
+    }
+
+    @Provides
+    @Singleton
+    BookingLinkDAO bookingLinkDAO(MongoDBBookingLinkDAO delegate, EventBus eventBus) {
+        return new EventBusBookingLinkDAO(delegate, eventBus);
     }
 
     @Provides


### PR DESCRIPTION
Closes #945

Implements the payload-free, convergent notification agreed on in the issue: any booking link CRUD emits a `BookingLinkStateChangedEvent` on the owner's `UsernameRegistrationKey`, delivered over the WebSocket as:

```json
{"bookingLinkStateChanged": true}
```

The front re-fetches `GET /api/booking-links` on reception. No delta is carried, so a dropped message is recovered by the next mutation and no ordering has to be maintained. No client-side `register` is needed: the notification rides the `calendarList` default subscription, which is registered unconditionally at connection time on the very same key.

## Changes

- `BookingLinkStateChangedEvent` (storage-api): payload-free, `isNoop()` returns `false`.
- `EventBusBookingLinkDAO`: a `BookingLinkDAO` decorator dispatching on `insert` / `update` / `delete` / `resetPublicId`. Being at the DAO level it covers both the REST routes and `BookingLinkUserRoutes` (webadmin), and since every mutating method takes the owner `Username`, an administrator writing on behalf of a user notifies that user rather than himself. Bound through `@Provides` in `MemoryStorageModule` and `MongoDBStorageModule`, both of which are only installed where `EventBus` is bound; the DAO contract tests keep instantiating the raw DAOs.
- `CalendarEventSerializer`: added `BookingLinkStateChangedDTO` to `@JsonSubTypes`, `toDTO` and `fromDTO`. Without this the event would work on `InVMEventBus` and be silently dropped once Redis is enabled.
- `DefaultWebSocketNotificationListener`: handles the new event and emits `BookingLinkStateChangedMessage`.
- `docs/apis/websocket.md`: documents the push, and states that clients should debounce bursts.

Semantics: spurious events are acceptable, missing ones are not. Deleting an already deleted link emits an event with nothing having changed, which is harmless given the re-fetch semantic. `POST /api/booking-links/{id}/book` does not mutate the link record and emits nothing — the resulting calendar change already reaches the owner through the existing calendar event push.

## Tests

- `CalendarEventSerializerTest`: serialization round-trip for the new DTO.
- `WebsocketRouteTest` (Redis + MongoDB): the frame arrives on the default subscription without any `register`, upon creation, upon deletion, and upon a REST `PATCH`; a user does not receive the notifications of another user.

All four WebSocket tests and the serializer tests pass locally; checkstyle is clean.

---
*Generated automatically*
