### PR TITLE
ISSUE-976 Event update: base not-email-in-the-past guard on the new event time

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipEmailNotificationPublisher.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipEmailNotificationPublisher.java
@@ -21,6 +21,7 @@ package com.linagora.calendar.amqp;
 import static com.linagora.calendar.storage.event.EventParseUtils.createInstanceVEvent;
 
 import java.net.URI;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.chrono.ChronoZonedDateTime;
 import java.time.temporal.Temporal;
@@ -69,13 +70,16 @@ class ItipEmailNotificationPublisher {
     private final NotificationStrategy singleEventNotificationStrategy;
     private final NotificationStrategy recurringEventNotificationStrategy;
     private final Function<byte[], OutboundMessage> outboundMessageFunction;
+    private final Clock clock;
 
     public ItipEmailNotificationPublisher(Sender sender,
-                                          Function<byte[], OutboundMessage> outboundMessageFunction) {
+                                          Function<byte[], OutboundMessage> outboundMessageFunction,
+                                          Clock clock) {
         this.sender = sender;
         this.singleEventNotificationStrategy = new SingleEventNotificationStrategy();
         this.recurringEventNotificationStrategy = new RecurringEventNotificationStrategy();
         this.outboundMessageFunction = outboundMessageFunction;
+        this.clock = clock;
     }
 
     Mono<Void> send(ItipLocalDeliveryDTO localDelivery,
@@ -98,7 +102,21 @@ class ItipEmailNotificationPublisher {
                                                                 Optional<Calendar> oldEventCalendar) {
         Calendar newCalendar = CalendarUtil.parseIcs(localDelivery.message());
         return notificationStrategy(newCalendar)
-            .handle(localDelivery, eventPath, newCalendar, oldEventCalendar);
+            .handle(localDelivery, eventPath, newCalendar, oldEventCalendar)
+            .stream()
+            .filter(this::notExpired)
+            .toList();
+    }
+
+    /**
+     * Suppresses notifications for events that have already occurred, mirroring esn-sabre's
+     * {@code IMipPlugin::testIfEventIsExpired}. The check is based on the event carried by the
+     * notification, which always reflects the new (rescheduled) time: rescheduling a past event to
+     * a future slot therefore still notifies attendees.
+     */
+    private boolean notExpired(NotificationEmailDTO notification) {
+        Calendar calendar = CalendarUtil.parseIcs(notification.event());
+        return !CalendarEventUtils.vEventExpired(EventParseUtils.getFirstEvent(calendar), clock);
     }
 
     private NotificationStrategy notificationStrategy(Calendar newCalendar) {

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumer.java
@@ -25,6 +25,7 @@ import static org.apache.james.util.ReactorUtils.DEFAULT_CONCURRENCY;
 
 import java.io.Closeable;
 import java.net.URI;
+import java.time.Clock;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -112,7 +113,8 @@ public class ItipLocalDeliveryConsumer implements Closeable, Startable {
                                      @Named(INJECT_KEY_DAV) Supplier<QueueArguments.Builder> queueArgumentSupplier,
                                      CalDavClient calDavClient,
                                      LocalRecipientResolver localRecipientResolver,
-                                     @Named("itipEventMessagesPrefetchCount") int prefetchCount) {
+                                     @Named("itipEventMessagesPrefetchCount") int prefetchCount,
+                                     Clock clock) {
         this.receiverProvider = channelPool::createReceiver;
         this.sender = channelPool.getSender();
         this.calDavClient = calDavClient;
@@ -120,7 +122,7 @@ public class ItipLocalDeliveryConsumer implements Closeable, Startable {
         this.prefetchCount = prefetchCount;
         this.queueArgumentSupplier = queueArgumentSupplier;
         this.itipEmailNotificationPublisher = new ItipEmailNotificationPublisher(sender,
-            bytes -> new OutboundMessage(EventEmailConsumer.EXCHANGE_NAME, EMPTY_ROUTING_KEY, bytes));
+            bytes -> new OutboundMessage(EventEmailConsumer.EXCHANGE_NAME, EMPTY_ROUTING_KEY, bytes), clock);
     }
 
     private static void declareExchangeAndQueue(Supplier<Builder> queueArgumentSupplier, Sender sender) {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipEmailNotificationPublisherTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipEmailNotificationPublisherTest.java
@@ -24,6 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,13 +47,21 @@ class ItipEmailNotificationPublisherTest {
     private static final String CALENDAR_ID = "team-calendar";
     private static final URI EVENT_PATH = URI.create("/calendars/openpaas/team-calendar/event-uid@test.ics");
 
+    // All the fixtures below start on 2026-04-01, so a clock anchored before that keeps them upcoming.
+    private static final Clock CLOCK_BEFORE_EVENTS = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC);
+
     private ItipEmailNotificationPublisher testee;
 
     @BeforeEach
     void setUp() {
-        testee = new ItipEmailNotificationPublisher(
+        testee = publisherWithClock(CLOCK_BEFORE_EVENTS);
+    }
+
+    private static ItipEmailNotificationPublisher publisherWithClock(Clock clock) {
+        return new ItipEmailNotificationPublisher(
             mock(Sender.class),
-            body -> new OutboundMessage("exchange", "routingKey", body));
+            body -> new OutboundMessage("exchange", "routingKey", body),
+            clock);
     }
 
     @Nested
@@ -177,6 +188,34 @@ class ItipEmailNotificationPublisherTest {
                                 }
                             }""");
                 });
+        }
+
+        @Test
+        void rescheduleFromPastToFutureShouldStillNotify() {
+            // Issue #976: the event was at 10:00, has just passed (clock is 10:05), and gets moved to 11:00.
+            // The past-guard must be based on the new time (11:00, still upcoming) so the attendee is notified.
+            Clock justAfterOldStart = Clock.fixed(Instant.parse("2026-04-01T10:05:00Z"), ZoneOffset.UTC);
+            String rescheduledToFuture = SINGLE_REQUEST_NEW
+                .replace("DTSTART:20260401T103000Z", "DTSTART:20260401T110000Z")
+                .replace("DTEND:20260401T113000Z", "DTEND:20260401T120000Z");
+            ItipLocalDeliveryDTO dto = dto(Method.VALUE_REQUEST, rescheduledToFuture, Optional.of(SINGLE_REQUEST_OLD));
+
+            List<NotificationEmailDTO> notifications = publisherWithClock(justAfterOldStart)
+                .buildNotificationMessages(dto, EVENT_PATH, Optional.of(parseIcs(SINGLE_REQUEST_OLD)));
+
+            assertThat(notifications).hasSize(1);
+        }
+
+        @Test
+        void updateShouldBeSuppressedWhenNewEventIsAlreadyInThePast() {
+            // The new start (10:30) is already past relative to the clock (11:00): no point emailing.
+            Clock afterNewStart = Clock.fixed(Instant.parse("2026-04-01T11:00:00Z"), ZoneOffset.UTC);
+            ItipLocalDeliveryDTO dto = dto(Method.VALUE_REQUEST, SINGLE_REQUEST_NEW, Optional.of(SINGLE_REQUEST_OLD));
+
+            List<NotificationEmailDTO> notifications = publisherWithClock(afterNewStart)
+                .buildNotificationMessages(dto, EVENT_PATH, Optional.of(parseIcs(SINGLE_REQUEST_OLD)));
+
+            assertThat(notifications).isEmpty();
         }
 
         @Test

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
@@ -29,7 +29,10 @@ import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -179,7 +182,8 @@ public class ItipLocalDeliveryConsumerTest {
             QueueArguments.Builder::new,
             calDavClient,
             localRecipientResolver,
-            DEFAULT_ITIP_EVENT_MESSAGES_PREFETCH_COUNT);
+            DEFAULT_ITIP_EVENT_MESSAGES_PREFETCH_COUNT,
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC));
 
         consumer.init();
         declareExchange(EventEmailConsumer.EXCHANGE_NAME);

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/SabreAsyncSchedulingExtension.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/SabreAsyncSchedulingExtension.java
@@ -83,7 +83,8 @@ public class SabreAsyncSchedulingExtension implements BeforeAllCallback, BeforeE
             QueueArguments.Builder::new,
             new CalDavClient(sabreDavExtension.dockerSabreDavSetup().davConfiguration(), TECHNICAL_TOKEN_SERVICE_TESTING),
             localRecipientResolver(),
-            DEFAULT_ITIP_EVENT_MESSAGES_PREFETCH_COUNT);
+            DEFAULT_ITIP_EVENT_MESSAGES_PREFETCH_COUNT,
+            Clock.systemUTC());
         itipLocalDeliveryConsumer.init();
     }
 


### PR DESCRIPTION
Closes #976

## Problem

The not-email-in-the-past guard (esn-sabre `IMipPlugin::testIfEventIsExpired`) suppresses an update notification when the event has already started. In the scenario from the issue — Bob invites Alice at 9:00, Alice does not show up, then at 9:05 Bob reschedules the event to 10:00 — the attendee should still be notified because the *new* start time is in the future.

## Findings

In the async scheduling path (`ItipLocalDeliveryConsumer` → `ItipEmailNotificationPublisher` → `EventEmailConsumer`), which is the side-service port of esn-sabre `IMipPlugin::schedule`, the expiration guard was **not** wired: `CalendarEventUtils.vEventExpired` (ported from `testIfEventIsExpired` in #668) existed with tests but was never called. So notifications were published regardless of the event being past.

## Fix

Wire `CalendarEventUtils.vEventExpired` into `ItipEmailNotificationPublisher.buildNotificationMessages`, filtering out notifications whose event has expired. The check is based on the event each notification carries, which always reflects the **new (rescheduled)** time:

- reschedule of a past event to a future slot → still notifies attendees;
- an update whose new start is already in the past → suppressed.

This mirrors esn-sabre, where the guard is applied to every produced `eventMessage` in the publish loop, so it currently covers all methods (REQUEST/REPLY/CANCEL/COUNTER). Happy to restrict it to REQUEST-only if you prefer a narrower scope.

## Tests

- `rescheduleFromPastToFutureShouldStillNotify` — the issue scenario.
- `updateShouldBeSuppressedWhenNewEventIsAlreadyInThePast`.
- Existing `ItipEmailNotificationPublisherTest` / `ItipLocalDeliveryConsumerTest` fixtures use fixed 2026-04 dates, so they now run against a fixed clock anchored before those events; async integration tests use far-future (year 3025) events and keep the system clock.

---
*Generated automatically*
