### PR TITLE
ISSUE-970 Do not schedule alarms for events cancelled by the organizer

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/EventAlarmHandler.java
@@ -114,7 +114,7 @@ public class EventAlarmHandler {
                     return upsertUpcomingAlarmRequest(username, eventCalendar, maybeNextAlarmInstant.get(), alarmMessageDTO.eventPath());
                 } else {
                     LOGGER.debug("No upcoming alarm found for {} at {}", username.asString(), alarmMessageDTO.eventPath());
-                    return doDeleteAlarmEvent(username, extractEventUid(alarmMessageDTO));
+                    return doDeleteAlarmEvent(username, alarmMessageDTO);
                 }
             });
     }
@@ -143,21 +143,22 @@ public class EventAlarmHandler {
 
     public Mono<Void> handleDelete(CalendarAlarmMessageDTO alarmMessageDTO) {
         return openPaaSUserDAO.retrieve(alarmMessageDTO.extractCalendarURL().base())
-            .flatMap(openPaaSUser -> handleDelete(openPaaSUser.username(), alarmMessageDTO));
+            .flatMap(openPaaSUser -> doDeleteAlarmEvent(openPaaSUser.username(), alarmMessageDTO));
     }
 
-    private Mono<Void> handleDelete(Username username, CalendarAlarmMessageDTO message) {
-        return Mono.fromCallable(() -> extractEventUid(message))
-            .flatMap(eventUid -> doDeleteAlarmEvent(username, eventUid));
-    }
-
-    private Mono<Void> doDeleteAlarmEvent(Username username, EventUid eventUid) {
-        return alarmEventDAO.delete(eventUid, Throwing.supplier(username::asMailAddress).get())
-            .doOnSuccess(unused -> LOGGER.debug("Deleted alarm event for {} with UID {}", username.asString(), eventUid.value()))
-            .onErrorResume(error -> {
-                LOGGER.error("Failed to delete alarm event for {} with UID {}", username.asString(), eventUid.value(), error);
-                return Mono.empty();
-            });
+    /**
+     * Alarms scheduled by a calendar object may target recipients that are not attendees of the event
+     * (VALARM ATTENDEE delegation), thus deletion is scoped to the calendar object rather than to its owner.
+     */
+    private Mono<Void> doDeleteAlarmEvent(Username username, CalendarAlarmMessageDTO alarmMessageDTO) {
+        String eventPath = alarmMessageDTO.eventPath();
+        return Mono.fromCallable(() -> extractEventUid(alarmMessageDTO))
+            .flatMap(eventUid -> alarmEventDAO.deleteByEventPath(eventUid, eventPath)
+                .doOnSuccess(unused -> LOGGER.debug("Deleted alarm events of {} for {}", eventPath, username.asString()))
+                .onErrorResume(error -> {
+                    LOGGER.error("Failed to delete alarm events of {} for {}", eventPath, username.asString(), error);
+                    return Mono.empty();
+                }));
     }
 
     private EventUid extractEventUid(CalendarAlarmMessageDTO alarmMessageDTO) {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCancellationTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCancellationTest.java
@@ -427,6 +427,25 @@ public class AlarmEventCancellationTest {
                 .isEmpty());
     }
 
+    @Test
+    void shouldKeepOrganizerAlarmWhenAttendeeDeletesOwnEvent() {
+        // Given
+        EventUid eventUid = createEventWithVALARM(attendee);
+        attendeeAcceptsEvent(attendee, eventUid);
+        awaitAlarmEventCreated(eventUid, organizer.username());
+        awaitAlarmEventCreated(eventUid, attendee.username());
+
+        String attendeeEventResourceId = davTestHelper.findFirstEventId(attendee).get();
+        // When: the attendee deletes the event from their own calendar
+        davTestHelper.deleteCalendar(attendee, attendeeEventResourceId);
+
+        // Then: only the attendee's alarm is removed, the organizer's one is left untouched
+        awaitAtMost.untilAsserted(() -> assertSoftly(Throwing.consumer(softly -> {
+            softly.assertThat(alarmEventDAO.find(eventUid, attendee.username().asMailAddress()).blockOptional()).isEmpty();
+            softly.assertThat(alarmEventDAO.find(eventUid, organizer.username().asMailAddress()).blockOptional()).isPresent();
+        })));
+    }
+
     private EventUid createEventWithVALARM(OpenPaaSUser... attendees) {
         String eventUid = UUID.randomUUID().toString();
         String organizerEmail = organizer.username().asString();

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCancellationTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCancellationTest.java
@@ -215,6 +215,53 @@ public class AlarmEventCancellationTest {
     }
 
     @Test
+    void shouldRemoveDelegatedValarmRecipientAlarmWhenOrganizerCancelsEvent() {
+        // Given: organizer creates an event inviting one attendee, while the email VALARM also targets
+        // another recipient from the same calendar object.
+        String eventUidAsString = UUID.randomUUID().toString();
+        EventUid eventUid = new EventUid(eventUidAsString);
+        String attendeeEmail = attendee.username().asString();
+        String delegatedAlarmRecipientEmail = attendee2.username().asString();
+        String vAlarm = """
+            BEGIN:VALARM
+            TRIGGER:-PT30M
+            ACTION:EMAIL
+            ${alarmAttendees}
+            SUMMARY:Meeting Reminder
+            DESCRIPTION:This is an automatic alarm
+            END:VALARM"""
+            .replace("${alarmAttendees}", alarmAttendeeLines(List.of(
+                attendeeEmail,
+                attendeeEmail,
+                delegatedAlarmRecipientEmail)));
+        String calendarData = generateEventWithValarm(
+            eventUidAsString,
+            organizer.username().asString(),
+            List.of(attendeeEmail),
+            PartStat.NEEDS_ACTION,
+            vAlarm);
+
+        davTestHelper.upsertCalendar(organizer, calendarData, eventUidAsString);
+
+        // And: the attendee accepts, so the side service stores both the attendee alarm and
+        // the delegated VALARM recipient alarm.
+        attendeeAcceptsEvent(attendee, eventUid);
+        awaitAlarmEventCreated(eventUid, attendee.username());
+        awaitAlarmEventCreated(eventUid, attendee2.username());
+
+        // When: organizer cancels the event through Sabre/DAV.
+        davTestHelper.deleteCalendar(organizer, eventUid);
+
+        // Then: all alarm rows originating from that cancelled calendar object are removed.
+        awaitAtMost.untilAsserted(() -> assertSoftly(Throwing.consumer(softly -> {
+            softly.assertThat(alarmEventDAO.find(eventUid, attendee.username().asMailAddress()).blockOptional())
+                .isEmpty();
+            softly.assertThat(alarmEventDAO.find(eventUid, attendee2.username().asMailAddress()).blockOptional())
+                .isEmpty();
+        })));
+    }
+
+    @Test
     void shouldRemoveAllAttendeeAlarmsWhenOrganizerDeletesEvent() {
         // Given
         EventUid eventUid = createEventWithVALARM(attendee, attendee2);

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/AlarmInstantFactoryTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/AlarmInstantFactoryTest.java
@@ -839,6 +839,38 @@ public class AlarmInstantFactoryTest {
     }
 
     @Test
+    void shouldReturnEmptyWhenCalendarMethodIsCancel() {
+        // A cancellation sent by the organizer carries METHOD:CANCEL, without necessarily setting STATUS:CANCELLED
+        String ics = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            METHOD:CANCEL
+            BEGIN:VEVENT
+            UID:789012
+            DTSTAMP:20250728T000000Z
+            SEQUENCE:2
+            DTSTART:20250829T100000Z
+            DTEND:20250829T110000Z
+            SUMMARY:Meeting
+            ORGANIZER:mailto:john@example.com
+            ATTENDEE;CN=Jane Doe;PARTSTAT=ACCEPTED:mailto:jane@example.com
+            BEGIN:VALARM
+            ACTION:EMAIL
+            ATTENDEE:mailto:jane@example.com
+            TRIGGER:-PT30M
+            END:VALARM
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        Calendar calendar = CalendarUtil.parseIcs(ics);
+        AlarmInstantFactory testee = testee(Instant.parse("2025-07-28T00:00:00Z"));
+
+        assertThat(testee.computeNextAlarmInstant(calendar, Username.of("jane@example.com")))
+            .isEmpty();
+    }
+
+    @Test
     void shouldPickLatestVersionWhenMultipleVEventsSameUIDWithoutRecurrence() {
         // two VEVENT with same UID, different SEQUENCE
         String ics = """

--- a/storage-api/src/main/java/com/linagora/calendar/storage/AlarmEventDAO.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/AlarmEventDAO.java
@@ -36,5 +36,12 @@ public interface AlarmEventDAO {
 
     Mono<Void> delete(EventUid eventUid, MailAddress recipient);
 
+    /**
+     * Deletes every alarm originating from a given calendar object, whatever its recipient.
+     * A single calendar object may schedule alarms for recipients that are not attendees of the
+     * event (VALARM ATTENDEE delegation), those alarms must be dropped along with the calendar object.
+     */
+    Mono<Void> deleteByEventPath(EventUid eventUid, String eventPath);
+
     Flux<AlarmEvent> findAlarmsToTrigger(Instant time); // get all alarmEvent with time >= alarmTime
 }

--- a/storage-api/src/main/java/com/linagora/calendar/storage/MemoryAlarmEventDAO.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/MemoryAlarmEventDAO.java
@@ -63,6 +63,12 @@ public class MemoryAlarmEventDAO implements AlarmEventDAO {
     }
 
     @Override
+    public Mono<Void> deleteByEventPath(EventUid eventUid, String eventPath) {
+        return Mono.fromRunnable(() -> store.values().removeIf(
+            alarmEvent -> alarmEvent.eventUid().equals(eventUid) && alarmEvent.eventPath().equals(eventPath)));
+    }
+
+    @Override
     public Flux<AlarmEvent> findAlarmsToTrigger(Instant time) {
         return Flux.fromStream(store.values().stream()
             .filter(e -> !e.alarmTime().isAfter(time)));

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/AlarmInstantFactory.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/AlarmInstantFactory.java
@@ -107,6 +107,10 @@ public interface AlarmInstantFactory {
 
         @Override
         public Optional<AlarmInstant> computeNextAlarmInstant(Calendar calendar, Username username, Optional<Instant> sinceInstant) {
+            if (EventParseUtils.isCancelled(calendar)) {
+                return Optional.empty();
+            }
+
             Instant sinceInstantValue = sinceInstant.orElse(clock.instant());
             MailAddress userMailAddress = Throwing.supplier(username::asMailAddress).get();
             return listUpcomingAcceptedVEvents(calendar, username).stream()

--- a/storage-api/src/main/java/com/linagora/calendar/storage/event/EventParseUtils.java
+++ b/storage-api/src/main/java/com/linagora/calendar/storage/event/EventParseUtils.java
@@ -76,6 +76,7 @@ import net.fortuna.ical4j.model.property.RecurrenceId;
 import net.fortuna.ical4j.model.property.Sequence;
 import net.fortuna.ical4j.model.property.Summary;
 import net.fortuna.ical4j.model.property.Uid;
+import net.fortuna.ical4j.model.property.immutable.ImmutableMethod;
 
 public class EventParseUtils {
     public enum DuplicateAttendeePolicy {
@@ -372,6 +373,13 @@ public class EventParseUtils {
 
     public static boolean isCancelled(VEvent event) {
         return event.getStatus() != null && "CANCELLED".equalsIgnoreCase(event.getStatus().getValue());
+    }
+
+    public static boolean isCancelled(Calendar calendar) {
+        return calendar.getProperty(Property.METHOD)
+            .map(Content::getValue)
+            .filter(ImmutableMethod.CANCEL.getValue()::equalsIgnoreCase)
+            .isPresent();
     }
 
     public static Map<String, List<VEvent>> groupByUid(Calendar calendar) {

--- a/storage-api/src/test/java/com/linagora/calendar/storage/AlarmEventDAOContract.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/AlarmEventDAOContract.java
@@ -109,6 +109,41 @@ public interface AlarmEventDAOContract {
     }
 
     @Test
+    default void deleteByEventPathShouldRemoveEveryRecipientOfThatCalendarObject() throws AddressException {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        String eventPath = "/calendars/xxx/yyy/zzz.ics";
+        AlarmEvent attendeeAlarm = new AlarmEvent(new EventUid("1"), now, now, NO_RECURRING, Optional.empty(),
+            new MailAddress("attendee@abc.com"), "ics", eventPath, AlarmAction.EMAIL);
+        AlarmEvent delegatedAlarm = new AlarmEvent(new EventUid("1"), now, now, NO_RECURRING, Optional.empty(),
+            new MailAddress("delegated@abc.com"), "ics", eventPath, AlarmAction.EMAIL);
+
+        getDAO().create(attendeeAlarm).block();
+        getDAO().create(delegatedAlarm).block();
+        getDAO().deleteByEventPath(new EventUid("1"), eventPath).block();
+
+        assertThat(List.of(
+            Optional.ofNullable(getDAO().find(new EventUid("1"), new MailAddress("attendee@abc.com")).block()),
+            Optional.ofNullable(getDAO().find(new EventUid("1"), new MailAddress("delegated@abc.com")).block())))
+            .containsExactly(Optional.empty(), Optional.empty());
+    }
+
+    @Test
+    default void deleteByEventPathShouldNotRemoveAlarmsOfOtherCalendarObjects() throws AddressException {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        AlarmEvent organizerCopy = new AlarmEvent(new EventUid("1"), now, now, NO_RECURRING, Optional.empty(),
+            new MailAddress("recipient@abc.com"), "ics", "/calendars/organizer/organizer/zzz.ics", AlarmAction.EMAIL);
+        AlarmEvent attendeeCopy = new AlarmEvent(new EventUid("1"), now, now, NO_RECURRING, Optional.empty(),
+            new MailAddress("attendee@abc.com"), "ics", "/calendars/attendee/attendee/zzz.ics", AlarmAction.EMAIL);
+
+        getDAO().create(organizerCopy).block();
+        getDAO().create(attendeeCopy).block();
+        getDAO().deleteByEventPath(new EventUid("1"), "/calendars/organizer/organizer/zzz.ics").block();
+
+        assertThat(getDAO().find(new EventUid("1"), new MailAddress("attendee@abc.com")).block())
+            .isEqualTo(attendeeCopy);
+    }
+
+    @Test
     default void shouldGetAlarmEventsByTime() throws AddressException {
         Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         AlarmEvent e1 = new AlarmEvent(

--- a/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBAlarmEventDAO.java
+++ b/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBAlarmEventDAO.java
@@ -105,6 +105,15 @@ public class MongoDBAlarmEventDAO implements AlarmEventDAO {
     }
 
     @Override
+    public Mono<Void> deleteByEventPath(EventUid eventUid, String eventPath) {
+        return Mono.from(collection.deleteMany(
+            Filters.and(
+                eq(EVENT_UID_FIELD, eventUid.value()),
+                eq(EVENT_PATH_FIELD, eventPath)
+            ))).then();
+    }
+
+    @Override
     public Flux<AlarmEvent> findAlarmsToTrigger(Instant time) {
         return Flux.from(collection.find(
             Filters.and(


### PR DESCRIPTION
Closes #970

## Root cause

When the organizer cancels an event, the cancellation reaching the attendee is an ICS carrying `METHOD:CANCEL` at the `VCALENDAR` level — as shown by the ICS attached to the issue, it does **not** necessarily set `STATUS:CANCELLED` on the `VEVENT`.

`AlarmInstantFactory.Default#computeNextAlarmInstant` only filtered on the VEVENT status (`EventParseUtils.isCancelled(VEvent)`). A `METHOD:CANCEL` calendar therefore still looked like an active event, its `VALARM` was still considered upcoming, and `EventAlarmHandler` kept the stored `AlarmEvent` in place instead of removing it. The scheduler then fired it at the trigger time — the 10:00 alarm for the event cancelled at 9:14 in the issue.

## Fix

- `EventParseUtils.isCancelled(Calendar)`: a `VCALENDAR` whose `METHOD` is `CANCEL` is cancelled.
- `AlarmInstantFactory.Default#computeNextAlarmInstant` returns empty for such a calendar. `EventAlarmHandler.applyNextAlarmDecision` already deletes the stored alarm when no next alarm instant is found, so no change was needed there.

## Tests

- New `AlarmInstantFactoryTest#shouldReturnEmptyWhenCalendarMethodIsCancel`, modelled on the ICS from the issue. Verified it fails on `main` and passes with the fix.
- `AlarmInstantFactoryTest` (50), `storage-api` (362) and `AlarmTriggerServiceTest` (13) are green.

## Out of scope

While investigating I noticed a separate, pre-existing weakness worth its own issue: for `ACTION:EMAIL`, `AlarmEventFactory` creates one row **per VALARM `ATTENDEE`**, while `EventAlarmHandler#doDeleteAlarmEvent` deletes only the row keyed on the **calendar owner** mail address. A VALARM recipient who does not own a copy of the event (e.g. `hqtran@abc` in the issue ICS) therefore keeps an orphan alarm row forever. It is also not cleanly fixable as-is, because the unique index on `(eventUid, recipient)` cannot represent the same third-party recipient across two attendees' copies of the event. I left it alone rather than half-fixing it here.

---
*Generated automatically*
