### PR TITLE
chore - Calendar event notification email dto - Remove unused field

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarEventNotificationEmailDTO.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarEventNotificationEmailDTO.java
@@ -37,7 +37,6 @@ public record CalendarEventNotificationEmailDTO(@JsonProperty("senderEmail") @Js
                                                 @JsonProperty("recipientEmail") @JsonDeserialize(using = MailAddressDeserializer.class) MailAddress recipientEmail,
                                                 @JsonProperty("method") Method method,
                                                 @JsonProperty("event") @JsonDeserialize(using = CalendarEventDeserializer.class) Calendar event,
-                                                @JsonProperty("notify") boolean notifyEvent,
                                                 @JsonProperty("calendarURI") String calendarURI,
                                                 @JsonProperty("eventPath") String eventPath,
                                                 @JsonProperty("changes") Optional<Changes> changes,

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipEmailNotificationPublisher.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipEmailNotificationPublisher.java
@@ -318,7 +318,6 @@ class ItipEmailNotificationPublisher {
                                 @JsonProperty("recipientEmail") String recipientEmail,
                                 @JsonProperty("method") String method,
                                 @JsonProperty("event") String event,
-                                @JsonProperty("notify") boolean shouldNotify,
                                 @JsonProperty("calendarURI") String calendarURI,
                                 @JsonProperty("eventPath") Optional<String> eventPath,
                                 @JsonProperty("oldEvent") Optional<String> oldEvent,
@@ -344,7 +343,6 @@ class ItipEmailNotificationPublisher {
             private final String senderEmail;
             private final String recipientEmail;
             private String method;
-            private final boolean shouldNotify;
             private final String calendarURI;
             private String event;
             private boolean isNewEvent;
@@ -358,7 +356,6 @@ class ItipEmailNotificationPublisher {
                 this.recipientEmail = recipientEmail;
                 this.calendarURI = calendarURI;
                 this.method = method;
-                this.shouldNotify = true;
             }
 
             Builder withEvent(String eventIcs) {
@@ -413,7 +410,7 @@ class ItipEmailNotificationPublisher {
 
             NotificationEmailDTO build() {
                 return new NotificationEmailDTO(
-                    senderEmail, recipientEmail, method, event, shouldNotify, calendarURI,
+                    senderEmail, recipientEmail, method, event, calendarURI,
                     eventPath.map(URI::getPath), oldEvent, isNewEvent, changes);
             }
         }

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventNotificationEmail.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/model/CalendarEventNotificationEmail.java
@@ -47,7 +47,6 @@ public record CalendarEventNotificationEmail(MailAddress senderEmail,
                                              MailAddress recipientEmail,
                                              Method method,
                                              Calendar event,
-                                             boolean notifyEvent,
                                              String calendarURI,
                                              String eventPath) {
 
@@ -62,7 +61,6 @@ public record CalendarEventNotificationEmail(MailAddress senderEmail,
             dto.recipientEmail(),
             dto.method(),
             dto.event(),
-            dto.notifyEvent(),
             dto.calendarURI(),
             dto.eventPath()
         );

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarEventNotificationEmailDeserializeTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarEventNotificationEmailDeserializeTest.java
@@ -53,7 +53,6 @@ class CalendarEventNotificationEmailDeserializeTest {
                 "recipientEmail": "btellier@linagora.com",
                 "method": "REQUEST",
                 "event": "%s",
-                "notify": true,
                 "calendarURI": "67e26ebbecd9f300255a9f80",
                 "eventPath": "/calendars/5f50a663bdaffe002629099c/5f50a663bdaffe002629099c/sabredav-71741739-8806-4a9e-98b0-cc386d248832.ics",
                 "isNewEvent": true
@@ -66,7 +65,6 @@ class CalendarEventNotificationEmailDeserializeTest {
             softly.assertThat(calendarEvent.recipientEmail().asString()).isEqualTo("btellier@linagora.com");
             softly.assertThat(calendarEvent.method()).isEqualTo(ImmutableMethod.REQUEST);
             softly.assertThat(calendarEvent.event()).isEqualTo(CalendarUtil.parseIcs(eventIcs));
-            softly.assertThat(calendarEvent.notifyEvent()).isTrue();
             softly.assertThat(calendarEvent.calendarURI()).isEqualTo("67e26ebbecd9f300255a9f80");
             softly.assertThat(calendarEvent.eventPath()).isEqualTo("/calendars/5f50a663bdaffe002629099c/5f50a663bdaffe002629099c/sabredav-71741739-8806-4a9e-98b0-cc386d248832.ics");
             softly.assertThat(calendarEvent.isNewEvent().get()).isTrue();
@@ -95,7 +93,6 @@ class CalendarEventNotificationEmailDeserializeTest {
                 "recipientEmail": "btellier@linagora.com",
                 "method": "REQUEST",
                 "event": "%s",
-                "notify": true,
                 "calendarURI": "67e26ebbecd9f300255a9f80",
                 "eventPath": "/calendars/5f50a663bdaffe002629099c/5f50a663bdaffe002629099c/sabredav-71741739-8806-4a9e-98b0-cc386d248832.ics",
                 "changes": {
@@ -149,7 +146,6 @@ class CalendarEventNotificationEmailDeserializeTest {
             softly.assertThat(calendarEvent.recipientEmail().asString()).isEqualTo("btellier@linagora.com");
             softly.assertThat(calendarEvent.method()).isEqualTo(ImmutableMethod.REQUEST);
             softly.assertThat(calendarEvent.event()).isEqualTo(CalendarUtil.parseIcs(eventIcs));
-            softly.assertThat(calendarEvent.notifyEvent()).isTrue();
             softly.assertThat(calendarEvent.calendarURI()).isEqualTo("67e26ebbecd9f300255a9f80");
             softly.assertThat(calendarEvent.eventPath()).isEqualTo("/calendars/5f50a663bdaffe002629099c/5f50a663bdaffe002629099c/sabredav-71741739-8806-4a9e-98b0-cc386d248832.ics");
             softly.assertThat(calendarEvent.changes().get().summary()).isPresent();
@@ -204,7 +200,6 @@ class CalendarEventNotificationEmailDeserializeTest {
                 "recipientEmail": "btellier@linagora.com",
                 "method": "CANCEL",
                 "event": "%s",
-                "notify": true,
                 "calendarURI": "67e26ebbecd9f300255a9f80",
                 "eventPath": "/calendars/5f50a663bdaffe002629099c/5f50a663bdaffe002629099c/sabredav-71741739-8806-4a9e-98b0-cc386d248832.ics"
             }
@@ -216,7 +211,6 @@ class CalendarEventNotificationEmailDeserializeTest {
             softly.assertThat(calendarEvent.recipientEmail().asString()).isEqualTo("btellier@linagora.com");
             softly.assertThat(calendarEvent.method()).isEqualTo(ImmutableMethod.CANCEL);
             softly.assertThat(calendarEvent.event()).isEqualTo(CalendarUtil.parseIcs(eventIcs));
-            softly.assertThat(calendarEvent.notifyEvent()).isTrue();
             softly.assertThat(calendarEvent.calendarURI()).isEqualTo("67e26ebbecd9f300255a9f80");
             softly.assertThat(calendarEvent.eventPath()).isEqualTo("/calendars/5f50a663bdaffe002629099c/5f50a663bdaffe002629099c/sabredav-71741739-8806-4a9e-98b0-cc386d248832.ics");
         });
@@ -257,7 +251,6 @@ class CalendarEventNotificationEmailDeserializeTest {
               "recipientEmail": "user1@open-paas.org",
               "method": "REPLY",
               "event": "%s",
-              "notify": true,
               "calendarURI": "6853ca6c1cbe800055fd838b",
               "eventPath": "/calendars/6853ca6c1cbe800055fd838a/6853ca6c1cbe800055fd838a/a92de371-8529-45f8-948a-70ddf27bbc09.ics"
             }
@@ -269,7 +262,6 @@ class CalendarEventNotificationEmailDeserializeTest {
             softly.assertThat(calendarEvent.recipientEmail().asString()).isEqualTo("user1@open-paas.org");
             softly.assertThat(calendarEvent.method()).isEqualTo(ImmutableMethod.REPLY);
             softly.assertThat(calendarEvent.event()).isEqualTo(CalendarUtil.parseIcs(eventIcs));
-            softly.assertThat(calendarEvent.notifyEvent()).isTrue();
             softly.assertThat(calendarEvent.calendarURI()).isEqualTo("6853ca6c1cbe800055fd838b");
             softly.assertThat(calendarEvent.eventPath()).isEqualTo("/calendars/6853ca6c1cbe800055fd838a/6853ca6c1cbe800055fd838a/a92de371-8529-45f8-948a-70ddf27bbc09.ics");
         });
@@ -337,7 +329,6 @@ class CalendarEventNotificationEmailDeserializeTest {
               "recipientEmail": "user1@open-paas.org",
               "method": "COUNTER",
               "event": "%s",
-              "notify": true,
               "calendarURI": "6853ca6c1cbe800055fd838b",
               "eventPath": "/calendars/6853ca6c1cbe800055fd838a/6853ca6c1cbe800055fd838a/a92de371-8529-45f8-948a-70ddf27bbc09.ics",
               "oldEvent": "%s"
@@ -351,7 +342,6 @@ class CalendarEventNotificationEmailDeserializeTest {
             softly.assertThat(calendarEvent.method()).isEqualTo(ImmutableMethod.COUNTER);
             softly.assertThat(calendarEvent.event()).isEqualTo(CalendarUtil.parseIcs(eventIcs));
             softly.assertThat(calendarEvent.oldEvent().get()).isEqualTo(CalendarUtil.parseIcs(oldEventIcs));
-            softly.assertThat(calendarEvent.notifyEvent()).isTrue();
             softly.assertThat(calendarEvent.calendarURI()).isEqualTo("6853ca6c1cbe800055fd838b");
             softly.assertThat(calendarEvent.eventPath()).isEqualTo("/calendars/6853ca6c1cbe800055fd838a/6853ca6c1cbe800055fd838a/a92de371-8529-45f8-948a-70ddf27bbc09.ics");
         });

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCounterEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCounterEmailConsumerTest.java
@@ -311,7 +311,6 @@ public class EventCounterEmailConsumerTest {
               "recipientEmail": "%s",
               "method": "COUNTER",
               "event": "%s",
-              "notify": true,
               "calendarURI": "%s",
               "eventPath": "%s",
               "oldEvent": "%s"

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
@@ -466,7 +466,6 @@ public class EventPublicAgendaEmailConsumerTest {
               "recipientEmail": "%s",
               "method": "REQUEST",
               "event": %s,
-              "notify": true,
               "calendarURI": "calendar-uri",
               "eventPath": "/calendars/%s/events/%s.ics",
               "changes": {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipEmailNotificationPublisherTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipEmailNotificationPublisherTest.java
@@ -299,7 +299,6 @@ class ItipEmailNotificationPublisherTest {
                     assertThat(notification.calendarURI()).isEqualTo("public-team-calendar");
                     assertThat(notification.method()).isEqualTo(Method.VALUE_REQUEST);
                     assertThat(notification.eventPath()).contains(EVENT_PATH.getPath());
-                    assertThat(notification.shouldNotify()).isTrue();
                     assertThat(notification.event()).isEqualTo(SINGLE_REQUEST_NEW);
                 });
         }
@@ -398,7 +397,6 @@ class ItipEmailNotificationPublisherTest {
                     assertThat(notification.calendarURI()).isEqualTo("public-recurring-calendar");
                     assertThat(notification.method()).isEqualTo(Method.VALUE_REQUEST);
                     assertThat(notification.eventPath()).contains(EVENT_PATH.getPath());
-                    assertThat(notification.shouldNotify()).isTrue();
                 });
         }
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
@@ -551,7 +551,6 @@ public class ItipLocalDeliveryConsumerTest {
             assertThat(emailPayload.at("/senderEmail").asText()).isEqualTo(BOB);
             assertThat(emailPayload.at("/recipientEmail").asText()).isEqualTo(ALICE);
             assertThat(emailPayload.at("/method").asText()).isEqualTo("REQUEST");
-            assertThat(emailPayload.at("/notify").asBoolean()).isTrue();
             assertThat(emailPayload.at("/calendarURI").asText()).isEqualTo(CALENDAR_ID);
         });
     }

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/OrganizerAbsentActionLinksTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/OrganizerAbsentActionLinksTest.java
@@ -57,7 +57,6 @@ class OrganizerAbsentActionLinksTest {
             new MailAddress("bob@domain.tld"),
             new Method(Method.VALUE_REQUEST),
             calendar,
-            true,
             "/calendars/uri",
             "/calendars/base/event.ics");
     }

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/OrganizerAbsentRenderTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/OrganizerAbsentRenderTest.java
@@ -89,7 +89,6 @@ class OrganizerAbsentRenderTest {
             new MailAddress("bob@domain.tld"),
             new Method(Method.VALUE_REQUEST),
             calendar,
-            true,
             "/calendars/uri",
             "/calendars/base/event.ics");
     }
@@ -230,7 +229,6 @@ class OrganizerAbsentRenderTest {
             new MailAddress("bob@domain.tld"),
             new Method(Method.VALUE_REQUEST),
             calendar,
-            true,
             "/calendars/uri",
             "/calendars/base/event.ics");
         CalendarEventBookingConfirmedNotificationEmail email = new CalendarEventBookingConfirmedNotificationEmail(base);


### PR DESCRIPTION
`notify` field was originally kept to match the legacy payload format. 
After checking the latest esn-sabre and side-service code, it is no longer used anywhere, so this change removes it from the notification email DTO and related tests.