### PR TITLE
ISSUE-958 Booking link: extraAttendee field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
  - ISSUE-864 Booking links: reference the originating booking link in generated event ICS through the `X-OPENPAAS-BOOKING-LINK` property
  - ISSUE-867 Booking links: index the originating booking link and expose a `bookingLink` event search criterion on it
  - ISSUE-875 Booking links: admin task to delete all events created by a booking link (with an optional `since` filter), convenient for mass clean up e.g. after a link compromission
+ - ISSUE-958 Booking links: optional `extraAttendees` field, to hand over a single link for a meeting involving several people. Offered slots intersect the availability of the extra attendees, as seen by the booking link owner, and booked events invite them.
 
 ## [2.1.0] - 2026-05-07
 

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
@@ -44,6 +44,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
@@ -64,6 +66,7 @@ import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+import com.linagora.calendar.storage.booking.ExtraAttendees;
 
 import io.restassured.RestAssured;
 import io.restassured.authentication.PreemptiveBasicAuthScheme;
@@ -527,7 +530,7 @@ class BookingLinkCreateRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 30,
                     "active": true,
-                    "extraAttendees": ["%s"]
+                    "extraAttendees": { "and": [ { "participant": "%s" } ] }
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString(), extraAttendee.id().value()))
         .when()
@@ -538,7 +541,7 @@ class BookingLinkCreateRouteTest {
 
         BookingLink stored = bookingLinkProbe.findBookingLink(openPaaSUser.username(), new BookingLinkPublicId(UUID.fromString(publicId)));
 
-        assertThat(stored.extraAttendees()).containsExactly(extraAttendee.id());
+        assertThat(stored.extraAttendees()).isEqualTo(ExtraAttendees.of(extraAttendee.id()));
     }
 
     @Test
@@ -559,7 +562,7 @@ class BookingLinkCreateRouteTest {
 
         BookingLink stored = bookingLinkProbe.findBookingLink(openPaaSUser.username(), new BookingLinkPublicId(UUID.fromString(publicId)));
 
-        assertThat(stored.extraAttendees()).isEmpty();
+        assertThat(stored.extraAttendees()).isEqualTo(ExtraAttendees.NONE);
     }
 
     @Test
@@ -570,7 +573,7 @@ class BookingLinkCreateRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 30,
                     "active": true,
-                    "extraAttendees": ["659387b9d486dc0046aeffff"]
+                    "extraAttendees": { "and": [ { "participant": "659387b9d486dc0046aeffff" } ] }
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
         .when()
@@ -589,7 +592,7 @@ class BookingLinkCreateRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 30,
                     "active": true,
-                    "extraAttendees": ["%s"]
+                    "extraAttendees": { "and": [ { "participant": "%s" } ] }
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString(), openPaaSUser.id().value()))
         .when()
@@ -608,9 +611,30 @@ class BookingLinkCreateRouteTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 30,
                     "active": true,
