### PR TITLE
Remove obsolete old organizer guard from iTIP delivery

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
@@ -264,7 +264,7 @@ public class ItipLocalDeliveryConsumer implements Closeable, Startable {
                                          Calendar calendar,
                                          Optional<Calendar> oldEventCalendar) {
         if (Method.VALUE_REQUEST.equalsIgnoreCase(localDelivery.method())
-            && hasInvalidRequestOrganizer(localDelivery, calendar, oldEventCalendar)) {
+            && hasInvalidRequestOrganizer(localDelivery, calendar)) {
             return SKIP;
         }
         if (Method.VALUE_REPLY.equalsIgnoreCase(localDelivery.method())
@@ -315,28 +315,14 @@ public class ItipLocalDeliveryConsumer implements Closeable, Startable {
     }
 
     private boolean hasInvalidRequestOrganizer(ItipLocalDeliveryDTO localDelivery,
-                                               Calendar calendar,
-                                               Optional<Calendar> oldEventCalendar) {
+                                               Calendar calendar) {
         Set<Username> currentOrganizers = extractOrganizer(calendar);
         if (currentOrganizers.size() != 1) {
             return SKIP;
         }
 
         Username currentOrganizer = currentOrganizers.iterator().next();
-        if (organizerChanged(currentOrganizer, oldEventCalendar)) {
-            return SKIP;
-        }
-
         return senderIsNotOrganizer(localDelivery, currentOrganizer);
-    }
-
-    private boolean organizerChanged(Username currentOrganizer, Optional<Calendar> oldEventCalendar) {
-        return oldEventCalendar
-            .map(oldCalendar -> {
-                Set<Username> oldOrganizers = extractOrganizer(oldCalendar);
-                return oldOrganizers.size() != 1 || !oldOrganizers.iterator().next().equals(currentOrganizer);
-            })
-            .orElse(!SKIP);
     }
 
     private boolean senderIsNotOrganizer(ItipLocalDeliveryDTO localDelivery, Username organizer) {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
@@ -430,35 +430,6 @@ public class ItipLocalDeliveryConsumerTest {
     }
 
     @Test
-    void shouldIgnoreDeliveryWhenRequestOrganizerChangedComparedToOldMessage() {
-        when(localRecipientResolver.resolve(Username.of(ALICE)))
-            .thenReturn(Mono.just(Optional.of(new LocalRecipientResolver.ResolvedRecipient.LocalUser(new OpenPaaSId(LOCAL_USER_ID)))));
-        declareQueueBoundToExchange(EventEmailConsumer.EXCHANGE_NAME, testEmailQueue);
-        List<JsonNode> emailMessages = consumeJsonMessages(testEmailQueue);
-        String oldMessageWithDifferentOrganizer = SIMPLE_ICAL.replace("mailto:" + BOB, "mailto:" + CEDRIC);
-
-        String payload = """
-            {
-              "sender": "mailto:%s",
-              "method": "REQUEST",
-              "uid": "%s",
-              "calendarId": "%s",
-              "message": %s,
-              "oldMessage": %s,
-              "hasChange": true,
-              "recipients": ["mailto:%s"]
-            }
-            """.formatted(BOB, EVENT_UID, CALENDAR_ID, jsonString(SIMPLE_ICAL), jsonString(oldMessageWithDifferentOrganizer), ALICE);
-
-        publishToConsumer(payload);
-
-        AWAIT_AT_MOST.untilAsserted(() -> {
-            WireMock.verify(0, WireMock.postRequestedFor(WireMock.urlEqualTo("/itip")));
-            assertThat(emailMessages).isEmpty();
-        });
-    }
-
-    @Test
     void shouldIgnoreDeliveryWhenRecurringRequestHasMultipleOrganizers() {
         when(localRecipientResolver.resolve(Username.of(ALICE)))
             .thenReturn(Mono.just(Optional.of(new LocalRecipientResolver.ResolvedRecipient.LocalUser(new OpenPaaSId(LOCAL_USER_ID)))));
@@ -477,36 +448,6 @@ public class ItipLocalDeliveryConsumerTest {
               "recipients": ["mailto:%s"]
             }
             """.formatted(BOB, EVENT_UID, CALENDAR_ID, jsonString(recurringMessage), ALICE);
-
-        publishToConsumer(payload);
-
-        AWAIT_AT_MOST.untilAsserted(() -> {
-            WireMock.verify(0, WireMock.postRequestedFor(WireMock.urlEqualTo("/itip")));
-            assertThat(emailMessages).isEmpty();
-        });
-    }
-
-    @Test
-    void shouldIgnoreDeliveryWhenRecurringRequestOrganizerChangedComparedToOldMessage() {
-        when(localRecipientResolver.resolve(Username.of(ALICE)))
-            .thenReturn(Mono.just(Optional.of(new LocalRecipientResolver.ResolvedRecipient.LocalUser(new OpenPaaSId(LOCAL_USER_ID)))));
-        declareQueueBoundToExchange(EventEmailConsumer.EXCHANGE_NAME, testEmailQueue);
-        List<JsonNode> emailMessages = consumeJsonMessages(testEmailQueue);
-        String recurringCurrentMessage = recurringIcal(BOB, BOB);
-        String recurringOldMessage = recurringIcal(CEDRIC, CEDRIC);
-
-        String payload = """
-            {
-              "sender": "mailto:%s",
-              "method": "REQUEST",
-              "uid": "%s",
-              "calendarId": "%s",
-              "message": %s,
-              "oldMessage": %s,
-              "hasChange": true,
-              "recipients": ["mailto:%s"]
-            }
-            """.formatted(BOB, EVENT_UID, CALENDAR_ID, jsonString(recurringCurrentMessage), jsonString(recurringOldMessage), ALICE);
 
         publishToConsumer(payload);
 


### PR DESCRIPTION
## Why

This guard was introduced as a short-term fix for [twake-calendar-side-service#697](https://github.com/linagora/twake-calendar-side-service/issues/697), to prevent attendees from changing `ORGANIZER` via PUT and propagating that forged organizer to other calendars.

esn-sabre now enforces this protection at the CalDAV write boundary: it rejects attendee updates to organizer-controlled fields, including ORGANIZER, before scheduling. 
ref: https://github.com/linagora/twake-calendar-side-service/issues/699

Integration coverage in twake-calendar-integration-tests:
- SabreV4SchedulingTest / attendeeUpdatingForbiddenSchedulingPropertyShouldBeRejected
- SabreV4SchedulingTest / attendeeChangingOrganizerShouldBeRejected
- SabreV4SchedulingTest / attendeeChangingOrganizerOnRecurringShouldBeRejected


Keeping this side-service guard blocks valid organizer transfer flows, especially for team calendars


