### PR TITLE
ISSUE-950 AuditTrail: log connectedUser

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAuditLogConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAuditLogConsumer.java
@@ -252,9 +252,13 @@ public class EventAuditLogConsumer implements Closeable, Startable {
     public static Optional<String> extractConnectedUser(String body) {
         try {
             JsonNode root = MAPPER.readTree(body);
-            return Optional.ofNullable(root.path("connectedUser").asText(null))
+            if (!root.has("connectedUser")) {
+                return Optional.empty();
+            }
+            return Optional.ofNullable(root.get("connectedUser").asText(null))
                 .filter(user -> !user.isBlank());
         } catch (Exception e) {
+            LOGGER.error("Error when extracting connectedUser from audit log event", e);
             return Optional.empty();
         }
     }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAuditLogConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAuditLogConsumer.java
@@ -202,6 +202,7 @@ public class EventAuditLogConsumer implements Closeable, Startable {
                     .parameters(() -> {
                         ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                         extractPath(body).ifPresent(p -> params.put("path", p));
+                        extractConnectedUser(body).ifPresent(user -> params.put("connectedUser", user));
                         return params.build();
                     })
                     .log(formatMessage(body, exchangeName));
@@ -238,6 +239,21 @@ public class EventAuditLogConsumer implements Closeable, Startable {
                 path = Optional.ofNullable(root.get("calendarPath").asText(null));
             }
             return path.flatMap(EventAuditLogConsumer::parseOwnerFromPath);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * The principal URI of the user who actually performed the action, as reported by Sabre.
+     * It may differ from the resource owner (delegation, admin impersonation), which is what
+     * makes it worth auditing. Older Sabre versions do not emit it: absence is not an error.
+     */
+    public static Optional<String> extractConnectedUser(String body) {
+        try {
+            JsonNode root = MAPPER.readTree(body);
+            return Optional.ofNullable(root.path("connectedUser").asText(null))
+                .filter(user -> !user.isBlank());
         } catch (Exception e) {
             return Optional.empty();
         }

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventAuditLogConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventAuditLogConsumerTest.java
@@ -73,6 +73,85 @@ class EventAuditLogConsumerTest {
             .contains("explicit-owner");
     }
 
+    @Test
+    void extractConnectedUserShouldReturnPrincipalWhenFieldIsPresent() {
+        String amqpMessage = """
+            {
+              "eventPath": "/calendars/base1/calendar1/3423434.ics",
+              "connectedUser": "principals/users/64b111111111111111111111"
+            }
+            """;
+
+        assertThat(EventAuditLogConsumer.extractConnectedUser(amqpMessage))
+            .contains("principals/users/64b111111111111111111111");
+    }
+
+    @Test
+    void extractConnectedUserShouldReturnDelegatePrincipalWhenActingOnAnotherOwnerCalendar() {
+        String amqpMessage = """
+            {
+              "eventPath": "/calendars/owner/calendar1/3423434.ics",
+              "connectedUser": "principals/users/delegate"
+            }
+            """;
+
+        assertThat(EventAuditLogConsumer.extractConnectedUser(amqpMessage))
+            .contains("principals/users/delegate");
+        assertThat(EventAuditLogConsumer.extractOwner(amqpMessage))
+            .contains("owner");
+    }
+
+    @Test
+    void extractConnectedUserShouldBeEmptyWhenFieldIsAbsent() {
+        assertThat(EventAuditLogConsumer.extractConnectedUser(CALENDAR_EVENT_NOTIFICATION))
+            .isEmpty();
+    }
+
+    @Test
+    void extractConnectedUserShouldBeEmptyWhenFieldIsNull() {
+        String amqpMessage = """
+            {
+              "eventPath": "/calendars/base1/calendar1/3423434.ics",
+              "connectedUser": null
+            }
+            """;
+
+        assertThat(EventAuditLogConsumer.extractConnectedUser(amqpMessage))
+            .isEmpty();
+    }
+
+    @Test
+    void extractConnectedUserShouldBeEmptyWhenFieldIsBlank() {
+        String amqpMessage = """
+            {
+              "eventPath": "/calendars/base1/calendar1/3423434.ics",
+              "connectedUser": ""
+            }
+            """;
+
+        assertThat(EventAuditLogConsumer.extractConnectedUser(amqpMessage))
+            .isEmpty();
+    }
+
+    @Test
+    void extractConnectedUserShouldBeEmptyWhenPayloadIsNotJson() {
+        assertThat(EventAuditLogConsumer.extractConnectedUser("not json"))
+            .isEmpty();
+    }
+
+    @Test
+    void formatMessageShouldNotBeImpactedByConnectedUser() {
+        String amqpMessage = """
+            {
+              "eventPath": "/calendars/base1/calendar1/3423434.ics",
+              "connectedUser": "principals/users/delegate"
+            }
+            """;
+
+        assertThat(EventAuditLogConsumer.formatMessage(amqpMessage, "calendar:event:updated"))
+            .isEqualTo("Calendar event updated [/calendars/base1/calendar1/3423434.ics]");
+    }
+
     private static Stream<EventAmqpMessageSample> eventAmqpMessageSamplesFromExistingConsumerTests() {
         // Only use AMQP payload literals already present in focused consumer/message tests.
         return Stream.of(


### PR DESCRIPTION
Closes #950

## Why

[esn-sabre](https://github.com/linagora/esn-sabre/pull/419/commits/21810f6b8082e9af4406a0a62ef9924e96eacec0) now injects a `connectedUser` field into the AMQP payloads it publishes: the principal URI of the user who *actually performed* the action. That principal may differ from the resource owner (delegation, admin impersonation, technical token), which is precisely what makes it worth auditing -- the audit log introduced by linagora/twake-calendar-side-service#903 currently only reports the owner deduced from the resource path.

## What

- `EventAuditLogConsumer` now extracts `connectedUser` from the payload and adds it as a `connectedUser` parameter of the audit log entry, alongside the existing `path`.
- The field is optional: when it is absent (older Sabre), `null`, or blank, no parameter is emitted and nothing fails. `username` (the owner) and the human readable message are unchanged.

## Tests

Unit tests in `EventAuditLogConsumerTest` cover the field being present, absent, `null`, blank, and a non-JSON payload, plus the delegation case where `connectedUser` (the delegate) differs from the owner derived from `eventPath`.

Integration coverage of the field on the wire lives in linagora/twake-calendar-integration-tests#293.

---
*Generated automatically*