-                    "extraAttendees": [" "]
+                    "extraAttendees": { "and": [ { "participant": " " } ] }
                 }
                 """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "[\"659387b9d486dc0046aeffb1\"]",
+        "{\"or\": [{\"participant\": \"659387b9d486dc0046aeffb1\"}]}",
+        "{\"and\": [{\"and\": [{\"participant\": \"659387b9d486dc0046aeffb1\"}]}]}"})
+    void shouldReturn400WhenExtraAttendeesShapeIsNotSupported(String extraAttendees) {
+        given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "extraAttendees": %s
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString(), extraAttendees))
         .when()
             .post("/api/booking-links")
         .then()

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
@@ -518,6 +518,106 @@ class BookingLinkCreateRouteTest {
     }
 
     @Test
+    void shouldStoreExtraAttendeesWhenProvided() {
+        OpenPaaSUser extraAttendee = newProvisionedUser();
+
+        String publicId = given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "extraAttendees": ["%s"]
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString(), extraAttendee.id().value()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED)
+            .extract().jsonPath().getString("bookingLinkPublicId");
+
+        BookingLink stored = bookingLinkProbe.findBookingLink(openPaaSUser.username(), new BookingLinkPublicId(UUID.fromString(publicId)));
+
+        assertThat(stored.extraAttendees()).containsExactly(extraAttendee.id());
+    }
+
+    @Test
+    void shouldDefaultExtraAttendeesToEmptyWhenOmitted() {
+        String publicId = given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED)
+            .extract().jsonPath().getString("bookingLinkPublicId");
+
+        BookingLink stored = bookingLinkProbe.findBookingLink(openPaaSUser.username(), new BookingLinkPublicId(UUID.fromString(publicId)));
+
+        assertThat(stored.extraAttendees()).isEmpty();
+    }
+
+    @Test
+    void shouldReturn400WhenExtraAttendeeDoesNotExist() {
+        given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "extraAttendees": ["659387b9d486dc0046aeffff"]
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+        assertThat(bookingLinkProbe.listBookingLinks(openPaaSUser.username())).isEmpty();
+    }
+
+    @Test
+    void shouldReturn400WhenExtraAttendeesContainsTheOwner() {
+        given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "extraAttendees": ["%s"]
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString(), openPaaSUser.id().value()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+        assertThat(bookingLinkProbe.listBookingLinks(openPaaSUser.username())).isEmpty();
+    }
+
+    @Test
+    void shouldReturn400WhenExtraAttendeeIsBlank() {
+        given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "extraAttendees": [" "]
+                }
+                """.formatted(CalendarURL.from(openPaaSUser.id()).asUri().toString()))
+        .when()
+            .post("/api/booking-links")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @Test
     void shouldReturn400WhenCalendarUrlIsMissing() {
         given()
             .body("""

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -55,6 +56,7 @@ import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
@@ -143,6 +145,36 @@ class BookingLinkGetRouteTest {
                     "durationMinutes": 30,
                     "active": true,
                     "autoAccept": false,
+                    "color": "#6B4ECC"
+                }
+                """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));
+    }
+
+    @Test
+    void shouldReturn200WithExtraAttendeesWhenSet() {
+        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
+                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(),
+                List.of(new OpenPaaSId("659387b9d486dc0046aeffb1"), new OpenPaaSId("659387b9d486dc0046aeffb2")),
+                Optional.empty(), Optional.empty(), Optional.empty()));
+
+        String response = given()
+        .when()
+            .get("/api/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON)
+            .extract().body().asString();
+
+        assertThatJson(response)
+            .isEqualTo("""
+                {
+                    "publicId": "%s",
+                    "calendarUrl": "%s",
+                    "durationMinutes": 30,
+                    "active": true,
+                    "autoAccept": false,
+                    "extraAttendees": ["659387b9d486dc0046aeffb1", "659387b9d486dc0046aeffb2"],
                     "color": "#6B4ECC"
                 }
                 """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkGetRouteTest.java
@@ -60,6 +60,7 @@ import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
+import com.linagora.calendar.storage.booking.ExtraAttendees;
 
 import io.restassured.RestAssured;
 import io.restassured.authentication.PreemptiveBasicAuthScheme;
@@ -155,7 +156,7 @@ class BookingLinkGetRouteTest {
         BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
                 BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(),
-                List.of(new OpenPaaSId("659387b9d486dc0046aeffb1"), new OpenPaaSId("659387b9d486dc0046aeffb2")),
+                ExtraAttendees.of(new OpenPaaSId("659387b9d486dc0046aeffb1"), new OpenPaaSId("659387b9d486dc0046aeffb2")),
                 Optional.empty(), Optional.empty(), Optional.empty()));
 
         String response = given()
@@ -174,7 +175,7 @@ class BookingLinkGetRouteTest {
                     "durationMinutes": 30,
                     "active": true,
                     "autoAccept": false,
-                    "extraAttendees": ["659387b9d486dc0046aeffb1", "659387b9d486dc0046aeffb2"],
+                    "extraAttendees": { "and": [ { "participant": "659387b9d486dc0046aeffb1" }, { "participant": "659387b9d486dc0046aeffb2" } ] },
                     "color": "#6B4ECC"
                 }
                 """.formatted(inserted.publicId().value(), CalendarURL.from(openPaaSUser.id()).asUri().toString()));

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
@@ -31,6 +31,7 @@ import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -127,6 +128,12 @@ class BookingLinkPatchRouteTest {
             .build();
 
         calDavClient = new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING);
+    }
+
+    private OpenPaaSUser newProvisionedUser(TwakeCalendarGuiceServer server) {
+        OpenPaaSUser user = sabreDavExtension.newTestUser();
+        server.getProbe(CalendarDataProbe.class).addUserToRepository(user.username(), PASSWORD);
+        return user;
     }
 
     @Test
@@ -386,6 +393,67 @@ class BookingLinkPatchRouteTest {
 
         BookingLink updated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
         assertThat(updated.availabilityRules()).isEmpty();
+    }
+
+    @Test
+    void shouldPersistUpdatedExtraAttendees(TwakeCalendarGuiceServer server) {
+        OpenPaaSUser extraAttendee = newProvisionedUser(server);
+        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        given()
+            .body("""
+                { "extraAttendees": ["%s"] }
+                """.formatted(extraAttendee.id().value()))
+        .when()
+            .patch("/api/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        BookingLink updated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
+        assertThat(updated.extraAttendees()).containsExactly(extraAttendee.id());
+    }
+
+    @Test
+    void shouldRemoveExtraAttendeesWhenSetToNull(TwakeCalendarGuiceServer server) {
+        OpenPaaSUser extraAttendee = newProvisionedUser(server);
+        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
+                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(), List.of(extraAttendee.id()),
+                Optional.empty(), Optional.empty(), Optional.empty()));
+
+        given()
+            .body("""
+                { "extraAttendees": null }
+                """)
+        .when()
+            .patch("/api/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        BookingLink updated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
+        assertThat(updated.extraAttendees()).isEmpty();
+    }
+
+    @Test
+    void shouldReturn400WhenUpdatedExtraAttendeeDoesNotExist(TwakeCalendarGuiceServer server) {
+        OpenPaaSUser extraAttendee = newProvisionedUser(server);
+        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
+                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(), List.of(extraAttendee.id()),
+                Optional.empty(), Optional.empty(), Optional.empty()));
+
+        given()
+            .body("""
+                { "extraAttendees": ["659387b9d486dc0046aeffff"] }
+                """)
+        .when()
+            .patch("/api/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+        BookingLink notUpdated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
+        assertThat(notUpdated.extraAttendees()).containsExactly(extraAttendee.id());
     }
 
     @Test

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
@@ -64,6 +64,7 @@ import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
+import com.linagora.calendar.storage.booking.ExtraAttendees;
 
 import io.restassured.RestAssured;
 import io.restassured.authentication.PreemptiveBasicAuthScheme;
@@ -403,7 +404,7 @@ class BookingLinkPatchRouteTest {
 
         given()
             .body("""
-                { "extraAttendees": ["%s"] }
+                { "extraAttendees": { "and": [ { "participant": "%s" } ] } }
                 """.formatted(extraAttendee.id().value()))
         .when()
             .patch("/api/booking-links/" + inserted.publicId().value())
@@ -411,7 +412,7 @@ class BookingLinkPatchRouteTest {
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
         BookingLink updated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
-        assertThat(updated.extraAttendees()).containsExactly(extraAttendee.id());
+        assertThat(updated.extraAttendees()).isEqualTo(ExtraAttendees.of(extraAttendee.id()));
     }
 
     @Test
@@ -419,7 +420,7 @@ class BookingLinkPatchRouteTest {
         OpenPaaSUser extraAttendee = newProvisionedUser(server);
         BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
-                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(), List.of(extraAttendee.id()),
+                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(), ExtraAttendees.of(extraAttendee.id()),
                 Optional.empty(), Optional.empty(), Optional.empty()));
 
         given()
@@ -432,7 +433,7 @@ class BookingLinkPatchRouteTest {
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
         BookingLink updated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
-        assertThat(updated.extraAttendees()).isEmpty();
+        assertThat(updated.extraAttendees()).isEqualTo(ExtraAttendees.NONE);
     }
 
     @Test
@@ -440,12 +441,12 @@ class BookingLinkPatchRouteTest {
         OpenPaaSUser extraAttendee = newProvisionedUser(server);
         BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
-                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(), List.of(extraAttendee.id()),
+                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(), ExtraAttendees.of(extraAttendee.id()),
                 Optional.empty(), Optional.empty(), Optional.empty()));
 
         given()
             .body("""
-                { "extraAttendees": ["659387b9d486dc0046aeffff"] }
+                { "extraAttendees": { "and": [ { "participant": "659387b9d486dc0046aeffff" } ] } }
                 """)
         .when()
             .patch("/api/booking-links/" + inserted.publicId().value())
@@ -453,7 +454,7 @@ class BookingLinkPatchRouteTest {
             .statusCode(HttpStatus.SC_BAD_REQUEST);
 
         BookingLink notUpdated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
-        assertThat(notUpdated.extraAttendees()).containsExactly(extraAttendee.id());
+        assertThat(notUpdated.extraAttendees()).isEqualTo(ExtraAttendees.of(extraAttendee.id()));
     }
 
     @Test
@@ -461,12 +462,12 @@ class BookingLinkPatchRouteTest {
         OpenPaaSUser extraAttendee = newProvisionedUser(server);
         BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
             new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
-                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(), List.of(extraAttendee.id()),
+                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(), ExtraAttendees.of(extraAttendee.id()),
                 Optional.empty(), Optional.empty(), Optional.empty()));
 
         given()
             .body("""
-                { "extraAttendees": ["%s"] }
+                { "extraAttendees": { "and": [ { "participant": "%s" } ] } }
                 """.formatted(openPaaSUser.id().value()))
         .when()
             .patch("/api/booking-links/" + inserted.publicId().value())
@@ -474,7 +475,7 @@ class BookingLinkPatchRouteTest {
             .statusCode(HttpStatus.SC_BAD_REQUEST);
 
         BookingLink notUpdated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
-        assertThat(notUpdated.extraAttendees()).containsExactly(extraAttendee.id());
+        assertThat(notUpdated.extraAttendees()).isEqualTo(ExtraAttendees.of(extraAttendee.id()));
     }
 
     @Test
@@ -484,7 +485,7 @@ class BookingLinkPatchRouteTest {
 
         given()
             .body("""
-                { "extraAttendees": [" "] }
+                { "extraAttendees": { "and": [ { "participant": " " } ] } }
                 """)
         .when()
             .patch("/api/booking-links/" + inserted.publicId().value())

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkPatchRouteTest.java
@@ -457,6 +457,42 @@ class BookingLinkPatchRouteTest {
     }
 
     @Test
+    void shouldReturn400WhenUpdatedExtraAttendeesContainsTheOwner(TwakeCalendarGuiceServer server) {
+        OpenPaaSUser extraAttendee = newProvisionedUser(server);
+        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE,
+                BookingLinkInsertRequest.AUTO_ACCEPT, Optional.empty(), List.of(extraAttendee.id()),
+                Optional.empty(), Optional.empty(), Optional.empty()));
+
+        given()
+            .body("""
+                { "extraAttendees": ["%s"] }
+                """.formatted(openPaaSUser.id().value()))
+        .when()
+            .patch("/api/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+        BookingLink notUpdated = bookingLinkProbe.findBookingLink(openPaaSUser.username(), inserted.publicId());
+        assertThat(notUpdated.extraAttendees()).containsExactly(extraAttendee.id());
+    }
+
+    @Test
+    void shouldReturn400WhenUpdatedExtraAttendeeIsBlank() {
+        BookingLink inserted = bookingLinkProbe.insertBookingLink(openPaaSUser.username(),
+            new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), Duration.ofMinutes(30), ACTIVE, Optional.empty()));
+
+        given()
+            .body("""
+                { "extraAttendees": [" "] }
+                """)
+        .when()
+            .patch("/api/booking-links/" + inserted.publicId().value())
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @Test
     void shouldNotUpdateFieldsAbsentFromRequest() {
         AvailabilityRules existingRules = AvailabilityRules.of(
             new WeeklyAvailabilityRule(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(17, 0), UTC));

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -80,6 +80,7 @@ import com.linagora.calendar.smtp.MailSenderConfiguration;
 import com.linagora.calendar.smtp.MockSmtpServerExtension;
 import com.linagora.calendar.smtp.template.MailTemplateConfiguration;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
@@ -1337,6 +1338,85 @@ class BookingLinkReservationRouteTest {
             .post("/api/booking-links/{bookingLinkPublicId}/book")
         .then()
             .statusCode(HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    void shouldAddBookingLinkExtraAttendeesToTheCreatedEvent(TwakeCalendarGuiceServer server) {
+        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
+        Username extraAttendeeUsername = Username.fromLocalPartWithDomain("extra-" + UUID.randomUUID(), Domain.of("open-paas.org"));
+        calendarDataProbe.addUser(extraAttendeeUsername, PASSWORD, "Extra", "Attendee");
+        OpenPaaSUser extraAttendee = calendarDataProbe.getUser(extraAttendeeUsername);
+
+        BookingLink inserted = server.getProbe(BookingLinkProbe.class)
+            .insert(openPaaSUser.username(), new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
+                true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(extraAttendee.id()),
+                Optional.empty(), Optional.empty(), Optional.empty()));
+
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body(bodyRequest("2036-01-26T09:00:00Z"))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+
+        String unfoldedCalendar = exportCalendar(openPaaSUser).replace("\r\n ", "");
+
+        assertThat(unfoldedCalendar)
+            .describedAs("extra attendees are invited and still have to answer")
+            .contains("ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;CN=%s:mailto:%s"
+                .formatted(extraAttendee.fullName(), extraAttendee.username().asString()));
+    }
+
+    @Test
+    void shouldStillBookWhenAnExtraAttendeeNoLongerExists(TwakeCalendarGuiceServer server) {
+        // An extra attendee deleted after the booking link creation must not make the link unbookable.
+        BookingLink inserted = server.getProbe(BookingLinkProbe.class)
+            .insert(openPaaSUser.username(), new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
+                true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(new OpenPaaSId("659387b9d486dc0046aeffff")),
+                Optional.empty(), Optional.empty(), Optional.empty()));
+
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body(bodyRequest("2036-01-26T09:00:00Z"))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+    }
+
+    @Test
+    void shouldNotDuplicateAttendeeWhenAnExtraAttendeeBooksTheSlotThemselves(TwakeCalendarGuiceServer server) {
+        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class);
+        Username extraAttendeeUsername = Username.fromLocalPartWithDomain("extra-" + UUID.randomUUID(), Domain.of("open-paas.org"));
+        calendarDataProbe.addUser(extraAttendeeUsername, PASSWORD, "Extra", "Attendee");
+        OpenPaaSUser extraAttendee = calendarDataProbe.getUser(extraAttendeeUsername);
+
+        BookingLink inserted = server.getProbe(BookingLinkProbe.class)
+            .insert(openPaaSUser.username(), new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
+                true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(extraAttendee.id()),
+                Optional.empty(), Optional.empty(), Optional.empty()));
+
+        given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .body("""
+                {
+                  "startUtc": "2036-01-26T09:00:00Z",
+                  "creator": { "email": "%s" },
+                  "eventTitle": "booked by an extra attendee"
+                }
+                """.formatted(extraAttendee.username().asString()))
+        .when()
+            .post("/api/booking-links/{bookingLinkPublicId}/book")
+        .then()
+            .statusCode(HttpStatus.SC_CREATED);
+
+        String unfoldedCalendar = exportCalendar(openPaaSUser).replace("\r\n ", "");
+
+        assertThat(unfoldedCalendar.lines()
+            .filter(line -> line.startsWith("ATTENDEE") && line.contains(extraAttendee.username().asString())))
+            .describedAs("the booker already is an attendee: no duplicate ATTENDEE with a conflicting PARTSTAT")
+            .hasSize(1);
     }
 
     private BookingLink insertActiveBookingLink(TwakeCalendarGuiceServer server) {

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkReservationRouteTest.java
@@ -85,6 +85,7 @@ import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+import com.linagora.calendar.storage.booking.ExtraAttendees;
 import com.linagora.calendar.storage.event.EventFields.Person;
 import com.linagora.calendar.storage.event.EventParseUtils;
 
@@ -1349,7 +1350,7 @@ class BookingLinkReservationRouteTest {
 
         BookingLink inserted = server.getProbe(BookingLinkProbe.class)
             .insert(openPaaSUser.username(), new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
-                true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(extraAttendee.id()),
+                true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), ExtraAttendees.of(extraAttendee.id()),
                 Optional.empty(), Optional.empty(), Optional.empty()));
 
         given()
@@ -1373,7 +1374,7 @@ class BookingLinkReservationRouteTest {
         // An extra attendee deleted after the booking link creation must not make the link unbookable.
         BookingLink inserted = server.getProbe(BookingLinkProbe.class)
             .insert(openPaaSUser.username(), new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
-                true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(new OpenPaaSId("659387b9d486dc0046aeffff")),
+                true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), ExtraAttendees.of(new OpenPaaSId("659387b9d486dc0046aeffff")),
                 Optional.empty(), Optional.empty(), Optional.empty()));
 
         given()
@@ -1394,7 +1395,7 @@ class BookingLinkReservationRouteTest {
 
         BookingLink inserted = server.getProbe(BookingLinkProbe.class)
             .insert(openPaaSUser.username(), new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
-                true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(extraAttendee.id()),
+                true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), ExtraAttendees.of(extraAttendee.id()),
                 Optional.empty(), Optional.empty(), Optional.empty()));
 
         given()

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -55,6 +56,7 @@ import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
@@ -480,6 +482,113 @@ class BookingLinkSlotsRouteTest {
                   { "start": "2036-01-26T09:00:00Z" },
                   { "start": "2036-01-26T10:00:00Z" },
                   { "start": "2036-01-26T10:30:00Z" },
+                  { "start": "2036-01-26T11:30:00Z" }
+                ]
+                """);
+    }
+
+    @Test
+    void shouldExcludeExtraAttendeeBusyIntervalsFromReturnedSlots(TwakeCalendarGuiceServer server) {
+        // Given: a booking link carrying an extra attendee. Their free/busy is queried by impersonating the
+        // booking link owner, so the DAV server decides what the owner may see of that calendar.
+        OpenPaaSUser extraAttendee = createTestUser(server, "extra");
+
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
+            true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(extraAttendee.id()),
+            Optional.empty(), Optional.empty(), Optional.empty());
+        BookingLink inserted = server.getProbe(BookingLinkProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        // Given owner busy interval [09:30, 10:00): this should exclude slot starting at 09:30.
+        String ownerBusyUid = UUID.randomUUID().toString();
+        davTestHelper.upsertCalendar(openPaaSUser, """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Twake//BookingSlotsTest//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20360101T000000Z
+            DTSTART:20360126T093000Z
+            DTEND:20360126T100000Z
+            SUMMARY:owner-busy
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(ownerBusyUid), ownerBusyUid);
+
+        // Given extra attendee busy interval [11:00, 11:30): this should exclude slot starting at 11:00 too.
+        String extraAttendeeBusyUid = UUID.randomUUID().toString();
+        davTestHelper.upsertCalendar(extraAttendee, """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Twake//BookingSlotsTest//EN
+            BEGIN:VEVENT
+            UID:%s
+            DTSTAMP:20360101T000000Z
+            DTSTART:20360126T110000Z
+            DTEND:20360126T113000Z
+            SUMMARY:extra-attendee-busy
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+            """.formatted(extraAttendeeBusyUid), extraAttendeeBusyUid);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .describedAs("offered slots should be the intersection of the owner and the extra attendee availability")
+            .inPath("$.slots")
+            .isEqualTo("""
+                [
+                  { "start": "2036-01-26T09:00:00Z" },
+                  { "start": "2036-01-26T10:00:00Z" },
+                  { "start": "2036-01-26T10:30:00Z" },
+                  { "start": "2036-01-26T11:30:00Z" }
+                ]
+                """);
+    }
+
+    @Test
+    void shouldStillReturnSlotsWhenExtraAttendeeCalendarCannotBeRead(TwakeCalendarGuiceServer server) {
+        // Given: an extra attendee whose calendar the owner cannot read at all. Such an attendee is treated
+        // as free rather than breaking the whole booking link.
+        BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
+            true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(new OpenPaaSId("659387b9d486dc0046aeffff")),
+            Optional.empty(), Optional.empty(), Optional.empty());
+        BookingLink inserted = server.getProbe(BookingLinkProbe.class).insert(openPaaSUser.username(), insertRequest);
+
+        String response = given()
+            .pathParam("bookingLinkPublicId", inserted.publicId().value())
+            .queryParam("from", FROM_20360126)
+            .queryParam("to", TO_20360127)
+        .when()
+            .get("/api/booking-links/{bookingLinkPublicId}/slots")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .extract()
+            .body()
+            .asString();
+
+        assertThatJson(response)
+            .inPath("$.slots")
+            .isEqualTo("""
+                [
+                  { "start": "2036-01-26T09:00:00Z" },
+                  { "start": "2036-01-26T09:30:00Z" },
+                  { "start": "2036-01-26T10:00:00Z" },
+                  { "start": "2036-01-26T10:30:00Z" },
+                  { "start": "2036-01-26T11:00:00Z" },
                   { "start": "2036-01-26T11:30:00Z" }
                 ]
                 """);

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkSlotsRouteTest.java
@@ -60,6 +60,7 @@ import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
+import com.linagora.calendar.storage.booking.ExtraAttendees;
 
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -494,7 +495,7 @@ class BookingLinkSlotsRouteTest {
         OpenPaaSUser extraAttendee = createTestUser(server, "extra");
 
         BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
-            true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(extraAttendee.id()),
+            true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), ExtraAttendees.of(extraAttendee.id()),
             Optional.empty(), Optional.empty(), Optional.empty());
         BookingLink inserted = server.getProbe(BookingLinkProbe.class).insert(openPaaSUser.username(), insertRequest);
 
@@ -563,7 +564,7 @@ class BookingLinkSlotsRouteTest {
         // Given: an extra attendee whose calendar the owner cannot read at all. Such an attendee is treated
         // as free rather than breaking the whole booking link.
         BookingLinkInsertRequest insertRequest = new BookingLinkInsertRequest(CalendarURL.from(openPaaSUser.id()), DURATION_30_MINUTES,
-            true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), List.of(new OpenPaaSId("659387b9d486dc0046aeffff")),
+            true, BookingLinkInsertRequest.AUTO_ACCEPT, Optional.of(AVAILABILITY_RULE), ExtraAttendees.of(new OpenPaaSId("659387b9d486dc0046aeffff")),
             Optional.empty(), Optional.empty(), Optional.empty());
         BookingLink inserted = server.getProbe(BookingLinkProbe.class).insert(openPaaSUser.username(), insertRequest);
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
@@ -41,6 +41,7 @@ import org.apache.james.mailbox.MailboxSession;
 import org.apache.james.metrics.api.MetricFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.linagora.calendar.api.booking.AvailabilityRule;
@@ -69,7 +70,7 @@ public class BookingLinkCreateRoute extends CalendarRoute {
                                               @JsonProperty("active") Boolean active,
                                               @JsonProperty("autoAccept") Optional<Boolean> autoAccept,
                                               @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules,
-                                              @JsonProperty("extraAttendees") Optional<List<String>> extraAttendees,
+                                              @JsonProperty("extraAttendees") Optional<JsonNode> extraAttendees,
                                               @JsonProperty("name") Optional<String> name,
                                               @JsonProperty("description") Optional<String> description,
                                               @JsonProperty("color") Optional<String> color) {
@@ -144,7 +145,7 @@ public class BookingLinkCreateRoute extends CalendarRoute {
                     CreateBookingLinkRequestDTO.toBookingLinkInsertRequest(dto, resolvedSettings.zoneId(), getDefaultAvailabilityRules(resolvedSettings))))
             .flatMap(insertRequest ->
                 validateCalendarAccess(insertRequest.calendarUrl(), session)
-                    .then(extraAttendeeResolver.validate(session.getUser(), insertRequest.extraAttendees()))
+                    .then(extraAttendeeResolver.validate(session.getUser(), insertRequest.extraAttendees().participants()))
                     .thenReturn(insertRequest))
             .flatMap(insertRequest -> bookingLinkDAO.insert(session.getUser(), insertRequest))
             .flatMap(bookingLink -> response.status(HttpResponseStatus.CREATED)

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkCreateRoute.java
@@ -51,6 +51,7 @@ import com.linagora.calendar.restapi.routes.dto.AvailabilityRuleDTO;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.booking.BookingLinkColorUtil;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.BookingLinkExtraAttendeeUtil;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
 import com.linagora.calendar.storage.configuration.resolver.BusinessHoursSettingReader;
 import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
@@ -68,6 +69,7 @@ public class BookingLinkCreateRoute extends CalendarRoute {
                                               @JsonProperty("active") Boolean active,
                                               @JsonProperty("autoAccept") Optional<Boolean> autoAccept,
                                               @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules,
+                                              @JsonProperty("extraAttendees") Optional<List<String>> extraAttendees,
                                               @JsonProperty("name") Optional<String> name,
                                               @JsonProperty("description") Optional<String> description,
                                               @JsonProperty("color") Optional<String> color) {
@@ -87,6 +89,7 @@ public class BookingLinkCreateRoute extends CalendarRoute {
 
             return new BookingLinkInsertRequest(calendarURL, duration, request.active,
                 request.autoAccept.orElse(BookingLinkInsertRequest.AUTO_ACCEPT), availabilityRules,
+                BookingLinkExtraAttendeeUtil.parse(request.extraAttendees),
                 normalize(request.name), normalize(request.description), BookingLinkColorUtil.sanitize(request.color));
         }
 
@@ -110,17 +113,20 @@ public class BookingLinkCreateRoute extends CalendarRoute {
     private final BookingLinkDAO bookingLinkDAO;
     private final CalDavClient calDavClient;
     private final SettingsBasedResolver settingsResolver;
+    private final BookingLinkExtraAttendeeResolver extraAttendeeResolver;
 
     @Inject
     public BookingLinkCreateRoute(Authenticator authenticator,
                                   MetricFactory metricFactory,
                                   BookingLinkDAO bookingLinkDAO,
                                   CalDavClient calDavClient,
-                                  @Named("businessHours") SettingsBasedResolver settingsResolver) {
+                                  @Named("businessHours") SettingsBasedResolver settingsResolver,
+                                  BookingLinkExtraAttendeeResolver extraAttendeeResolver) {
         super(authenticator, metricFactory);
         this.bookingLinkDAO = bookingLinkDAO;
         this.calDavClient = calDavClient;
         this.settingsResolver = settingsResolver;
+        this.extraAttendeeResolver = extraAttendeeResolver;
     }
 
     @Override
@@ -138,6 +144,7 @@ public class BookingLinkCreateRoute extends CalendarRoute {
                     CreateBookingLinkRequestDTO.toBookingLinkInsertRequest(dto, resolvedSettings.zoneId(), getDefaultAvailabilityRules(resolvedSettings))))
             .flatMap(insertRequest ->
                 validateCalendarAccess(insertRequest.calendarUrl(), session)
+                    .then(extraAttendeeResolver.validate(session.getUser(), insertRequest.extraAttendees()))
                     .thenReturn(insertRequest))
             .flatMap(insertRequest -> bookingLinkDAO.insert(session.getUser(), insertRequest))
             .flatMap(bookingLink -> response.status(HttpResponseStatus.CREATED)

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilder.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilder.java
@@ -25,6 +25,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
@@ -33,6 +35,7 @@ import org.apache.james.util.FunctionalUtils;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest;
 import com.linagora.calendar.restapi.routes.BookingLinkReservationService.BookingRequest.BookingAttendee;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
@@ -92,6 +95,15 @@ public class BookingLinkEventIcsBuilder {
     }
 
     public BuildResult build(BookingRequest request, BookingAttendee organizer, Duration eventDuration, BookingLinkPublicId bookingLinkPublicId, boolean autoAccept) {
+        return build(request, organizer, List.of(), eventDuration, bookingLinkPublicId, autoAccept);
+    }
+
+    public BuildResult build(BookingRequest request,
+                             BookingAttendee organizer,
+                             List<BookingAttendee> extraAttendees,
+                             Duration eventDuration,
+                             BookingLinkPublicId bookingLinkPublicId,
+                             boolean autoAccept) {
         Uid eventUid = uidGenerator.generateUid();
         Optional<URL> maybeMeetingLink = Optional.of(request.visioLink())
             .filter(FunctionalUtils.identityPredicate())
@@ -100,7 +112,7 @@ public class BookingLinkEventIcsBuilder {
         Calendar calendar = new Calendar()
             .withDefaults()
             .withProdId(PROD_ID)
-            .withComponent(buildEvent(request, organizer, eventUid, eventDuration, maybeMeetingLink, bookingLinkPublicId, autoAccept))
+            .withComponent(buildEvent(request, organizer, extraAttendees, eventUid, eventDuration, maybeMeetingLink, bookingLinkPublicId, autoAccept))
             .getFluentTarget();
 
         return new BuildResult(eventUid, calendar, maybeMeetingLink);
@@ -108,6 +120,7 @@ public class BookingLinkEventIcsBuilder {
 
     private VEvent buildEvent(BookingRequest request,
                               BookingAttendee organizer,
+                              List<BookingAttendee> extraAttendees,
                               Uid eventUid,
                               Duration eventDuration,
                               Optional<URL> maybeMeetingLink,
@@ -124,6 +137,9 @@ public class BookingLinkEventIcsBuilder {
             .add(buildAttendee(request.creator()))
             .addAll(request.additionalAttendees().stream()
                 .map(this::buildAttendee)
+                .toList())
+            .addAll(newExtraAttendees(request, extraAttendees).stream()
+                .map(this::buildExtraAttendee)
                 .toList());
 
         buildDescription(request.notes(), maybeMeetingLink)
@@ -155,12 +171,38 @@ public class BookingLinkEventIcsBuilder {
                 .orElse(null))));
     }
 
+    /**
+     * An extra attendee who booked the slot themselves, or who the booker also listed, already has an ATTENDEE
+     * line: keep that one rather than emitting a duplicate with a conflicting PARTSTAT.
+     */
+    private List<BookingAttendee> newExtraAttendees(BookingRequest request, List<BookingAttendee> extraAttendees) {
+        Set<String> alreadyInvited = Stream.concat(Stream.of(request.creator()), request.additionalAttendees().stream())
+            .map(attendee -> attendee.email().asString())
+            .collect(ImmutableSet.toImmutableSet());
+
+        return extraAttendees.stream()
+            .filter(extraAttendee -> !alreadyInvited.contains(extraAttendee.email().asString()))
+            .toList();
+    }
+
     private Attendee buildAttendee(BookingAttendee attendee) {
+        return buildAttendee(attendee, PartStat.ACCEPTED);
+    }
+
+    /**
+     * Extra attendees of the booking link were never asked: they are invited through the regular
+     * iTIP flow and still have to answer.
+     */
+    private Attendee buildExtraAttendee(BookingAttendee attendee) {
+        return buildAttendee(attendee, PartStat.NEEDS_ACTION);
+    }
+
+    private Attendee buildAttendee(BookingAttendee attendee, PartStat partStat) {
         Attendee builtAttendee = (Attendee) new Attendee(URI.create(MAIL_TO_PREFIX + attendee.email().asString()))
             .withParameter(Rsvp.TRUE)
             .withParameter(Role.REQ_PARTICIPANT)
             .withParameter(CuType.INDIVIDUAL)
-            .withParameter(PartStat.ACCEPTED)
+            .withParameter(partStat)
             .getFluentTarget();
 
         if (StringUtils.isNotBlank(attendee.name())) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkExtraAttendeeResolver.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkExtraAttendeeResolver.java
@@ -67,11 +67,13 @@ public class BookingLinkExtraAttendeeResolver {
         if (extraAttendees.isEmpty()) {
             return Mono.empty();
         }
-        return openPaaSUserDAO.retrieve(owner)
+        return resolve(extraAttendees)
             .map(OpenPaaSUser::id)
-            .flatMapMany(ownerId -> resolve(extraAttendees)
-                .filter(extraAttendee -> extraAttendee.id().equals(ownerId))
-                .concatMap(extraAttendee -> Mono.<Void>error(new IllegalArgumentException(
+            .collectList()
+            .flatMap(extraAttendeeIds -> openPaaSUserDAO.retrieve(owner)
+                .map(OpenPaaSUser::id)
+                .filter(extraAttendeeIds::contains)
+                .flatMap(ownerId -> Mono.<Void>error(new IllegalArgumentException(
                     "'extraAttendees' must not contain the booking link owner: " + ownerId.value()))))
             .then();
     }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkExtraAttendeeResolver.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkExtraAttendeeResolver.java
@@ -67,15 +67,12 @@ public class BookingLinkExtraAttendeeResolver {
         if (extraAttendees.isEmpty()) {
             return Mono.empty();
         }
-        Mono<OpenPaaSId> ownerId = openPaaSUserDAO.retrieve(owner)
+        return openPaaSUserDAO.retrieve(owner)
             .map(OpenPaaSUser::id)
-            .cache();
-
-        return resolve(extraAttendees)
-            .concatMap(extraAttendee -> ownerId
-                .filter(id -> id.equals(extraAttendee.id()))
-                .flatMap(id -> Mono.<Void>error(new IllegalArgumentException(
-                    "'extraAttendees' must not contain the booking link owner: " + id.value()))))
+            .flatMapMany(ownerId -> resolve(extraAttendees)
+                .filter(extraAttendee -> extraAttendee.id().equals(ownerId))
+                .concatMap(extraAttendee -> Mono.<Void>error(new IllegalArgumentException(
+                    "'extraAttendees' must not contain the booking link owner: " + ownerId.value()))))
             .then();
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkExtraAttendeeResolver.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkExtraAttendeeResolver.java
@@ -1,0 +1,85 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.core.Username;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Resolves the extra attendees of a booking link, which are stored as OpenPaaS ids of registered users.
+ */
+public class BookingLinkExtraAttendeeResolver {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BookingLinkExtraAttendeeResolver.class);
+
+    private final OpenPaaSUserDAO openPaaSUserDAO;
+
+    @Inject
+    public BookingLinkExtraAttendeeResolver(OpenPaaSUserDAO openPaaSUserDAO) {
+        this.openPaaSUserDAO = openPaaSUserDAO;
+    }
+
+    public Flux<OpenPaaSUser> resolve(List<OpenPaaSId> extraAttendees) {
+        return Flux.fromIterable(extraAttendees)
+            .concatMap(id -> openPaaSUserDAO.retrieve(id)
+                .switchIfEmpty(Mono.error(() -> unknownUser(id))));
+    }
+
+    /**
+     * Resolves the extra attendees that still exist, skipping the others: a user deleted after the booking link
+     * was created must not make the link unbookable.
+     */
+    public Flux<OpenPaaSUser> resolveExisting(List<OpenPaaSId> extraAttendees) {
+        return Flux.fromIterable(extraAttendees)
+            .concatMap(id -> openPaaSUserDAO.retrieve(id)
+                .switchIfEmpty(Mono.fromRunnable(() ->
+                    LOGGER.warn("Skipping extra attendee {}: no such user anymore", id.value()))));
+    }
+
+    public Mono<Void> validate(Username owner, List<OpenPaaSId> extraAttendees) {
+        if (extraAttendees.isEmpty()) {
+            return Mono.empty();
+        }
+        Mono<OpenPaaSId> ownerId = openPaaSUserDAO.retrieve(owner)
+            .map(OpenPaaSUser::id)
+            .cache();
+
+        return resolve(extraAttendees)
+            .concatMap(extraAttendee -> ownerId
+                .filter(id -> id.equals(extraAttendee.id()))
+                .flatMap(id -> Mono.<Void>error(new IllegalArgumentException(
+                    "'extraAttendees' must not contain the booking link owner: " + id.value()))))
+            .then();
+    }
+
+    private IllegalArgumentException unknownUser(OpenPaaSId id) {
+        return new IllegalArgumentException("'extraAttendees' references a user that does not exist: " + id.value());
+    }
+}

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
@@ -43,8 +43,10 @@ import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.restapi.ForbiddenException;
 import com.linagora.calendar.restapi.routes.dto.AvailabilityRuleDTO;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.booking.BookingLinkColorUtil;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.BookingLinkExtraAttendeeUtil;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
 import com.linagora.calendar.storage.booking.BookingLinkPatchRequest;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
@@ -64,6 +66,7 @@ public class BookingLinkPatchRoute extends CalendarRoute {
     private static final String FIELD_ACTIVE = "active";
     private static final String FIELD_AUTO_ACCEPT = "autoAccept";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
+    private static final String FIELD_EXTRA_ATTENDEES = "extraAttendees";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_DESCRIPTION = "description";
     private static final String FIELD_COLOR = "color";
@@ -73,6 +76,7 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                            @JsonProperty(FIELD_ACTIVE) Optional<Boolean> active,
                            @JsonProperty(FIELD_AUTO_ACCEPT) Optional<Boolean> autoAccept,
                            @JsonProperty(FIELD_AVAILABILITY_RULES) Optional<List<AvailabilityRuleDTO>> availabilityRules,
+                           @JsonProperty(FIELD_EXTRA_ATTENDEES) Optional<List<String>> extraAttendees,
                            @JsonProperty(FIELD_NAME) Optional<String> name,
                            @JsonProperty(FIELD_DESCRIPTION) Optional<String> description,
                            @JsonProperty(FIELD_COLOR) Optional<String> color) {
@@ -81,17 +85,20 @@ public class BookingLinkPatchRoute extends CalendarRoute {
     private final BookingLinkDAO bookingLinkDAO;
     private final CalDavClient calDavClient;
     private final SettingsBasedResolver settingsResolver;
+    private final BookingLinkExtraAttendeeResolver extraAttendeeResolver;
 
     @Inject
     public BookingLinkPatchRoute(Authenticator authenticator,
                                  MetricFactory metricFactory,
                                  BookingLinkDAO bookingLinkDAO,
                                  CalDavClient calDavClient,
-                                 @Named("businessHours") SettingsBasedResolver settingsResolver) {
+                                 @Named("businessHours") SettingsBasedResolver settingsResolver,
+                                 BookingLinkExtraAttendeeResolver extraAttendeeResolver) {
         super(authenticator, metricFactory);
         this.bookingLinkDAO = bookingLinkDAO;
         this.calDavClient = calDavClient;
         this.settingsResolver = settingsResolver;
+        this.extraAttendeeResolver = extraAttendeeResolver;
     }
 
     @Override
@@ -110,6 +117,9 @@ public class BookingLinkPatchRoute extends CalendarRoute {
             .flatMap(patchRequest ->
                 patchRequest.calendarUrl().toOptional().map(calendarURL ->
                     validateCalendarAccess(calendarURL, session).thenReturn(patchRequest)).orElse(Mono.just(patchRequest)))
+            .flatMap(patchRequest -> extraAttendeeResolver.validate(session.getUser(),
+                    patchRequest.extraAttendees().getOrElse(List.of()))
+                .thenReturn(patchRequest))
             .flatMap(patchRequest -> bookingLinkDAO.update(session.getUser(), publicId, patchRequest))
             .then(response.status(HttpResponseStatus.NO_CONTENT).send().then())
             .onErrorResume(BookingLinkNotFoundException.class, e ->
@@ -135,6 +145,7 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                 parseActive(node, dto),
                 parseAutoAccept(node, dto),
                 parseAvailabilityRules(node, dto, defaultTimeZone),
+                parseExtraAttendees(node, dto),
                 parseName(node, dto),
                 parseDescription(node, dto),
                 parseColor(node, dto));
@@ -201,6 +212,16 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                 Preconditions.checkArgument(!ruleList.isEmpty(), "'availabilityRules' cannot be empty if provided");
                 return new AvailabilityRules(ruleList);
             })
+            .map(ValuePatch::modifyTo)
+            .orElseGet(ValuePatch::remove);
+    }
+
+    private ValuePatch<List<OpenPaaSId>> parseExtraAttendees(JsonNode node, PatchDto dto) {
+        if (!node.has(FIELD_EXTRA_ATTENDEES)) {
+            return ValuePatch.keep();
+        }
+        return dto.extraAttendees().map(BookingLinkExtraAttendeeUtil::parse)
+            .filter(extraAttendees -> !extraAttendees.isEmpty())
             .map(ValuePatch::modifyTo)
             .orElseGet(ValuePatch::remove);
     }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkPatchRoute.java
@@ -43,13 +43,13 @@ import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.restapi.ForbiddenException;
 import com.linagora.calendar.restapi.routes.dto.AvailabilityRuleDTO;
 import com.linagora.calendar.storage.CalendarURL;
-import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.booking.BookingLinkColorUtil;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
 import com.linagora.calendar.storage.booking.BookingLinkExtraAttendeeUtil;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
 import com.linagora.calendar.storage.booking.BookingLinkPatchRequest;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+import com.linagora.calendar.storage.booking.ExtraAttendees;
 import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
 
 import io.netty.handler.codec.http.HttpMethod;
@@ -76,7 +76,7 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                            @JsonProperty(FIELD_ACTIVE) Optional<Boolean> active,
                            @JsonProperty(FIELD_AUTO_ACCEPT) Optional<Boolean> autoAccept,
                            @JsonProperty(FIELD_AVAILABILITY_RULES) Optional<List<AvailabilityRuleDTO>> availabilityRules,
-                           @JsonProperty(FIELD_EXTRA_ATTENDEES) Optional<List<String>> extraAttendees,
+                           @JsonProperty(FIELD_EXTRA_ATTENDEES) Optional<JsonNode> extraAttendees,
                            @JsonProperty(FIELD_NAME) Optional<String> name,
                            @JsonProperty(FIELD_DESCRIPTION) Optional<String> description,
                            @JsonProperty(FIELD_COLOR) Optional<String> color) {
@@ -118,7 +118,7 @@ public class BookingLinkPatchRoute extends CalendarRoute {
                 patchRequest.calendarUrl().toOptional().map(calendarURL ->
                     validateCalendarAccess(calendarURL, session).thenReturn(patchRequest)).orElse(Mono.just(patchRequest)))
             .flatMap(patchRequest -> extraAttendeeResolver.validate(session.getUser(),
-                    patchRequest.extraAttendees().getOrElse(List.of()))
+                    patchRequest.extraAttendees().getOrElse(ExtraAttendees.NONE).participants())
                 .thenReturn(patchRequest))
             .flatMap(patchRequest -> bookingLinkDAO.update(session.getUser(), publicId, patchRequest))
             .then(response.status(HttpResponseStatus.NO_CONTENT).send().then())
@@ -216,14 +216,11 @@ public class BookingLinkPatchRoute extends CalendarRoute {
             .orElseGet(ValuePatch::remove);
     }
 
-    private ValuePatch<List<OpenPaaSId>> parseExtraAttendees(JsonNode node, PatchDto dto) {
+    private ValuePatch<ExtraAttendees> parseExtraAttendees(JsonNode node, PatchDto dto) {
         if (!node.has(FIELD_EXTRA_ATTENDEES)) {
             return ValuePatch.keep();
         }
-        return dto.extraAttendees().map(BookingLinkExtraAttendeeUtil::parse)
-            .filter(extraAttendees -> !extraAttendees.isEmpty())
-            .map(ValuePatch::modifyTo)
-            .orElseGet(ValuePatch::remove);
+        return BookingLinkExtraAttendeeUtil.parsePatch(dto.extraAttendees());
     }
 
     private ValuePatch<String> parseName(JsonNode node, PatchDto dto) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
@@ -55,6 +55,7 @@ public class BookingLinkReservationService {
     private final OpenPaaSUserDAO openPaaSUserDAO;
     private final PublicAgendaProposalNotifier publicAgendaProposalNotifier;
     private final BookingLinkRequestAcknowledgementNotifier bookingLinkRequestAcknowledgementNotifier;
+    private final BookingLinkExtraAttendeeResolver extraAttendeeResolver;
 
     @Inject
     public BookingLinkReservationService(Clock clock,
@@ -63,10 +64,12 @@ public class BookingLinkReservationService {
                                          CalDavClient calDavClient,
                                          OpenPaaSUserDAO openPaaSUserDAO,
                                          PublicAgendaProposalNotifier publicAgendaProposalNotifier,
-                                         BookingLinkRequestAcknowledgementNotifier bookingLinkRequestAcknowledgementNotifier) {
+                                         BookingLinkRequestAcknowledgementNotifier bookingLinkRequestAcknowledgementNotifier,
+                                         BookingLinkExtraAttendeeResolver extraAttendeeResolver) {
         this.calDavClient = calDavClient;
         this.bookingLinkSlotsService = bookingLinkSlotsService;
         this.openPaaSUserDAO = openPaaSUserDAO;
+        this.extraAttendeeResolver = extraAttendeeResolver;
         this.publicAgendaProposalNotifier = publicAgendaProposalNotifier;
         this.bookingLinkRequestAcknowledgementNotifier = bookingLinkRequestAcknowledgementNotifier;
         this.bookingLinkEventIcsBuilder = new BookingLinkEventIcsBuilder(clock, new MeetingConferenceLinkResolver.Visio(restApiConfiguration));
@@ -103,10 +106,12 @@ public class BookingLinkReservationService {
     }
 
     private Mono<BookedEvent> createBooking(BookingLink bookingLink, BookingRequest request) {
-        return openPaaSUserDAO.retrieve(bookingLink.username())
-            .flatMap(organizer -> {
+        return Mono.zip(openPaaSUserDAO.retrieve(bookingLink.username()), resolveExtraAttendees(bookingLink))
+            .flatMap(tuple -> {
+                OpenPaaSUser organizer = tuple.getT1();
                 BuildResult eventIcsResult = bookingLinkEventIcsBuilder.build(request,
-                    BookingAttendee.from(organizer.fullName(), organizer.username().asString()), bookingLink.duration(), bookingLink.publicId(), bookingLink.autoAccept());
+                    BookingAttendee.from(organizer.fullName(), organizer.username().asString()), tuple.getT2(),
+                    bookingLink.duration(), bookingLink.publicId(), bookingLink.autoAccept());
 
                 return calDavClient.importCalendar(bookingLink.calendarUrl(), eventIcsResult.eventIdAsString(), bookingLink.username(), eventIcsResult.icsBytes())
                     .onErrorMap(throwable -> BookingLinkReservationException.createEventFailed(bookingLink.publicId(), eventIcsResult.eventIdAsString(), throwable))
@@ -117,6 +122,12 @@ public class BookingLinkReservationService {
                         bookingLink.calendarUrl().base().value(),
                         eventIcsResult.eventIdAsString()));
             });
+    }
+
+    private Mono<List<BookingAttendee>> resolveExtraAttendees(BookingLink bookingLink) {
+        return extraAttendeeResolver.resolveExisting(bookingLink.extraAttendees())
+            .map(user -> BookingAttendee.from(user.fullName(), user.username().asString()))
+            .collectList();
     }
 
     private Mono<Void> notifyBookingCreated(BookingCreated bookingCreated) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkReservationService.java
@@ -125,7 +125,7 @@ public class BookingLinkReservationService {
     }
 
     private Mono<List<BookingAttendee>> resolveExtraAttendees(BookingLink bookingLink) {
-        return extraAttendeeResolver.resolveExisting(bookingLink.extraAttendees())
+        return extraAttendeeResolver.resolveExisting(bookingLink.extraAttendees().participants())
             .map(user -> BookingAttendee.from(user.fullName(), user.username().asString()))
             .collectList();
     }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
@@ -22,10 +22,14 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linagora.calendar.api.booking.AvailabilityRule.FixedAvailabilityRule;
 import com.linagora.calendar.api.booking.AvailabilityRules;
@@ -35,6 +39,8 @@ import com.linagora.calendar.api.booking.AvailableSlotsCalculator.ComputeSlotsRe
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.UnavailableTimeRanges;
 import com.linagora.calendar.api.booking.AvailableSlotsCalculator.UnavailableTimeRanges.TimeRange;
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.FreeBusyQueryResponseObject.BusyInterval;
+import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.booking.BookingLink;
@@ -43,9 +49,12 @@ import com.linagora.calendar.storage.booking.BookingLinkNotActiveException;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class BookingLinkSlotsService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BookingLinkSlotsService.class);
+
     public record SlotsResult(BookingLink bookingLink, OpenPaaSUser owner, Set<AvailabilitySlot> slots) {
     }
 
@@ -100,10 +109,31 @@ public class BookingLinkSlotsService {
     }
 
     private Mono<UnavailableTimeRanges> retrieveUnavailableTimeRanges(BookingLink bookingLink, Instant from, Instant to) {
-        return calDavClient.findBusyIntervals(bookingLink.username(), bookingLink.calendarUrl(), from, to)
+        return Flux.concat(
+                calDavClient.findBusyIntervals(bookingLink.username(), bookingLink.calendarUrl(), from, to),
+                extraAttendeesBusyIntervals(bookingLink, from, to))
             .map(busyInterval -> new TimeRange(busyInterval.start(), busyInterval.end()))
             .collectList()
             .map(UnavailableTimeRanges::new);
+    }
+
+    /**
+     * Extra attendees availability is seen from the organizer point of view: the free-busy query runs as the
+     * booking link owner, so the calendar server decides what the owner may see of each attendee calendar.
+     * A calendar that cannot be read must not break the whole booking link: such an attendee is treated as free.
+     * Busy intervals are collected per attendee so that a failure mid-answer discards that attendee's partial
+     * view rather than mixing it in.
+     */
+    private Flux<BusyInterval> extraAttendeesBusyIntervals(BookingLink bookingLink, Instant from, Instant to) {
+        return Flux.fromIterable(bookingLink.extraAttendees())
+            .concatMap(extraAttendee -> calDavClient.findBusyIntervals(bookingLink.username(), CalendarURL.from(extraAttendee), from, to)
+                .collectList()
+                .onErrorResume(error -> {
+                    LOGGER.warn("Booking link {} could not read the calendar of extra attendee {} as {}: treating them as free",
+                        bookingLink.publicId().value(), extraAttendee.value(), bookingLink.username().asString(), error);
+                    return Mono.just(List.of());
+                })
+                .flatMapIterable(busyIntervals -> busyIntervals));
     }
 
     Mono<BookingLink> getBookingLink(BookingLinkPublicId publicId) {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/BookingLinkSlotsService.java
@@ -125,7 +125,7 @@ public class BookingLinkSlotsService {
      * view rather than mixing it in.
      */
     private Flux<BusyInterval> extraAttendeesBusyIntervals(BookingLink bookingLink, Instant from, Instant to) {
-        return Flux.fromIterable(bookingLink.extraAttendees())
+        return Flux.fromIterable(bookingLink.extraAttendees().participants())
             .concatMap(extraAttendee -> calDavClient.findBusyIntervals(bookingLink.username(), CalendarURL.from(extraAttendee), from, to)
                 .collectList()
                 .onErrorResume(error -> {

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/BookingLinkDTO.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/BookingLinkDTO.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.booking.BookingLink;
 
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
@@ -32,6 +33,7 @@ public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
                              @JsonProperty("active") boolean active,
                              @JsonProperty("autoAccept") boolean autoAccept,
                              @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules,
+                             @JsonProperty("extraAttendees") Optional<List<String>> extraAttendees,
                              @JsonProperty("name") Optional<String> name,
                              @JsonProperty("description") Optional<String> description,
                              @JsonProperty("color") String color) {
@@ -42,6 +44,12 @@ public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
                 .map(AvailabilityRuleDTO::from)
                 .toList());
 
+        Optional<List<String>> extraAttendees = Optional.of(bookingLink.extraAttendees())
+            .filter(attendees -> !attendees.isEmpty())
+            .map(attendees -> attendees.stream()
+                .map(OpenPaaSId::value)
+                .toList());
+
         return new BookingLinkDTO(
             bookingLink.publicId().value().toString(),
             bookingLink.calendarUrl().asUri().toString(),
@@ -49,6 +57,7 @@ public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
             bookingLink.active(),
             bookingLink.autoAccept(),
             ruleDTOs,
+            extraAttendees,
             bookingLink.name(),
             bookingLink.description(),
             bookingLink.colorOrDefault());

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/BookingLinkDTO.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/dto/BookingLinkDTO.java
@@ -23,8 +23,9 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.linagora.calendar.storage.OpenPaaSId;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linagora.calendar.storage.booking.BookingLink;
+import com.linagora.calendar.storage.booking.BookingLinkExtraAttendeeUtil;
 
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
@@ -33,7 +34,7 @@ public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
                              @JsonProperty("active") boolean active,
                              @JsonProperty("autoAccept") boolean autoAccept,
                              @JsonProperty("availabilityRules") Optional<List<AvailabilityRuleDTO>> availabilityRules,
-                             @JsonProperty("extraAttendees") Optional<List<String>> extraAttendees,
+                             @JsonProperty("extraAttendees") Optional<JsonNode> extraAttendees,
                              @JsonProperty("name") Optional<String> name,
                              @JsonProperty("description") Optional<String> description,
                              @JsonProperty("color") String color) {
@@ -44,11 +45,9 @@ public record BookingLinkDTO(@JsonProperty("publicId") String publicId,
                 .map(AvailabilityRuleDTO::from)
                 .toList());
 
-        Optional<List<String>> extraAttendees = Optional.of(bookingLink.extraAttendees())
+        Optional<JsonNode> extraAttendees = Optional.of(bookingLink.extraAttendees())
             .filter(attendees -> !attendees.isEmpty())
-            .map(attendees -> attendees.stream()
-                .map(OpenPaaSId::value)
-                .toList());
+            .map(BookingLinkExtraAttendeeUtil::serialize);
 
         return new BookingLinkDTO(
             bookingLink.publicId().value().toString(),

--- a/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilderTest.java
+++ b/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkEventIcsBuilderTest.java
@@ -264,6 +264,59 @@ public class BookingLinkEventIcsBuilderTest {
     }
 
     @Test
+    void buildShouldAddExtraAttendeesAsNeedsActionAttendees() {
+        BookingLinkEventIcsBuilder testee = new BookingLinkEventIcsBuilder(FIXED_CLOCK, () -> VISIO_URL, FIXED_UID_GENERATOR);
+
+        List<BookingAttendee> extraAttendees = List.of(
+            BookingAttendee.from("Presales Engineer", "presales@example.com"),
+            BookingAttendee.from("Project Manager", "pm@example.com"));
+
+        String ics = new String(testee.build(bookingRequest(), OWNER, extraAttendees, Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID, false)
+            .icsBytes(), StandardCharsets.UTF_8);
+
+        assertThat(ics)
+            .contains("ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;CN=Presales Engineer:mailto:presales@example.com")
+            .contains("ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;CN=Project Manager:mailto:pm@example.com");
+    }
+
+    @Test
+    void buildShouldNotDuplicateExtraAttendeeAlreadyInvitedByTheBooker() {
+        BookingLinkEventIcsBuilder testee = new BookingLinkEventIcsBuilder(FIXED_CLOCK, () -> VISIO_URL, FIXED_UID_GENERATOR);
+
+        BookingRequest request = new BookingRequest(
+            Instant.parse("2036-01-26T09:30:00Z"),
+            BookingAttendee.from("BOB", "creator@example.com"),
+            List.of(BookingAttendee.from("Presales Engineer", "presales@example.com")),
+            "eventTitle",
+            false,
+            null);
+
+        // Both the booker and an additional attendee collide with an extra attendee of the booking link.
+        List<BookingAttendee> extraAttendees = List.of(
+            BookingAttendee.from("Presales Engineer", "presales@example.com"),
+            BookingAttendee.from("BOB", "creator@example.com"));
+
+        String ics = new String(testee.build(request, OWNER, extraAttendees, Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID, false)
+            .icsBytes(), StandardCharsets.UTF_8);
+
+        assertThat(ics.lines().filter(line -> line.startsWith("ATTENDEE")))
+            .describedAs("already invited attendees keep their single ATTENDEE line")
+            .hasSize(3)
+            .doesNotContain("ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;CN=Presales Engineer:mailto:presales@example.com");
+    }
+
+    @Test
+    void buildShouldNotAddAnyAttendeeWhenNoExtraAttendee() {
+        BookingLinkEventIcsBuilder testee = new BookingLinkEventIcsBuilder(FIXED_CLOCK, () -> VISIO_URL, FIXED_UID_GENERATOR);
+
+        String ics = new String(testee.build(bookingRequest(), OWNER, List.of(), Duration.ofMinutes(30), BOOKING_LINK_PUBLIC_ID, false)
+            .icsBytes(), StandardCharsets.UTF_8);
+
+        assertThat(ics.lines().filter(line -> line.startsWith("ATTENDEE")))
+            .hasSize(2);
+    }
+
+    @Test
     void icsBytesShouldNotCarryAMethodByDefault() {
         BookingLinkEventIcsBuilder testee = new BookingLinkEventIcsBuilder(FIXED_CLOCK, () -> VISIO_URL, FIXED_UID_GENERATOR);
 

--- a/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkExtraAttendeeResolverTest.java
+++ b/calendar-rest-api/src/test/java/com/linagora/calendar/restapi/routes/BookingLinkExtraAttendeeResolverTest.java
@@ -1,0 +1,105 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.apache.james.core.Username;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.linagora.calendar.storage.MemoryOpenPaaSUserDAO;
+import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.OpenPaaSUser;
+
+class BookingLinkExtraAttendeeResolverTest {
+
+    private static final Username OWNER = Username.of("owner@linagora.com");
+    private static final Username EXTRA_ATTENDEE = Username.of("extra@linagora.com");
+    private static final OpenPaaSId UNKNOWN_ID = new OpenPaaSId("659387b9d486dc0046aeffff");
+
+    private MemoryOpenPaaSUserDAO userDAO;
+    private BookingLinkExtraAttendeeResolver testee;
+
+    @BeforeEach
+    void setUp() {
+        userDAO = new MemoryOpenPaaSUserDAO();
+        testee = new BookingLinkExtraAttendeeResolver(userDAO);
+    }
+
+    @Test
+    void validateShouldAcceptRegisteredUsers() {
+        userDAO.add(OWNER).block();
+        OpenPaaSUser extraAttendee = userDAO.add(EXTRA_ATTENDEE).block();
+
+        assertThatCode(() -> testee.validate(OWNER, List.of(extraAttendee.id())).block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateShouldRejectUnknownUser() {
+        userDAO.add(OWNER).block();
+
+        assertThatThrownBy(() -> testee.validate(OWNER, List.of(UNKNOWN_ID)).block())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(UNKNOWN_ID.value());
+    }
+
+    @Test
+    void validateShouldRejectTheOwner() {
+        OpenPaaSUser owner = userDAO.add(OWNER).block();
+
+        assertThatThrownBy(() -> testee.validate(OWNER, List.of(owner.id())).block())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("must not contain the booking link owner");
+    }
+
+    @Test
+    void validateShouldRejectUnknownUserWhenOwnerIsNotRegistered() {
+        assertThatThrownBy(() -> testee.validate(OWNER, List.of(UNKNOWN_ID)).block())
+            .describedAs("an unregistered owner must not bypass the extra attendees validation")
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(UNKNOWN_ID.value());
+    }
+
+    @Test
+    void validateShouldAcceptEmptyExtraAttendees() {
+        assertThatCode(() -> testee.validate(OWNER, List.of()).block())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void resolveShouldFailWhenUserDoesNotExist() {
+        assertThatThrownBy(() -> testee.resolve(List.of(UNKNOWN_ID)).collectList().block())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(UNKNOWN_ID.value());
+    }
+
+    @Test
+    void resolveExistingShouldSkipUsersThatDoNotExist() {
+        OpenPaaSUser extraAttendee = userDAO.add(EXTRA_ATTENDEE).block();
+
+        assertThat(testee.resolveExisting(List.of(UNKNOWN_ID, extraAttendee.id())).collectList().block())
+            .containsExactly(extraAttendee);
+    }
+}

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
@@ -66,6 +66,7 @@ import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
 import com.linagora.calendar.storage.booking.BookingLinkPatchRequest;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+import com.linagora.calendar.storage.booking.ExtraAttendees;
 import com.linagora.calendar.webadmin.service.BookingLinkEventDeletionService;
 import com.linagora.calendar.webadmin.task.BookingLinkEventDeletionTask;
 
@@ -219,7 +220,7 @@ public class BookingLinkUserRoutes implements Routes {
         BookingLinkInsertRequest insertRequest = parseInsertRequest(request);
 
         BookingLink bookingLink = validateCalendarAccess(user.username(), insertRequest.calendarUrl())
-            .then(validateExtraAttendees(user.username(), insertRequest.extraAttendees()))
+            .then(validateExtraAttendees(user.username(), insertRequest.extraAttendees().participants()))
             .then(bookingLinkDAO.insert(user.username(), insertRequest))
             .block();
 
@@ -239,7 +240,7 @@ public class BookingLinkUserRoutes implements Routes {
             .orElse(Mono.empty());
 
         validateCalendar
-            .then(validateExtraAttendees(username, patchRequest.extraAttendees().getOrElse(List.of())))
+            .then(validateExtraAttendees(username, patchRequest.extraAttendees().getOrElse(ExtraAttendees.NONE).participants()))
             .then(bookingLinkDAO.update(username, publicId, patchRequest))
             .onErrorMap(BookingLinkNotFoundException.class, e -> bookingLinkNotFound(publicId))
             .block();
@@ -357,14 +358,11 @@ public class BookingLinkUserRoutes implements Routes {
             .orElseGet(ValuePatch::remove);
     }
 
-    private ValuePatch<List<OpenPaaSId>> parseExtraAttendees(JsonNode node, PatchDto dto) {
+    private ValuePatch<ExtraAttendees> parseExtraAttendees(JsonNode node, PatchDto dto) {
         if (!node.has(FIELD_EXTRA_ATTENDEES)) {
             return ValuePatch.keep();
         }
-        return dto.extraAttendees().map(BookingLinkExtraAttendeeUtil::parse)
-            .filter(extraAttendees -> !extraAttendees.isEmpty())
-            .map(ValuePatch::modifyTo)
-            .orElseGet(ValuePatch::remove);
+        return BookingLinkExtraAttendeeUtil.parsePatch(dto.extraAttendees());
     }
 
     private ValuePatch<String> parseName(JsonNode node, PatchDto dto) {

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/BookingLinkUserRoutes.java
@@ -51,14 +51,17 @@ import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.restapi.routes.BookingLinkCreateRoute.CreateBookingLinkRequestDTO;
+import com.linagora.calendar.restapi.routes.BookingLinkExtraAttendeeResolver;
 import com.linagora.calendar.restapi.routes.BookingLinkPatchRoute.PatchDto;
 import com.linagora.calendar.restapi.routes.dto.BookingLinkDTO;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkColorUtil;
 import com.linagora.calendar.storage.booking.BookingLinkDAO;
+import com.linagora.calendar.storage.booking.BookingLinkExtraAttendeeUtil;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
 import com.linagora.calendar.storage.booking.BookingLinkPatchRequest;
@@ -101,6 +104,7 @@ public class BookingLinkUserRoutes implements Routes {
     private static final String FIELD_ACTIVE = "active";
     private static final String FIELD_AUTO_ACCEPT = "autoAccept";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
+    private static final String FIELD_EXTRA_ATTENDEES = "extraAttendees";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_DESCRIPTION = "description";
     private static final String FIELD_COLOR = "color";
@@ -114,6 +118,7 @@ public class BookingLinkUserRoutes implements Routes {
     private final CalDavClient calDavClient;
     private final TaskManager taskManager;
     private final BookingLinkEventDeletionService eventDeletionService;
+    private final BookingLinkExtraAttendeeResolver extraAttendeeResolver;
     private final JsonTransformer jsonTransformer;
 
     @Inject
@@ -122,12 +127,14 @@ public class BookingLinkUserRoutes implements Routes {
                                  CalDavClient calDavClient,
                                  TaskManager taskManager,
                                  BookingLinkEventDeletionService eventDeletionService,
+                                 BookingLinkExtraAttendeeResolver extraAttendeeResolver,
                                  JsonTransformer jsonTransformer) {
         this.userDAO = userDAO;
         this.bookingLinkDAO = bookingLinkDAO;
         this.calDavClient = calDavClient;
         this.taskManager = taskManager;
         this.eventDeletionService = eventDeletionService;
+        this.extraAttendeeResolver = extraAttendeeResolver;
         this.jsonTransformer = jsonTransformer;
     }
 
@@ -212,6 +219,7 @@ public class BookingLinkUserRoutes implements Routes {
         BookingLinkInsertRequest insertRequest = parseInsertRequest(request);
 
         BookingLink bookingLink = validateCalendarAccess(user.username(), insertRequest.calendarUrl())
+            .then(validateExtraAttendees(user.username(), insertRequest.extraAttendees()))
             .then(bookingLinkDAO.insert(user.username(), insertRequest))
             .block();
 
@@ -231,6 +239,7 @@ public class BookingLinkUserRoutes implements Routes {
             .orElse(Mono.empty());
 
         validateCalendar
+            .then(validateExtraAttendees(username, patchRequest.extraAttendees().getOrElse(List.of())))
             .then(bookingLinkDAO.update(username, publicId, patchRequest))
             .onErrorMap(BookingLinkNotFoundException.class, e -> bookingLinkNotFound(publicId))
             .block();
@@ -286,6 +295,7 @@ public class BookingLinkUserRoutes implements Routes {
                 parseActive(node, dto),
                 parseAutoAccept(node, dto),
                 parseAvailabilityRules(node, dto),
+                parseExtraAttendees(node, dto),
                 parseName(node, dto),
                 parseDescription(node, dto),
                 parseColor(node, dto));
@@ -347,6 +357,16 @@ public class BookingLinkUserRoutes implements Routes {
             .orElseGet(ValuePatch::remove);
     }
 
+    private ValuePatch<List<OpenPaaSId>> parseExtraAttendees(JsonNode node, PatchDto dto) {
+        if (!node.has(FIELD_EXTRA_ATTENDEES)) {
+            return ValuePatch.keep();
+        }
+        return dto.extraAttendees().map(BookingLinkExtraAttendeeUtil::parse)
+            .filter(extraAttendees -> !extraAttendees.isEmpty())
+            .map(ValuePatch::modifyTo)
+            .orElseGet(ValuePatch::remove);
+    }
+
     private ValuePatch<String> parseName(JsonNode node, PatchDto dto) {
         if (!node.has(FIELD_NAME)) {
             return ValuePatch.keep();
@@ -372,6 +392,11 @@ public class BookingLinkUserRoutes implements Routes {
         return BookingLinkColorUtil.sanitize(dto.color())
             .map(ValuePatch::modifyTo)
             .orElseGet(ValuePatch::remove);
+    }
+
+    private Mono<Void> validateExtraAttendees(Username username, List<OpenPaaSId> extraAttendees) {
+        return extraAttendeeResolver.validate(username, extraAttendees)
+            .onErrorMap(IllegalArgumentException.class, e -> badRequest(e.getMessage(), e));
     }
 
     private Mono<Void> validateCalendarAccess(Username username, CalendarURL calendarURL) {

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkEventDeletionTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkEventDeletionTest.java
@@ -57,6 +57,7 @@ import com.linagora.calendar.api.booking.AvailabilityRule.WeeklyAvailabilityRule
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.restapi.routes.BookingLinkExtraAttendeeResolver;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
@@ -96,7 +97,8 @@ public class BookingLinkEventDeletionTest {
         BookingLinkEventDeletionService eventDeletionService = new BookingLinkEventDeletionService(calDavClient);
 
         webAdminServer = WebAdminUtils.createWebAdminServer(
-                new BookingLinkUserRoutes(userDAO, bookingLinkDAO, calDavClient, taskManager, eventDeletionService, new JsonTransformer()),
+                new BookingLinkUserRoutes(userDAO, bookingLinkDAO, calDavClient, taskManager, eventDeletionService,
+                    new BookingLinkExtraAttendeeResolver(userDAO), new JsonTransformer()),
                 new TasksRoutes(taskManager,
                     new JsonTransformer(),
                     new DTOConverter<>(ImmutableSet.<AdditionalInformationDTOModule<? extends TaskExecutionDetails.AdditionalInformation, ? extends AdditionalInformationDTO>>builder()

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
@@ -50,6 +50,7 @@ import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.restapi.routes.BookingLinkExtraAttendeeResolver;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
@@ -93,7 +94,8 @@ public class BookingLinkUserRoutesTest {
             new BookingLinkEventDeletionService(calDavClient);
 
         webAdminServer = WebAdminUtils.createWebAdminServer(
-            new BookingLinkUserRoutes(userDAO, bookingLinkDAO, calDavClient, taskManager, eventDeletionService, new JsonTransformer()))
+            new BookingLinkUserRoutes(userDAO, bookingLinkDAO, calDavClient, taskManager, eventDeletionService,
+                new BookingLinkExtraAttendeeResolver(userDAO), new JsonTransformer()))
             .start();
 
         RestAssured.requestSpecification = WebAdminUtils.buildRequestSpecification(webAdminServer).build();
@@ -224,6 +226,44 @@ public class BookingLinkUserRoutesTest {
         assertThat(stored).isNotNull();
         assertThat(stored.duration()).isEqualTo(Duration.ofMinutes(45));
         assertThat(stored.calendarUrl()).isEqualTo(CalendarURL.from(user.id()));
+    }
+
+    @Test
+    void createShouldStoreExtraAttendees() {
+        String publicId = given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 45,
+                    "active": true,
+                    "extraAttendees": ["%s"]
+                }
+                """.formatted(defaultCalendarUrl(user), otherUser.id().value()))
+        .when()
+            .post("/users/{username}/booking-links", user.username().asString())
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getString("bookingLinkPublicId");
+
+        BookingLink stored = bookingLinkDAO.findByPublicId(user.username(), new BookingLinkPublicId(UUID.fromString(publicId))).block();
+        assertThat(stored.extraAttendees()).containsExactly(otherUser.id());
+    }
+
+    @Test
+    void createShouldReturn400WhenExtraAttendeeDoesNotExist() {
+        given()
+            .body("""
+                {
+                    "calendarUrl": "%s",
+                    "durationMinutes": 45,
+                    "active": true,
+                    "extraAttendees": ["659387b9d486dc0046aeffff"]
+                }
+                """.formatted(defaultCalendarUrl(user)))
+        .when()
+            .post("/users/{username}/booking-links", user.username().asString())
+        .then()
+            .statusCode(400);
     }
 
     @Test

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
@@ -57,6 +57,7 @@ import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.booking.BookingLink;
 import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+import com.linagora.calendar.storage.booking.ExtraAttendees;
 import com.linagora.calendar.storage.mongodb.MongoDBBookingLinkDAO;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSDomainDAO;
 import com.linagora.calendar.storage.mongodb.MongoDBOpenPaaSUserDAO;
@@ -236,7 +237,7 @@ public class BookingLinkUserRoutesTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 45,
                     "active": true,
-                    "extraAttendees": ["%s"]
+                    "extraAttendees": { "and": [ { "participant": "%s" } ] }
                 }
                 """.formatted(defaultCalendarUrl(user), otherUser.id().value()))
         .when()
@@ -246,7 +247,7 @@ public class BookingLinkUserRoutesTest {
             .extract().jsonPath().getString("bookingLinkPublicId");
 
         BookingLink stored = bookingLinkDAO.findByPublicId(user.username(), new BookingLinkPublicId(UUID.fromString(publicId))).block();
-        assertThat(stored.extraAttendees()).containsExactly(otherUser.id());
+        assertThat(stored.extraAttendees()).isEqualTo(ExtraAttendees.of(otherUser.id()));
     }
 
     @Test
@@ -257,7 +258,7 @@ public class BookingLinkUserRoutesTest {
                     "calendarUrl": "%s",
                     "durationMinutes": 45,
                     "active": true,
-                    "extraAttendees": ["659387b9d486dc0046aeffff"]
+                    "extraAttendees": { "and": [ { "participant": "659387b9d486dc0046aeffff" } ] }
                 }
                 """.formatted(defaultCalendarUrl(user)))
         .when()

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -25,7 +25,7 @@ Public users can use booking links to book events.
 | `active`            | boolean          | Whether the booking link is active                                          |
 | `autoAccept`        | boolean          | When `true`, the organizer accepts as soon as a booking is created: no validation mail is sent to the organizer and no acknowledgement mail to the booker, the regular IMIP flow applies. When `false` (default), the booking starts the validation flow. |
 | `availabilityRules` | array (optional) | List of availability rule objects (weekly or fixed)                         |
-| `extraAttendees`    | array (optional) | OpenPaaS ids of registered users invited to every event booked through this link. Omitted from responses when empty. See [Extra attendees](#extra-attendees). |
+| `extraAttendees`    | object (optional)| Tree of the registered users invited to every event booked through this link. Omitted from responses when empty. See [Extra attendees](#extra-attendees). |
 | `name`              | string (optional)| Display name of the booking link                                            |
 | `description`       | string (optional)| Description of the booking link                                             |
 | `color`             | string           | Display color of the booking link, as a `#RRGGBB` hex string. Always present in responses, defaulting to `#6B4ECC` when not set. |
@@ -53,9 +53,27 @@ Public users can use booking links to book events.
 
 ### Extra attendees
 
-A booking link may carry `extraAttendees`: a list of OpenPaaS ids of registered users to invite alongside the owner.
-This allows handing over a single link for a meeting that needs several people, for instance a sales
-representative, a presales engineer and a project manager.
+A booking link may carry `extraAttendees`: registered users to invite alongside the owner. This allows handing
+over a single link for a meeting that needs several people, for instance a sales representative, a presales
+engineer and a project manager.
+
+They are expressed as a tree, whose only supported shape today is a single `and` node of `participant` leaves -
+invite all of them:
+
+```json
+{
+    "extraAttendees": {
+        "and": [
+            { "participant": "67c3a792e4b0884b05ef8af0" },
+            { "participant": "67c3a792e4b0884b05ef8af1" }
+        ]
+    }
+}
+```
+
+The tree leaves room for the richer combinations calendaring calls for (optional participants, substitutes:
+`bob` OR `michael` but only one of them) without a breaking change. Any other shape - other node types, nested
+`and`, extra fields on a leaf - is rejected with a `400 Bad Request` for now.
 
 Extra attendees change the booking link in two ways:
 
@@ -71,8 +89,8 @@ Working hours of the extra attendees own timezone are not taken into account.
 
 Constraints:
 
-- Each entry must be the OpenPaaS id of an existing user, and must not be the booking link owner.
-- At most 20 extra attendees. Duplicates are ignored.
+- Each `participant` must be the OpenPaaS id of an existing user, and must not be the booking link owner.
+- At most 20 participants. Duplicates are ignored.
 
 ---
 
@@ -91,7 +109,7 @@ Create a new booking link for the authenticated user.
 | `active`            | yes      | Whether the booking link is active                                                                                                                       |
 | `autoAccept`        | no       | Whether bookings are auto-accepted by the organizer. Defaults to `false` when omitted.                                                                   |
 | `availabilityRules` | no       | List of availability rules. Defaults to business hours from user settings when omitted. Each rule may specify its own `timeZone` (see availability rule object above). |
-| `extraAttendees`    | no       | OpenPaaS ids of registered users to invite on every booked event. Empty when omitted. See [Extra attendees](#extra-attendees).                            |
+| `extraAttendees`    | no       | Tree of the registered users to invite on every booked event. Empty when omitted. See [Extra attendees](#extra-attendees).                                |
 | `name`              | no       | Display name of the booking link. Blank values are ignored.                                                                                              |
 | `description`       | no       | Description of the booking link. Blank values are ignored.                                                                                               |
 | `color`             | no       | Display color as a `#RRGGBB` hex string. Blank values are ignored. Defaults to `#6B4ECC` when omitted.                                                    |
@@ -110,7 +128,7 @@ Content-Type: application/json
     "name": "Intro call",
     "description": "Book a 30-minute introduction call",
     "color": "#6B4ECC",
-    "extraAttendees": ["67c3a792e4b0884b05ef8af0", "67c3a792e4b0884b05ef8af1"],
+    "extraAttendees": { "and": [{ "participant": "67c3a792e4b0884b05ef8af0" }, { "participant": "67c3a792e4b0884b05ef8af1" }] },
     "availabilityRules": [
         { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Asia/Ho_Chi_Minh" },
         { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "timeZone": "Europe/London" },
@@ -242,7 +260,7 @@ All fields are optional. Include only the fields to update.
 | `active`            | New active state                                                                                                 |
 | `autoAccept`        | New auto-accept state                                                                                            |
 | `availabilityRules` | Replaces all existing rules. Set to `null` to remove all rules. Each rule may specify its own `timeZone`. |
-| `extraAttendees`    | Replaces all existing extra attendees. Set to `null` or `[]` to remove them all. See [Extra attendees](#extra-attendees). |
+| `extraAttendees`    | Replaces all existing extra attendees. Set to `null` or `{"and": []}` to remove them all. See [Extra attendees](#extra-attendees). |
 | `name`              | New display name. Set to `null` or a blank value to remove it.                                                   |
 | `description`       | New description. Set to `null` or a blank value to remove it.                                                    |
 | `color`             | New display color as a `#RRGGBB` hex string. Set to `null` or a blank value to remove it (the default `#6B4ECC` then applies). |

--- a/docs/apis/bookingLink.md
+++ b/docs/apis/bookingLink.md
@@ -25,6 +25,7 @@ Public users can use booking links to book events.
 | `active`            | boolean          | Whether the booking link is active                                          |
 | `autoAccept`        | boolean          | When `true`, the organizer accepts as soon as a booking is created: no validation mail is sent to the organizer and no acknowledgement mail to the booker, the regular IMIP flow applies. When `false` (default), the booking starts the validation flow. |
 | `availabilityRules` | array (optional) | List of availability rule objects (weekly or fixed)                         |
+| `extraAttendees`    | array (optional) | OpenPaaS ids of registered users invited to every event booked through this link. Omitted from responses when empty. See [Extra attendees](#extra-attendees). |
 | `name`              | string (optional)| Display name of the booking link                                            |
 | `description`       | string (optional)| Description of the booking link                                             |
 | `color`             | string           | Display color of the booking link, as a `#RRGGBB` hex string. Always present in responses, defaulting to `#6B4ECC` when not set. |
@@ -50,6 +51,29 @@ Public users can use booking links to book events.
 | `end`      | string | End date-time in `yyyy-MM-ddTHH:mm:ss` format       |
 | `timeZone` | string | IANA timezone used to interpret `start` and `end`. Default to the timezone setting of the user, then to the default configured timezone then UTC if omitted. |
 
+### Extra attendees
+
+A booking link may carry `extraAttendees`: a list of OpenPaaS ids of registered users to invite alongside the owner.
+This allows handing over a single link for a meeting that needs several people, for instance a sales
+representative, a presales engineer and a project manager.
+
+Extra attendees change the booking link in two ways:
+
+- The offered slots are the intersection of the availability rules, the owner availability, and each extra
+  attendee availability. Attendee availability is seen from the owner point of view: the free-busy lookup is
+  performed as the booking link owner, so only what the calendar server lets the owner see (public calendar,
+  read delegation) narrows down the slots. An attendee whose calendar cannot be read at all is considered free
+  rather than making the booking link unusable.
+- Every event booked through the link carries the extra attendees as attendees, with `PARTSTAT=NEEDS-ACTION`:
+  they are invited through the regular iTIP flow and still have to answer.
+
+Working hours of the extra attendees own timezone are not taken into account.
+
+Constraints:
+
+- Each entry must be the OpenPaaS id of an existing user, and must not be the booking link owner.
+- At most 20 extra attendees. Duplicates are ignored.
+
 ---
 
 ## Endpoints
@@ -67,6 +91,7 @@ Create a new booking link for the authenticated user.
 | `active`            | yes      | Whether the booking link is active                                                                                                                       |
 | `autoAccept`        | no       | Whether bookings are auto-accepted by the organizer. Defaults to `false` when omitted.                                                                   |
 | `availabilityRules` | no       | List of availability rules. Defaults to business hours from user settings when omitted. Each rule may specify its own `timeZone` (see availability rule object above). |
+| `extraAttendees`    | no       | OpenPaaS ids of registered users to invite on every booked event. Empty when omitted. See [Extra attendees](#extra-attendees).                            |
 | `name`              | no       | Display name of the booking link. Blank values are ignored.                                                                                              |
 | `description`       | no       | Description of the booking link. Blank values are ignored.                                                                                               |
 | `color`             | no       | Display color as a `#RRGGBB` hex string. Blank values are ignored. Defaults to `#6B4ECC` when omitted.                                                    |
@@ -85,6 +110,7 @@ Content-Type: application/json
     "name": "Intro call",
     "description": "Book a 30-minute introduction call",
     "color": "#6B4ECC",
+    "extraAttendees": ["67c3a792e4b0884b05ef8af0", "67c3a792e4b0884b05ef8af1"],
     "availabilityRules": [
         { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Asia/Ho_Chi_Minh" },
         { "type": "weekly", "dayOfWeek": "MON", "start": "13:00", "end": "17:00", "timeZone": "Europe/London" },
@@ -107,7 +133,7 @@ Content-Type: application/json
 
 | Status | Cause                                          |
 |--------|------------------------------------------------|
-| 400    | Missing or invalid field, unknown rule type, invalid `timeZone`, calendar not found or inaccessible |
+| 400    | Missing or invalid field, unknown rule type, invalid `timeZone`, calendar not found or inaccessible, unknown extra attendee, extra attendee is the owner |
 | 401    | Unauthenticated                                |
 
 ---
@@ -144,7 +170,7 @@ Content-Type: application/json
 ]
 ```
 
-Fields `availabilityRules`, `name` and `description` are omitted from each entry when not set.
+Fields `availabilityRules`, `extraAttendees`, `name` and `description` are omitted from each entry when not set.
 The `color` field is always present, defaulting to `#6B4ECC` when not set.
 
 **Error responses**
@@ -187,7 +213,7 @@ Content-Type: application/json
 }
 ```
 
-Fields `availabilityRules`, `name` and `description` are omitted from the response when not set.
+Fields `availabilityRules`, `extraAttendees`, `name` and `description` are omitted from the response when not set.
 The `color` field is always present, defaulting to `#6B4ECC` when not set.
 
 **Error responses**
@@ -216,6 +242,7 @@ All fields are optional. Include only the fields to update.
 | `active`            | New active state                                                                                                 |
 | `autoAccept`        | New auto-accept state                                                                                            |
 | `availabilityRules` | Replaces all existing rules. Set to `null` to remove all rules. Each rule may specify its own `timeZone`. |
+| `extraAttendees`    | Replaces all existing extra attendees. Set to `null` or `[]` to remove them all. See [Extra attendees](#extra-attendees). |
 | `name`              | New display name. Set to `null` or a blank value to remove it.                                                   |
 | `description`       | New description. Set to `null` or a blank value to remove it.                                                    |
 | `color`             | New display color as a `#RRGGBB` hex string. Set to `null` or a blank value to remove it (the default `#6B4ECC` then applies). |
@@ -265,7 +292,7 @@ HTTP/1.1 204 No Content
 
 | Status | Cause                                                             |
 |--------|-------------------------------------------------------------------|
-| 400    | No field provided, invalid value, invalid `timeZone`, calendar not found or inaccessible |
+| 400    | No field provided, invalid value, invalid `timeZone`, calendar not found or inaccessible, unknown extra attendee, extra attendee is the owner |
 | 401    | Unauthenticated                                                   |
 | 404    | Booking link not found or belongs to another user                 |
 

--- a/docs/apis/webadmin.md
+++ b/docs/apis/webadmin.md
@@ -1328,7 +1328,7 @@ Content-Type: application/json
 ]
 ```
 
-`availabilityRules`, `name` and `description` are omitted from an entry when not set.
+`availabilityRules`, `extraAttendees`, `name` and `description` are omitted from an entry when not set.
 The `color` field is always present, defaulting to `#6B4ECC` when not set.
 
 **Status codes**:
@@ -1359,13 +1359,17 @@ POST /users/{username}/booking-links
   "name": "Intro call",
   "description": "Book a 30-minute introduction call",
   "color": "#6B4ECC",
+  "extraAttendees": ["67c3a792e4b0884b05ef8af0"],
   "availabilityRules": [
     { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Europe/Paris" }
   ]
 }
 ```
 
-`calendarUrl`, `durationMinutes` and `active` are required. `autoAccept` (default `false`), `availabilityRules`, `name`, `description` and `color` (default `#6B4ECC`) are optional.
+`calendarUrl`, `durationMinutes` and `active` are required. `autoAccept` (default `false`), `availabilityRules`, `extraAttendees` (empty by default), `name`, `description` and `color` (default `#6B4ECC`) are optional.
+
+`extraAttendees` holds OpenPaaS ids of registered users invited on every booked event, and whose availability
+narrows down the offered slots. See the [booking link API](bookingLink.md#extra-attendees) for details.
 
 ```
 HTTP/1.1 201 Created
@@ -1379,7 +1383,7 @@ Content-Type: application/json
 
 **Status codes**:
 - `201`: the booking link was created
-- `400`: invalid `username`, missing/invalid field, unknown rule type, invalid `timeZone`, or the calendar does not exist for that user
+- `400`: invalid `username`, missing/invalid field, unknown rule type, invalid `timeZone`, the calendar does not exist for that user, or an extra attendee is unknown or is the owner
 - `404`: the user does not exist
 
 ### Updating a booking link
@@ -1393,8 +1397,8 @@ PATCH /users/{username}/booking-links/{publicId}
 ```
 
 Only the fields present in the body are updated. At least one field must be provided.
-Set `availabilityRules` to `null` to remove all rules. Set `name` or `description` to `null`
-or a blank value to remove them.
+Set `availabilityRules` to `null` to remove all rules. Set `extraAttendees` to `null` or `[]` to
+remove them all. Set `name` or `description` to `null` or a blank value to remove them.
 
 **Status codes**:
 - `204`: the booking link was updated

--- a/docs/apis/webadmin.md
+++ b/docs/apis/webadmin.md
@@ -1359,7 +1359,7 @@ POST /users/{username}/booking-links
   "name": "Intro call",
   "description": "Book a 30-minute introduction call",
   "color": "#6B4ECC",
-  "extraAttendees": ["67c3a792e4b0884b05ef8af0"],
+  "extraAttendees": { "and": [{ "participant": "67c3a792e4b0884b05ef8af0" }] },
   "availabilityRules": [
     { "type": "weekly", "dayOfWeek": "MON", "start": "09:00", "end": "12:00", "timeZone": "Europe/Paris" }
   ]
@@ -1368,8 +1368,9 @@ POST /users/{username}/booking-links
 
 `calendarUrl`, `durationMinutes` and `active` are required. `autoAccept` (default `false`), `availabilityRules`, `extraAttendees` (empty by default), `name`, `description` and `color` (default `#6B4ECC`) are optional.
 
-`extraAttendees` holds OpenPaaS ids of registered users invited on every booked event, and whose availability
-narrows down the offered slots. See the [booking link API](bookingLink.md#extra-attendees) for details.
+`extraAttendees` holds a tree of the registered users invited on every booked event, and whose availability
+narrows down the offered slots. Only a single `and` of `participant` leaves is supported today. See the
+[booking link API](bookingLink.md#extra-attendees) for details.
 
 ```
 HTTP/1.1 201 Created
@@ -1397,7 +1398,7 @@ PATCH /users/{username}/booking-links/{publicId}
 ```
 
 Only the fields present in the body are updated. At least one field must be provided.
-Set `availabilityRules` to `null` to remove all rules. Set `extraAttendees` to `null` or `[]` to
+Set `availabilityRules` to `null` to remove all rules. Set `extraAttendees` to `null` or `{"and": []}` to
 remove them all. Set `name` or `description` to `null` or a blank value to remove them.
 
 **Status codes**:

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLink.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLink.java
@@ -20,7 +20,6 @@ package com.linagora.calendar.storage.booking;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 
 import org.apache.james.core.Username;
@@ -28,7 +27,6 @@ import org.apache.james.core.Username;
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.storage.CalendarURL;
-import com.linagora.calendar.storage.OpenPaaSId;
 
 public record BookingLink(Username username,
                           BookingLinkPublicId publicId,
@@ -37,7 +35,7 @@ public record BookingLink(Username username,
                           boolean active,
                           boolean autoAccept,
                           Optional<AvailabilityRules> availabilityRules,
-                          List<OpenPaaSId> extraAttendees,
+                          ExtraAttendees extraAttendees,
                           Optional<String> name,
                           Optional<String> description,
                           Optional<String> color,
@@ -58,7 +56,6 @@ public record BookingLink(Username username,
         Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkNotNull(color, "'color' must not be null");
         Preconditions.checkNotNull(createdAt, "'createdAt' must not be null");
-        extraAttendees = List.copyOf(extraAttendees);
     }
 
     public String colorOrDefault() {
@@ -94,7 +91,7 @@ public record BookingLink(Username username,
         private boolean active;
         private boolean autoAccept;
         private Optional<AvailabilityRules> availabilityRules = Optional.empty();
-        private List<OpenPaaSId> extraAttendees = List.of();
+        private ExtraAttendees extraAttendees = ExtraAttendees.NONE;
         private Optional<String> name = Optional.empty();
         private Optional<String> description = Optional.empty();
         private Optional<String> color = Optional.empty();
@@ -136,7 +133,7 @@ public record BookingLink(Username username,
             return this;
         }
 
-        public Builder extraAttendees(List<OpenPaaSId> extraAttendees) {
+        public Builder extraAttendees(ExtraAttendees extraAttendees) {
             this.extraAttendees = extraAttendees;
             return this;
         }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLink.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLink.java
@@ -20,6 +20,7 @@ package com.linagora.calendar.storage.booking;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.james.core.Username;
@@ -27,6 +28,7 @@ import org.apache.james.core.Username;
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
 
 public record BookingLink(Username username,
                           BookingLinkPublicId publicId,
@@ -35,6 +37,7 @@ public record BookingLink(Username username,
                           boolean active,
                           boolean autoAccept,
                           Optional<AvailabilityRules> availabilityRules,
+                          List<OpenPaaSId> extraAttendees,
                           Optional<String> name,
                           Optional<String> description,
                           Optional<String> color,
@@ -50,10 +53,12 @@ public record BookingLink(Username username,
         Preconditions.checkNotNull(duration, "'eventDuration' must not be null");
         Preconditions.checkArgument(!duration.isNegative() && !duration.isZero(), "'eventDuration' must be positive");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
+        Preconditions.checkNotNull(extraAttendees, "'extraAttendees' must not be null");
         Preconditions.checkNotNull(name, "'name' must not be null");
         Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkNotNull(color, "'color' must not be null");
         Preconditions.checkNotNull(createdAt, "'createdAt' must not be null");
+        extraAttendees = List.copyOf(extraAttendees);
     }
 
     public String colorOrDefault() {
@@ -73,6 +78,7 @@ public record BookingLink(Username username,
             .active(active)
             .autoAccept(autoAccept)
             .availabilityRules(availabilityRules)
+            .extraAttendees(extraAttendees)
             .name(name)
             .description(description)
             .color(color)
@@ -88,6 +94,7 @@ public record BookingLink(Username username,
         private boolean active;
         private boolean autoAccept;
         private Optional<AvailabilityRules> availabilityRules = Optional.empty();
+        private List<OpenPaaSId> extraAttendees = List.of();
         private Optional<String> name = Optional.empty();
         private Optional<String> description = Optional.empty();
         private Optional<String> color = Optional.empty();
@@ -129,6 +136,11 @@ public record BookingLink(Username username,
             return this;
         }
 
+        public Builder extraAttendees(List<OpenPaaSId> extraAttendees) {
+            this.extraAttendees = extraAttendees;
+            return this;
+        }
+
         public Builder name(Optional<String> name) {
             this.name = name;
             return this;
@@ -155,7 +167,7 @@ public record BookingLink(Username username,
         }
 
         public BookingLink build() {
-            return new BookingLink(username, publicId, calendarUrl, duration, active, autoAccept, availabilityRules, name, description, color, createdAt, updatedAt);
+            return new BookingLink(username, publicId, calendarUrl, duration, active, autoAccept, availabilityRules, extraAttendees, name, description, color, createdAt, updatedAt);
         }
     }
 

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkExtraAttendeeUtil.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkExtraAttendeeUtil.java
@@ -1,0 +1,52 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage.booking;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Preconditions;
+import com.linagora.calendar.storage.OpenPaaSId;
+
+public class BookingLinkExtraAttendeeUtil {
+
+    public static final int MAX_EXTRA_ATTENDEES = 20;
+
+    public static List<OpenPaaSId> parse(Optional<List<String>> raw) {
+        return raw.map(BookingLinkExtraAttendeeUtil::parse)
+            .orElse(BookingLinkInsertRequest.NO_EXTRA_ATTENDEE);
+    }
+
+    public static List<OpenPaaSId> parse(List<String> raw) {
+        List<OpenPaaSId> parsed = raw.stream()
+            .map(StringUtils::trimToEmpty)
+            .peek(value -> Preconditions.checkArgument(!value.isEmpty(), "'extraAttendees' must not contain blank values"))
+            .map(OpenPaaSId::new)
+            .distinct()
+            .toList();
+        Preconditions.checkArgument(parsed.size() <= MAX_EXTRA_ATTENDEES,
+            "'extraAttendees' must not contain more than %s entries", MAX_EXTRA_ATTENDEES);
+        return parsed;
+    }
+
+    private BookingLinkExtraAttendeeUtil() {
+    }
+}

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkExtraAttendeeUtil.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkExtraAttendeeUtil.java
@@ -20,31 +20,103 @@ package com.linagora.calendar.storage.booking;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.james.util.ValuePatch;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.storage.OpenPaaSId;
 
+/**
+ * JSON representation of the {@link ExtraAttendees} tree:
+ *
+ * <pre>{@code {"and": [{"participant": "id1"}, {"participant": "id2"}]}}</pre>
+ *
+ * Only that shape - a single 'and' of 'participant' leaves - is accepted for now, richer trees being left for
+ * later.
+ */
 public class BookingLinkExtraAttendeeUtil {
 
     public static final int MAX_EXTRA_ATTENDEES = 20;
 
-    public static List<OpenPaaSId> parse(Optional<List<String>> raw) {
-        return raw.map(BookingLinkExtraAttendeeUtil::parse)
+    private static final String FIELD_AND = "and";
+    private static final String FIELD_PARTICIPANT = "participant";
+
+    public static ExtraAttendees parse(Optional<JsonNode> raw) {
+        return value(raw)
+            .map(BookingLinkExtraAttendeeUtil::parse)
             .orElse(BookingLinkInsertRequest.NO_EXTRA_ATTENDEE);
     }
 
-    public static List<OpenPaaSId> parse(List<String> raw) {
-        List<OpenPaaSId> parsed = raw.stream()
-            .map(StringUtils::trimToEmpty)
-            .peek(value -> Preconditions.checkArgument(!value.isEmpty(), "'extraAttendees' must not contain blank values"))
-            .map(OpenPaaSId::new)
+    /**
+     * Parses the 'extraAttendees' of a patch request, the caller being responsible for telling an absent field
+     * (keep) from a present one.
+     */
+    public static ValuePatch<ExtraAttendees> parsePatch(Optional<JsonNode> raw) {
+        return value(raw)
+            .map(BookingLinkExtraAttendeeUtil::parse)
+            .filter(extraAttendees -> !extraAttendees.isEmpty())
+            .map(ValuePatch::modifyTo)
+            .orElseGet(ValuePatch::remove);
+    }
+
+    public static ExtraAttendees parse(JsonNode raw) {
+        Preconditions.checkArgument(raw.isObject() && raw.size() == 1 && raw.has(FIELD_AND),
+            "'extraAttendees' must be an object holding a single 'and' field");
+        JsonNode and = raw.get(FIELD_AND);
+        Preconditions.checkArgument(and.isArray(), "'extraAttendees.and' must be an array");
+
+        List<OpenPaaSId> participants = StreamSupport.stream(and.spliterator(), false)
+            .map(BookingLinkExtraAttendeeUtil::parseParticipant)
             .distinct()
             .toList();
-        Preconditions.checkArgument(parsed.size() <= MAX_EXTRA_ATTENDEES,
+        Preconditions.checkArgument(participants.size() <= MAX_EXTRA_ATTENDEES,
             "'extraAttendees' must not contain more than %s entries", MAX_EXTRA_ATTENDEES);
-        return parsed;
+        return ExtraAttendees.of(participants);
+    }
+
+    public static JsonNode serialize(ExtraAttendees extraAttendees) {
+        return serialize(extraAttendees.root());
+    }
+
+    /**
+     * Jackson binds an absent as well as an explicitly null field typed as {@code Optional<JsonNode>} to a
+     * {@link com.fasterxml.jackson.databind.node.NullNode}, rather than to an empty Optional: hold both as no
+     * value at all.
+     */
+    private static Optional<JsonNode> value(Optional<JsonNode> raw) {
+        return raw.filter(node -> !node.isNull());
+    }
+
+    private static OpenPaaSId parseParticipant(JsonNode node) {
+        Preconditions.checkArgument(node.isObject() && node.size() == 1 && node.has(FIELD_PARTICIPANT),
+            "'extraAttendees.and' entries must be objects holding a single 'participant' field");
+        JsonNode participant = node.get(FIELD_PARTICIPANT);
+        Preconditions.checkArgument(participant.isTextual(), "'participant' must be a string");
+        String value = StringUtils.trimToEmpty(participant.asText());
+        Preconditions.checkArgument(!value.isEmpty(), "'participant' must not be blank");
+        return new OpenPaaSId(value);
+    }
+
+    private static JsonNode serialize(ExtraAttendeeNode node) {
+        return switch (node) {
+            case ExtraAttendeeNode.Participant participant -> JsonNodeFactory.instance.objectNode()
+                .put(FIELD_PARTICIPANT, participant.id().value());
+            case ExtraAttendeeNode.And and -> {
+                ArrayNode children = JsonNodeFactory.instance.arrayNode();
+                and.children().stream()
+                    .map(BookingLinkExtraAttendeeUtil::serialize)
+                    .forEach(children::add);
+                ObjectNode result = JsonNodeFactory.instance.objectNode();
+                result.set(FIELD_AND, children);
+                yield result;
+            }
+        };
     }
 
     private BookingLinkExtraAttendeeUtil() {

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
@@ -19,26 +19,24 @@
 package com.linagora.calendar.storage.booking;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.storage.CalendarURL;
-import com.linagora.calendar.storage.OpenPaaSId;
 
 public record BookingLinkInsertRequest(CalendarURL calendarUrl,
                                        Duration eventDuration,
                                        boolean active,
                                        boolean autoAccept,
                                        Optional<AvailabilityRules> availabilityRules,
-                                       List<OpenPaaSId> extraAttendees,
+                                       ExtraAttendees extraAttendees,
                                        Optional<String> name,
                                        Optional<String> description,
                                        Optional<String> color) {
     public static final boolean ACTIVE = true;
     public static final boolean AUTO_ACCEPT = false;
-    public static final List<OpenPaaSId> NO_EXTRA_ATTENDEE = List.of();
+    public static final ExtraAttendees NO_EXTRA_ATTENDEE = ExtraAttendees.NONE;
 
     public BookingLinkInsertRequest {
         Preconditions.checkNotNull(calendarUrl, "'calendarUrl' must not be null");
@@ -49,7 +47,6 @@ public record BookingLinkInsertRequest(CalendarURL calendarUrl,
         Preconditions.checkNotNull(name, "'name' must not be null");
         Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkNotNull(color, "'color' must not be null");
-        extraAttendees = List.copyOf(extraAttendees);
     }
 
     public BookingLinkInsertRequest(CalendarURL calendarUrl,

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkInsertRequest.java
@@ -19,31 +19,48 @@
 package com.linagora.calendar.storage.booking;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
 
 public record BookingLinkInsertRequest(CalendarURL calendarUrl,
                                        Duration eventDuration,
                                        boolean active,
                                        boolean autoAccept,
                                        Optional<AvailabilityRules> availabilityRules,
+                                       List<OpenPaaSId> extraAttendees,
                                        Optional<String> name,
                                        Optional<String> description,
                                        Optional<String> color) {
     public static final boolean ACTIVE = true;
     public static final boolean AUTO_ACCEPT = false;
+    public static final List<OpenPaaSId> NO_EXTRA_ATTENDEE = List.of();
 
     public BookingLinkInsertRequest {
         Preconditions.checkNotNull(calendarUrl, "'calendarUrl' must not be null");
         Preconditions.checkNotNull(eventDuration, "'eventDuration' must not be null");
         Preconditions.checkArgument(!eventDuration.isNegative() && !eventDuration.isZero(), "'eventDuration' must be positive");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
+        Preconditions.checkNotNull(extraAttendees, "'extraAttendees' must not be null");
         Preconditions.checkNotNull(name, "'name' must not be null");
         Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkNotNull(color, "'color' must not be null");
+        extraAttendees = List.copyOf(extraAttendees);
+    }
+
+    public BookingLinkInsertRequest(CalendarURL calendarUrl,
+                                    Duration eventDuration,
+                                    boolean active,
+                                    boolean autoAccept,
+                                    Optional<AvailabilityRules> availabilityRules,
+                                    Optional<String> name,
+                                    Optional<String> description,
+                                    Optional<String> color) {
+        this(calendarUrl, eventDuration, active, autoAccept, availabilityRules, NO_EXTRA_ATTENDEE, name, description, color);
     }
 
     public BookingLinkInsertRequest(CalendarURL calendarUrl,

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkPatchRequest.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkPatchRequest.java
@@ -19,21 +19,19 @@
 package com.linagora.calendar.storage.booking;
 
 import java.time.Duration;
-import java.util.List;
 
 import org.apache.james.util.ValuePatch;
 
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.storage.CalendarURL;
-import com.linagora.calendar.storage.OpenPaaSId;
 
 public record BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
                                       ValuePatch<Duration> duration,
                                       ValuePatch<Boolean> active,
                                       ValuePatch<Boolean> autoAccept,
                                       ValuePatch<AvailabilityRules> availabilityRules,
-                                      ValuePatch<List<OpenPaaSId>> extraAttendees,
+                                      ValuePatch<ExtraAttendees> extraAttendees,
                                       ValuePatch<String> name,
                                       ValuePatch<String> description,
                                       ValuePatch<String> color) {

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkPatchRequest.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/BookingLinkPatchRequest.java
@@ -19,18 +19,21 @@
 package com.linagora.calendar.storage.booking;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.apache.james.util.ValuePatch;
 
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.storage.CalendarURL;
+import com.linagora.calendar.storage.OpenPaaSId;
 
 public record BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
                                       ValuePatch<Duration> duration,
                                       ValuePatch<Boolean> active,
                                       ValuePatch<Boolean> autoAccept,
                                       ValuePatch<AvailabilityRules> availabilityRules,
+                                      ValuePatch<List<OpenPaaSId>> extraAttendees,
                                       ValuePatch<String> name,
                                       ValuePatch<String> description,
                                       ValuePatch<String> color) {
@@ -40,6 +43,7 @@ public record BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
         Preconditions.checkNotNull(active, "'active' must not be null");
         Preconditions.checkNotNull(autoAccept, "'autoAccept' must not be null");
         Preconditions.checkNotNull(availabilityRules, "'availabilityRules' must not be null");
+        Preconditions.checkNotNull(extraAttendees, "'extraAttendees' must not be null");
         Preconditions.checkNotNull(name, "'name' must not be null");
         Preconditions.checkNotNull(description, "'description' must not be null");
         Preconditions.checkNotNull(color, "'color' must not be null");
@@ -57,9 +61,21 @@ public record BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
             || !active.isKept()
             || !autoAccept.isKept()
             || !availabilityRules.isKept()
+            || !extraAttendees.isKept()
             || !name.isKept()
             || !description.isKept()
             || !color.isKept(), "At least one updatable field is required");
+    }
+
+    public BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,
+                                   ValuePatch<Duration> duration,
+                                   ValuePatch<Boolean> active,
+                                   ValuePatch<Boolean> autoAccept,
+                                   ValuePatch<AvailabilityRules> availabilityRules,
+                                   ValuePatch<String> name,
+                                   ValuePatch<String> description,
+                                   ValuePatch<String> color) {
+        this(calendarUrl, duration, active, autoAccept, availabilityRules, ValuePatch.keep(), name, description, color);
     }
 
     public BookingLinkPatchRequest(ValuePatch<CalendarURL> calendarUrl,

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/ExtraAttendeeNode.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/ExtraAttendeeNode.java
@@ -1,0 +1,60 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage.booking;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.google.common.base.Preconditions;
+import com.linagora.calendar.storage.OpenPaaSId;
+
+/**
+ * Node of the extra attendee tree of a booking link.
+ *
+ * <p>The tree shape leaves room for richer combinations (optional participants, substitutes: bob OR michael but
+ * only one of them). Today only an {@link And} of {@link Participant} leaves can be expressed through the APIs,
+ * which carries the historical semantic: invite all of them.
+ */
+public sealed interface ExtraAttendeeNode {
+
+    record Participant(OpenPaaSId id) implements ExtraAttendeeNode {
+        public Participant {
+            Preconditions.checkNotNull(id, "'participant' must not be null");
+        }
+
+        @Override
+        public Stream<OpenPaaSId> participants() {
+            return Stream.of(id);
+        }
+    }
+
+    record And(List<ExtraAttendeeNode> children) implements ExtraAttendeeNode {
+        public And {
+            Preconditions.checkNotNull(children, "'and' must not be null");
+            children = List.copyOf(children);
+        }
+
+        @Override
+        public Stream<OpenPaaSId> participants() {
+            return children.stream().flatMap(ExtraAttendeeNode::participants);
+        }
+    }
+
+    Stream<OpenPaaSId> participants();
+}

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/ExtraAttendees.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/ExtraAttendees.java
@@ -1,0 +1,59 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage.booking;
+
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+import com.linagora.calendar.storage.OpenPaaSId;
+
+/**
+ * Extra attendees of a booking link, held as a tree so that richer combinations can be modelled later on.
+ *
+ * @see ExtraAttendeeNode
+ */
+public record ExtraAttendees(ExtraAttendeeNode root) {
+
+    public static final ExtraAttendees NONE = of(List.of());
+
+    public static ExtraAttendees of(OpenPaaSId... participants) {
+        return of(List.of(participants));
+    }
+
+    public static ExtraAttendees of(List<OpenPaaSId> participants) {
+        return new ExtraAttendees(new ExtraAttendeeNode.And(participants.stream()
+            .<ExtraAttendeeNode>map(ExtraAttendeeNode.Participant::new)
+            .toList()));
+    }
+
+    public ExtraAttendees {
+        Preconditions.checkNotNull(root, "'extraAttendees' must not be null");
+    }
+
+    /**
+     * Flat view of the tree: the users to invite.
+     */
+    public List<OpenPaaSId> participants() {
+        return root.participants().toList();
+    }
+
+    public boolean isEmpty() {
+        return participants().isEmpty();
+    }
+}

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
@@ -21,6 +21,7 @@ package com.linagora.calendar.storage.booking;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -58,6 +59,7 @@ public class MemoryBookingLinkDAO implements BookingLinkDAO {
                 .active(request.active())
                 .autoAccept(request.autoAccept())
                 .availabilityRules(request.availabilityRules())
+                .extraAttendees(request.extraAttendees())
                 .name(request.name())
                 .description(request.description())
                 .color(request.color())
@@ -97,6 +99,9 @@ public class MemoryBookingLinkDAO implements BookingLinkDAO {
                 builder.active(request.active().getOrElse(existing.active()));
                 builder.autoAccept(request.autoAccept().getOrElse(existing.autoAccept()));
                 builder.availabilityRules(request.availabilityRules().notKeptOrElse(existing.availabilityRules()));
+                builder.extraAttendees(request.extraAttendees()
+                    .notKeptOrElse(Optional.of(existing.extraAttendees()))
+                    .orElse(List.of()));
                 builder.name(request.name().notKeptOrElse(existing.name()));
                 builder.description(request.description().notKeptOrElse(existing.description()));
                 builder.color(request.color().notKeptOrElse(existing.color()));

--- a/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/booking/MemoryBookingLinkDAO.java
@@ -21,7 +21,6 @@ package com.linagora.calendar.storage.booking;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -101,7 +100,7 @@ public class MemoryBookingLinkDAO implements BookingLinkDAO {
                 builder.availabilityRules(request.availabilityRules().notKeptOrElse(existing.availabilityRules()));
                 builder.extraAttendees(request.extraAttendees()
                     .notKeptOrElse(Optional.of(existing.extraAttendees()))
-                    .orElse(List.of()));
+                    .orElse(ExtraAttendees.NONE));
                 builder.name(request.name().notKeptOrElse(existing.name()));
                 builder.description(request.description().notKeptOrElse(existing.description()));
                 builder.color(request.color().notKeptOrElse(existing.color()));

--- a/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -49,6 +50,8 @@ public interface BookingLinkDAOContract {
     CalendarURL UPDATED_CALENDAR_URL = new CalendarURL(new OpenPaaSId("659387b9d486dc0046aeffaa"), new OpenPaaSId("659387b9d486dc0046aeffab"));
     Duration UPDATED_DURATION = Duration.ofMinutes(45);
     AvailabilityRules UPDATED_AVAILABILITY_RULES = AvailabilityRules.of(new WeeklyAvailabilityRule(DayOfWeek.FRIDAY, LocalTime.parse("08:00"), LocalTime.parse("12:00")));
+    OpenPaaSId EXTRA_ATTENDEE_1 = new OpenPaaSId("659387b9d486dc0046aeffb1");
+    OpenPaaSId EXTRA_ATTENDEE_2 = new OpenPaaSId("659387b9d486dc0046aeffb2");
 
     BookingLinkDAO testee();
 
@@ -430,6 +433,92 @@ public interface BookingLinkDAOContract {
         BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
 
         assertThat(updated.color()).isEmpty();
+    }
+
+    @Test
+    default void insertShouldPersistExtraAttendees() {
+        BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE, BookingLinkInsertRequest.AUTO_ACCEPT,
+            Optional.of(AVAILABILITY_RULES), List.of(EXTRA_ATTENDEE_1, EXTRA_ATTENDEE_2), Optional.empty(), Optional.empty(), Optional.empty());
+
+        BookingLink created = testee().insert(USER_1, request).block();
+
+        assertThat(created.extraAttendees()).containsExactly(EXTRA_ATTENDEE_1, EXTRA_ATTENDEE_2);
+
+        BookingLink found = testee().findByPublicId(USER_1, created.publicId()).block();
+        assertThat(found).isEqualTo(created);
+    }
+
+    @Test
+    default void insertShouldDefaultExtraAttendeesToEmpty() {
+        BookingLink created = testee().insert(USER_1, INSERT_REQUEST).block();
+
+        assertThat(created.extraAttendees()).isEmpty();
+
+        BookingLink found = testee().findByPublicId(USER_1, created.publicId()).block();
+        assertThat(found.extraAttendees()).isEmpty();
+    }
+
+    @Test
+    default void updateShouldApplyExtraAttendees() {
+        BookingLink inserted = testee().insert(USER_1, INSERT_REQUEST).block();
+        BookingLinkPatchRequest patchRequest = new BookingLinkPatchRequest(
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.modifyTo(List.of(EXTRA_ATTENDEE_1)),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep());
+
+        BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
+
+        assertThat(updated.extraAttendees()).containsExactly(EXTRA_ATTENDEE_1);
+        assertThat(testee().findByPublicId(USER_1, inserted.publicId()).block()).isEqualTo(updated);
+    }
+
+    @Test
+    default void updateShouldAllowRemovingExtraAttendees() {
+        BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE, BookingLinkInsertRequest.AUTO_ACCEPT,
+            Optional.of(AVAILABILITY_RULES), List.of(EXTRA_ATTENDEE_1), Optional.empty(), Optional.empty(), Optional.empty());
+        BookingLink inserted = testee().insert(USER_1, request).block();
+        BookingLinkPatchRequest patchRequest = new BookingLinkPatchRequest(
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.remove(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep());
+
+        BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
+
+        assertThat(updated.extraAttendees()).isEmpty();
+        assertThat(testee().findByPublicId(USER_1, inserted.publicId()).block().extraAttendees()).isEmpty();
+    }
+
+    @Test
+    default void updateShouldKeepExtraAttendeesWhenNotSpecified() {
+        BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE, BookingLinkInsertRequest.AUTO_ACCEPT,
+            Optional.of(AVAILABILITY_RULES), List.of(EXTRA_ATTENDEE_1), Optional.empty(), Optional.empty(), Optional.empty());
+        BookingLink inserted = testee().insert(USER_1, request).block();
+        BookingLinkPatchRequest patchRequest = new BookingLinkPatchRequest(
+            ValuePatch.keep(),
+            ValuePatch.modifyTo(UPDATED_DURATION),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep(),
+            ValuePatch.keep());
+
+        BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
+
+        assertThat(updated.extraAttendees()).containsExactly(EXTRA_ATTENDEE_1);
     }
 
     @Test

--- a/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkDAOContract.java
@@ -438,11 +438,11 @@ public interface BookingLinkDAOContract {
     @Test
     default void insertShouldPersistExtraAttendees() {
         BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE, BookingLinkInsertRequest.AUTO_ACCEPT,
-            Optional.of(AVAILABILITY_RULES), List.of(EXTRA_ATTENDEE_1, EXTRA_ATTENDEE_2), Optional.empty(), Optional.empty(), Optional.empty());
+            Optional.of(AVAILABILITY_RULES), ExtraAttendees.of(EXTRA_ATTENDEE_1, EXTRA_ATTENDEE_2), Optional.empty(), Optional.empty(), Optional.empty());
 
         BookingLink created = testee().insert(USER_1, request).block();
 
-        assertThat(created.extraAttendees()).containsExactly(EXTRA_ATTENDEE_1, EXTRA_ATTENDEE_2);
+        assertThat(created.extraAttendees()).isEqualTo(ExtraAttendees.of(EXTRA_ATTENDEE_1, EXTRA_ATTENDEE_2));
 
         BookingLink found = testee().findByPublicId(USER_1, created.publicId()).block();
         assertThat(found).isEqualTo(created);
@@ -452,10 +452,10 @@ public interface BookingLinkDAOContract {
     default void insertShouldDefaultExtraAttendeesToEmpty() {
         BookingLink created = testee().insert(USER_1, INSERT_REQUEST).block();
 
-        assertThat(created.extraAttendees()).isEmpty();
+        assertThat(created.extraAttendees()).isEqualTo(ExtraAttendees.NONE);
 
         BookingLink found = testee().findByPublicId(USER_1, created.publicId()).block();
-        assertThat(found.extraAttendees()).isEmpty();
+        assertThat(found.extraAttendees()).isEqualTo(ExtraAttendees.NONE);
     }
 
     @Test
@@ -467,21 +467,21 @@ public interface BookingLinkDAOContract {
             ValuePatch.keep(),
             ValuePatch.keep(),
             ValuePatch.keep(),
-            ValuePatch.modifyTo(List.of(EXTRA_ATTENDEE_1)),
+            ValuePatch.modifyTo(ExtraAttendees.of(EXTRA_ATTENDEE_1)),
             ValuePatch.keep(),
             ValuePatch.keep(),
             ValuePatch.keep());
 
         BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
 
-        assertThat(updated.extraAttendees()).containsExactly(EXTRA_ATTENDEE_1);
+        assertThat(updated.extraAttendees()).isEqualTo(ExtraAttendees.of(EXTRA_ATTENDEE_1));
         assertThat(testee().findByPublicId(USER_1, inserted.publicId()).block()).isEqualTo(updated);
     }
 
     @Test
     default void updateShouldAllowRemovingExtraAttendees() {
         BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE, BookingLinkInsertRequest.AUTO_ACCEPT,
-            Optional.of(AVAILABILITY_RULES), List.of(EXTRA_ATTENDEE_1), Optional.empty(), Optional.empty(), Optional.empty());
+            Optional.of(AVAILABILITY_RULES), ExtraAttendees.of(EXTRA_ATTENDEE_1), Optional.empty(), Optional.empty(), Optional.empty());
         BookingLink inserted = testee().insert(USER_1, request).block();
         BookingLinkPatchRequest patchRequest = new BookingLinkPatchRequest(
             ValuePatch.keep(),
@@ -496,14 +496,14 @@ public interface BookingLinkDAOContract {
 
         BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
 
-        assertThat(updated.extraAttendees()).isEmpty();
-        assertThat(testee().findByPublicId(USER_1, inserted.publicId()).block().extraAttendees()).isEmpty();
+        assertThat(updated.extraAttendees()).isEqualTo(ExtraAttendees.NONE);
+        assertThat(testee().findByPublicId(USER_1, inserted.publicId()).block().extraAttendees()).isEqualTo(ExtraAttendees.NONE);
     }
 
     @Test
     default void updateShouldKeepExtraAttendeesWhenNotSpecified() {
         BookingLinkInsertRequest request = new BookingLinkInsertRequest(CALENDAR_URL, EVENT_DURATION, ACTIVE, BookingLinkInsertRequest.AUTO_ACCEPT,
-            Optional.of(AVAILABILITY_RULES), List.of(EXTRA_ATTENDEE_1), Optional.empty(), Optional.empty(), Optional.empty());
+            Optional.of(AVAILABILITY_RULES), ExtraAttendees.of(EXTRA_ATTENDEE_1), Optional.empty(), Optional.empty(), Optional.empty());
         BookingLink inserted = testee().insert(USER_1, request).block();
         BookingLinkPatchRequest patchRequest = new BookingLinkPatchRequest(
             ValuePatch.keep(),
@@ -518,7 +518,7 @@ public interface BookingLinkDAOContract {
 
         BookingLink updated = testee().update(USER_1, inserted.publicId(), patchRequest).block();
 
-        assertThat(updated.extraAttendees()).containsExactly(EXTRA_ATTENDEE_1);
+        assertThat(updated.extraAttendees()).isEqualTo(ExtraAttendees.of(EXTRA_ATTENDEE_1));
     }
 
     @Test

--- a/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkExtraAttendeeUtilTest.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/booking/BookingLinkExtraAttendeeUtilTest.java
@@ -1,0 +1,165 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.storage.booking;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import org.apache.james.util.ValuePatch;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.linagora.calendar.storage.OpenPaaSId;
+
+class BookingLinkExtraAttendeeUtilTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final OpenPaaSId ATTENDEE_1 = new OpenPaaSId("659387b9d486dc0046aeffb1");
+    private static final OpenPaaSId ATTENDEE_2 = new OpenPaaSId("659387b9d486dc0046aeffb2");
+
+    private static JsonNode json(String value) {
+        try {
+            return OBJECT_MAPPER.readTree(value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void parseShouldReadParticipantsOfTheAndNode() {
+        assertThat(BookingLinkExtraAttendeeUtil.parse(json("""
+            {"and": [{"participant": "659387b9d486dc0046aeffb1"}, {"participant": "659387b9d486dc0046aeffb2"}]}""")))
+            .isEqualTo(ExtraAttendees.of(ATTENDEE_1, ATTENDEE_2));
+    }
+
+    @Test
+    void parseShouldAcceptEmptyAnd() {
+        assertThat(BookingLinkExtraAttendeeUtil.parse(json("""
+            {"and": []}""")))
+            .isEqualTo(ExtraAttendees.NONE);
+    }
+
+    @Test
+    void parseShouldTrimParticipants() {
+        assertThat(BookingLinkExtraAttendeeUtil.parse(json("""
+            {"and": [{"participant": "  659387b9d486dc0046aeffb1  "}]}""")))
+            .isEqualTo(ExtraAttendees.of(ATTENDEE_1));
+    }
+
+    @Test
+    void parseShouldDeduplicateParticipants() {
+        assertThat(BookingLinkExtraAttendeeUtil.parse(json("""
+            {"and": [{"participant": "659387b9d486dc0046aeffb1"}, {"participant": "659387b9d486dc0046aeffb1"}]}""")))
+            .isEqualTo(ExtraAttendees.of(ATTENDEE_1));
+    }
+
+    @Test
+    void parseShouldDefaultToNoneWhenAbsent() {
+        assertThat(BookingLinkExtraAttendeeUtil.parse(Optional.empty()))
+            .isEqualTo(ExtraAttendees.NONE);
+    }
+
+    @Test
+    void parseShouldDefaultToNoneWhenNullNode() {
+        // Jackson binds an absent 'extraAttendees' typed as Optional<JsonNode> to a NullNode, not to an empty
+        // Optional: omitting the field must not be rejected.
+        assertThat(BookingLinkExtraAttendeeUtil.parse(Optional.of(NullNode.instance)))
+            .isEqualTo(ExtraAttendees.NONE);
+    }
+
+    @Test
+    void parsePatchShouldModifyToParticipants() {
+        assertThat(BookingLinkExtraAttendeeUtil.parsePatch(Optional.of(json("""
+            {"and": [{"participant": "659387b9d486dc0046aeffb1"}]}"""))))
+            .isEqualTo(ValuePatch.modifyTo(ExtraAttendees.of(ATTENDEE_1)));
+    }
+
+    @Test
+    void parsePatchShouldRemoveWhenNullNode() {
+        assertThat(BookingLinkExtraAttendeeUtil.parsePatch(Optional.of(NullNode.instance)))
+            .isEqualTo(ValuePatch.remove());
+    }
+
+    @Test
+    void parsePatchShouldRemoveWhenEmptyAnd() {
+        assertThat(BookingLinkExtraAttendeeUtil.parsePatch(Optional.of(json("""
+            {"and": []}"""))))
+            .isEqualTo(ValuePatch.remove());
+    }
+
+    @Test
+    void parseShouldThrowWhenTooManyParticipants() {
+        String participants = IntStream.rangeClosed(0, BookingLinkExtraAttendeeUtil.MAX_EXTRA_ATTENDEES)
+            .mapToObj("{\"participant\": \"659387b9d486dc0046aef%03d\"}"::formatted)
+            .reduce((left, right) -> left + ", " + right)
+            .orElseThrow();
+
+        assertThatThrownBy(() -> BookingLinkExtraAttendeeUtil.parse(json("{\"and\": [" + participants + "]}")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("must not contain more than 20 entries");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "[\"659387b9d486dc0046aeffb1\"]",
+        "\"659387b9d486dc0046aeffb1\"",
+        "{}",
+        "{\"and\": {}}",
+        "{\"and\": [], \"or\": []}",
+        "{\"or\": [{\"participant\": \"659387b9d486dc0046aeffb1\"}]}",
+        "{\"and\": [{\"and\": [{\"participant\": \"659387b9d486dc0046aeffb1\"}]}]}",
+        "{\"and\": [\"659387b9d486dc0046aeffb1\"]}",
+        "{\"and\": [{\"participant\": 42}]}",
+        "{\"and\": [{\"participant\": \"  \"}]}",
+        "{\"and\": [{\"participant\": \"659387b9d486dc0046aeffb1\", \"role\": \"optional\"}]}"})
+    void parseShouldRejectUnsupportedShapes(String payload) {
+        assertThatThrownBy(() -> BookingLinkExtraAttendeeUtil.parse(json(payload)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void serializeShouldRoundTrip() {
+        ExtraAttendees extraAttendees = ExtraAttendees.of(ATTENDEE_1, ATTENDEE_2);
+
+        assertThat(BookingLinkExtraAttendeeUtil.parse(BookingLinkExtraAttendeeUtil.serialize(extraAttendees)))
+            .isEqualTo(extraAttendees);
+    }
+
+    @Test
+    void serializeShouldWriteAndOfParticipants() {
+        assertThatJson(BookingLinkExtraAttendeeUtil.serialize(ExtraAttendees.of(ATTENDEE_1, ATTENDEE_2)).toString())
+            .isEqualTo("""
+                {"and": [{"participant": "659387b9d486dc0046aeffb1"}, {"participant": "659387b9d486dc0046aeffb2"}]}""");
+    }
+
+    @Test
+    void serializeShouldWriteEmptyAndWhenNone() {
+        assertThatJson(BookingLinkExtraAttendeeUtil.serialize(ExtraAttendees.NONE).toString())
+            .isEqualTo("""
+                {"and": []}""");
+    }
+}

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
@@ -71,6 +71,7 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
     private static final String FIELD_ACTIVE = "active";
     private static final String FIELD_AUTO_ACCEPT = "autoAccept";
     private static final String FIELD_AVAILABILITY_RULES = "availabilityRules";
+    private static final String FIELD_EXTRA_ATTENDEES = "extraAttendees";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_DESCRIPTION = "description";
     private static final String FIELD_COLOR = "color";
@@ -114,6 +115,7 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
                 .active(request.active())
                 .autoAccept(request.autoAccept())
                 .availabilityRules(request.availabilityRules())
+                .extraAttendees(request.extraAttendees())
                 .name(request.name())
                 .description(request.description())
                 .color(request.color())
@@ -214,6 +216,11 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
         } else if (request.availabilityRules().isRemoved()) {
             unsetFields.append(FIELD_AVAILABILITY_RULES, "");
         }
+        if (request.extraAttendees().isModified()) {
+            setFields.append(FIELD_EXTRA_ATTENDEES, serializeExtraAttendees(request.extraAttendees().get()));
+        } else if (request.extraAttendees().isRemoved()) {
+            unsetFields.append(FIELD_EXTRA_ATTENDEES, "");
+        }
         if (request.name().isModified()) {
             setFields.append(FIELD_NAME, request.name().get());
         } else if (request.name().isRemoved()) {
@@ -251,11 +258,20 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
 
         bookingLink.availabilityRules().ifPresent(rules ->
             doc.append(FIELD_AVAILABILITY_RULES, serializeRules(rules)));
+        if (!bookingLink.extraAttendees().isEmpty()) {
+            doc.append(FIELD_EXTRA_ATTENDEES, serializeExtraAttendees(bookingLink.extraAttendees()));
+        }
         bookingLink.name().ifPresent(name -> doc.append(FIELD_NAME, name));
         bookingLink.description().ifPresent(description -> doc.append(FIELD_DESCRIPTION, description));
         bookingLink.color().ifPresent(color -> doc.append(FIELD_COLOR, color));
 
         return doc;
+    }
+
+    private List<String> serializeExtraAttendees(List<OpenPaaSId> extraAttendees) {
+        return extraAttendees.stream()
+            .map(OpenPaaSId::value)
+            .toList();
     }
 
     private List<Document> serializeRules(AvailabilityRules rules) {
@@ -292,6 +308,9 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
         Optional<AvailabilityRules> availabilityRules = Optional.ofNullable(doc.getList(FIELD_AVAILABILITY_RULES, Document.class))
             .filter(rules -> !rules.isEmpty())
             .map(rules -> new AvailabilityRules(rules.stream().map(this::deserializeRule).toList()));
+        List<OpenPaaSId> extraAttendees = Optional.ofNullable(doc.getList(FIELD_EXTRA_ATTENDEES, String.class))
+            .map(ids -> ids.stream().map(OpenPaaSId::new).toList())
+            .orElse(List.of());
         Optional<String> name = Optional.ofNullable(doc.getString(FIELD_NAME));
         Optional<String> description = Optional.ofNullable(doc.getString(FIELD_DESCRIPTION));
         Optional<String> color = Optional.ofNullable(doc.getString(FIELD_COLOR));
@@ -304,6 +323,7 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
             .active(active)
             .autoAccept(autoAccept)
             .availabilityRules(availabilityRules)
+            .extraAttendees(extraAttendees)
             .name(name)
             .description(description)
             .color(color)

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBBookingLinkDAO.java
@@ -47,6 +47,8 @@ import com.linagora.calendar.storage.booking.BookingLinkInsertRequest;
 import com.linagora.calendar.storage.booking.BookingLinkNotFoundException;
 import com.linagora.calendar.storage.booking.BookingLinkPatchRequest;
 import com.linagora.calendar.storage.booking.BookingLinkPublicId;
+import com.linagora.calendar.storage.booking.ExtraAttendeeNode;
+import com.linagora.calendar.storage.booking.ExtraAttendees;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.IndexOptions;
@@ -77,6 +79,9 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
     private static final String FIELD_COLOR = "color";
     private static final String FIELD_CREATED_AT = "createdAt";
     private static final String FIELD_UPDATED_AT = "updatedAt";
+
+    private static final String ATTENDEE_AND = "and";
+    private static final String ATTENDEE_PARTICIPANT = "participant";
 
     private static final String RULE_TYPE = "type";
     private static final String RULE_TYPE_WEEKLY = "weekly";
@@ -268,10 +273,33 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
         return doc;
     }
 
-    private List<String> serializeExtraAttendees(List<OpenPaaSId> extraAttendees) {
-        return extraAttendees.stream()
-            .map(OpenPaaSId::value)
-            .toList();
+    private Document serializeExtraAttendees(ExtraAttendees extraAttendees) {
+        return serializeExtraAttendeeNode(extraAttendees.root());
+    }
+
+    private Document serializeExtraAttendeeNode(ExtraAttendeeNode node) {
+        return switch (node) {
+            case ExtraAttendeeNode.Participant participant -> new Document(ATTENDEE_PARTICIPANT, participant.id().value());
+            case ExtraAttendeeNode.And and -> new Document(ATTENDEE_AND, and.children().stream()
+                .map(this::serializeExtraAttendeeNode)
+                .toList());
+        };
+    }
+
+    private ExtraAttendees deserializeExtraAttendees(Document doc) {
+        return new ExtraAttendees(deserializeExtraAttendeeNode(doc));
+    }
+
+    private ExtraAttendeeNode deserializeExtraAttendeeNode(Document doc) {
+        if (doc.containsKey(ATTENDEE_PARTICIPANT)) {
+            return new ExtraAttendeeNode.Participant(new OpenPaaSId(doc.getString(ATTENDEE_PARTICIPANT)));
+        }
+        if (doc.containsKey(ATTENDEE_AND)) {
+            return new ExtraAttendeeNode.And(doc.getList(ATTENDEE_AND, Document.class).stream()
+                .map(this::deserializeExtraAttendeeNode)
+                .toList());
+        }
+        throw new IllegalArgumentException("Unknown extra attendee node: " + doc.toJson());
     }
 
     private List<Document> serializeRules(AvailabilityRules rules) {
@@ -308,9 +336,9 @@ public class MongoDBBookingLinkDAO implements BookingLinkDAO {
         Optional<AvailabilityRules> availabilityRules = Optional.ofNullable(doc.getList(FIELD_AVAILABILITY_RULES, Document.class))
             .filter(rules -> !rules.isEmpty())
             .map(rules -> new AvailabilityRules(rules.stream().map(this::deserializeRule).toList()));
-        List<OpenPaaSId> extraAttendees = Optional.ofNullable(doc.getList(FIELD_EXTRA_ATTENDEES, String.class))
-            .map(ids -> ids.stream().map(OpenPaaSId::new).toList())
-            .orElse(List.of());
+        ExtraAttendees extraAttendees = Optional.ofNullable(doc.get(FIELD_EXTRA_ATTENDEES, Document.class))
+            .map(this::deserializeExtraAttendees)
+            .orElse(ExtraAttendees.NONE);
         Optional<String> name = Optional.ofNullable(doc.getString(FIELD_NAME));
         Optional<String> description = Optional.ofNullable(doc.getString(FIELD_DESCRIPTION));
         Optional<String> color = Optional.ofNullable(doc.getString(FIELD_COLOR));


### PR DESCRIPTION
Closes #958

Booking links now carry an optional `extraAttendees` field: a list of OpenPaaS ids of registered users, so a single link can be handed over for a meeting that needs several people (the sales guy, the presales engineer and the project manager of the ticket's example).

The field is surfaced on both the OpenPaaS (`POST`/`GET`/`PATCH /api/booking-links`) and webadmin (`/users/{username}/booking-links`) APIs. It is empty when omitted on creation and when absent from the database, and is omitted from responses when empty — consistent with how `availabilityRules`, `name` and `description` already behave.

It changes the booking link in two ways:

- **Availability is the intersection** of the availability rules, the owner availability, and each extra attendee availability.
- **Booked events invite the extra attendees**, with `PARTSTAT=NEEDS-ACTION`: unlike the booker, they were never asked, so they answer through the regular iTIP flow.

Working hours in the extra attendees own timezone are left out, as the ticket suggests.

## Points worth your attention

**Attendee availability is whatever the DAV server shows the owner.** The free-busy `REPORT` is issued impersonating the booking link owner, so Sabre decides what the owner may see. I initially wrote a test asserting that a *non*-delegated calendar contributes no busy intervals, and it failed: Sabre answers free-busy on another user's calendar without any explicit delegation. So "public calendar and read delegation" is enforced by the DAV server rather than by this code — which I think is the right split, but it means the effective visibility rule is Sabre's, not ours.

**An unreadable attendee calendar is treated as free** (warning logged) rather than failing the whole `/slots` and `/book` call. Offering a slot an extra attendee will decline seemed clearly less bad than a booking link that 500s permanently the day someone revokes a share. Same reasoning for an extra attendee whose account is deleted after link creation: they are skipped at booking time instead of making the link unbookable forever. Both are tested. Happy to make either strict if you would rather fail loudly.

**Validation** rejects unknown ids and the owner themselves (400), caps the list at 20, and dedupes. An extra attendee who also happens to be the booker keeps a single `ATTENDEE` line rather than getting a duplicate with a conflicting `PARTSTAT`.

## Tests

All green, checkstyle clean.

- `BookingLinkDAOContract`: 5 new cases (persist, default-empty, patch, remove, keep), so both Memory and MongoDB — 42 each.
- `BookingLinkExtraAttendeeResolverTest` (new), `BookingLinkEventIcsBuilderTest`: validation, lenient resolution, ICS attendees and dedup.
- App routes: create/get/patch/slots/reservation — 185 booking-link tests pass, including slot intersection, the unreadable-calendar fallback, and the deleted-attendee booking.
- Webadmin: `BookingLinkUserRoutesTest` — 34 pass.

Docs (`docs/apis/bookingLink.md`, `docs/apis/webadmin.md`) and `CHANGELOG.md` updated.

---
*Generated automatically*
