### PR TITLE
ISSUE-978 GET /api/team-calendars/{id}

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/TeamCalendarRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/TeamCalendarRouteTest.java
@@ -1,0 +1,300 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.app.restapi.routes;
+
+import static com.linagora.calendar.app.restapi.routes.ImportRouteTest.mailSenderConfigurationFunction;
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.EncoderConfig.encoderConfig;
+import static io.restassured.config.RedirectConfig.redirectConfig;
+import static io.restassured.config.RestAssuredConfig.newConfig;
+import static io.restassured.http.ContentType.JSON;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.utils.GuiceProbe;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.calendar.app.AppTestHelper;
+import com.linagora.calendar.app.DomainAdminProbe;
+import com.linagora.calendar.app.TwakeCalendarConfiguration;
+import com.linagora.calendar.app.TwakeCalendarExtension;
+import com.linagora.calendar.app.TwakeCalendarGuiceServer;
+import com.linagora.calendar.app.modules.CalendarDataProbe;
+import com.linagora.calendar.app.restapi.routes.PeopleSearchRouteTest.TeamCalendarProbe;
+import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.restapi.RestApiServerProbe;
+import com.linagora.calendar.smtp.MailSenderConfiguration;
+import com.linagora.calendar.smtp.MockSmtpServerExtension;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.model.TeamCalendar;
+import com.linagora.calendar.storage.model.TeamCalendarId;
+
+import io.restassured.RestAssured;
+import io.restassured.authentication.PreemptiveBasicAuthScheme;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import net.javacrumbs.jsonunit.core.Option;
+
+public class TeamCalendarRouteTest {
+    private static final String DEFAULT_USER_PASSWORD = "secret";
+    private static final String ADMIN = "admin@linagora.com";
+    private static final String ADMIN_PASSWORD = "secret";
+
+    @RegisterExtension
+    @Order(1)
+    static final MockSmtpServerExtension SMTP_EXTENSION = new MockSmtpServerExtension();
+
+    @RegisterExtension
+    @Order(2)
+    static SabreDavExtension SABRE_DAV_EXTENSION = SabreDavExtension.shared();
+
+    @RegisterExtension
+    @Order(3)
+    static final TwakeCalendarExtension TCALENDAR_EXTENSION = new TwakeCalendarExtension(
+        TwakeCalendarConfiguration.builder()
+            .configurationFromClasspath()
+            .userChoice(TwakeCalendarConfiguration.UserChoice.MEMORY)
+            .dbChoice(TwakeCalendarConfiguration.DbChoice.MONGODB),
+        AppTestHelper.OIDC_BY_PASS_MODULE,
+        DavModuleTestHelper.FROM_SABRE_EXTENSION.apply(SABRE_DAV_EXTENSION),
+        binder -> {
+            Multibinder.newSetBinder(binder, GuiceProbe.class)
+                .addBinding().to(TeamCalendarProbe.class);
+            Multibinder.newSetBinder(binder, GuiceProbe.class)
+                .addBinding().to(DomainAdminProbe.class);
+            binder.bind(MailSenderConfiguration.class)
+                .toInstance(mailSenderConfigurationFunction.apply(SMTP_EXTENSION));
+        });
+
+    @AfterAll
+    static void afterAll() {
+        RestAssured.reset();
+    }
+
+    private OpenPaaSUser openPaaSUser;
+    private OpenPaaSUser openPaaSUser2;
+    private Domain domain;
+    private TeamCalendar teamCalendar;
+    private TeamCalendar teamCalendar2;
+    private int restApiPort;
+
+    @BeforeEach
+    void setUp(TwakeCalendarGuiceServer server) {
+        openPaaSUser = SABRE_DAV_EXTENSION.newTestUser(Optional.of("openPaaSUser1"));
+        openPaaSUser2 = SABRE_DAV_EXTENSION.newTestUser(Optional.of("openPaaSUser2"));
+
+        server.getProbe(CalendarDataProbe.class)
+            .addUserToRepository(openPaaSUser.username(), DEFAULT_USER_PASSWORD);
+        server.getProbe(CalendarDataProbe.class)
+            .addUserToRepository(openPaaSUser2.username(), DEFAULT_USER_PASSWORD);
+
+        domain = openPaaSUser.username().getDomainPart().orElseThrow();
+
+        teamCalendar = server.getProbe(TeamCalendarProbe.class)
+            .save(domain, "engineering", "Engineering Team");
+        teamCalendar2 = server.getProbe(TeamCalendarProbe.class)
+            .save(domain, "marketing", "Marketing Team");
+
+        restApiPort = server.getProbe(RestApiServerProbe.class).getPort().getValue();
+
+        RestAssured.requestSpecification = buildRequestSpec(openPaaSUser.username().asString(), DEFAULT_USER_PASSWORD, restApiPort);
+
+        server.getProbe(DomainAdminProbe.class)
+            .addAdmin(teamCalendar.domain().id(), openPaaSUser.id());
+        server.getProbe(DomainAdminProbe.class)
+            .addAdmin(teamCalendar.domain().id(), openPaaSUser2.id());
+    }
+
+    @Test
+    void shouldReturn200WhenTeamCalendarExists() {
+        TeamCalendarId teamCalendarId = teamCalendar.id();
+
+        String actualResponse = given()
+            .when()
+            .get(String.format("/api/team-calendars/%s", teamCalendarId.value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .extract()
+            .body().asString();
+
+        assertThatJson(actualResponse)
+            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .isEqualTo("""
+                {
+                    "timestamps": {
+                        "creation": "${json-unit.ignore}",
+                        "updatedAt": "${json-unit.ignore}"
+                    },
+                    "_id": "{teamCalendarId}",
+                    "name": "engineering",
+                    "displayName": "Engineering Team",
+                    "domain": {
+                        "name": "open-paas.org",
+                        "_id": "{domainId}",
+                        "schemaVersion": 1,
+                        "administrators": [
+                            {
+                                "user_id": "{domainAdminId1}",
+                                "timestamps": {
+                                    "creation": "1970-01-01T00:00:00.000Z"
+                                }
+                            },
+                            {
+                                "user_id": "{domainAdminId2}",
+                                "timestamps": {
+                                    "creation": "1970-01-01T00:00:00.000Z"
+                                }
+                            }
+                        ],
+                        "timestamps": {
+                            "creation": "${json-unit.ignore}"
+                        },
+                        "hostnames": [
+                            "open-paas.org"
+                        ],
+                        "injections": [],
+                        "company_name": "open-paas.org",
+                        "__v": 0
+                    },
+                    "__v": 0
+                }
+                """.replace("{teamCalendarId}", teamCalendarId.value())
+                .replace("{domainAdminId1}", openPaaSUser.id().value())
+                .replace("{domainAdminId2}", openPaaSUser2.id().value())
+                .replace("{domainId}", teamCalendar.domain().id().value()));
+    }
+
+    @Test
+    void shouldAllowAnyAuthenticatedUserToGetTeamCalendar() {
+        given(buildRequestSpec(openPaaSUser2.username().asString(), DEFAULT_USER_PASSWORD, restApiPort))
+            .when()
+            .get(String.format("/api/team-calendars/%s", teamCalendar.id().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .body("_id", equalTo(teamCalendar.id().value()))
+            .body("name", equalTo(teamCalendar.name()))
+            .body("displayName", equalTo(teamCalendar.displayName()));
+    }
+
+    @Test
+    void shouldReturn404WhenAccessingTeamCalendarFromAnotherDomain(TwakeCalendarGuiceServer server) {
+        Domain otherDomain = Domain.of("domain999.tld");
+        Username otherDomainUser = Username.fromLocalPartWithDomain(UUID.randomUUID().toString(), otherDomain);
+        server.getProbe(CalendarDataProbe.class)
+            .addDomain(otherDomain)
+            .addUserToRepository(otherDomainUser, DEFAULT_USER_PASSWORD);
+
+        given(buildRequestSpec(otherDomainUser.asString(), DEFAULT_USER_PASSWORD, restApiPort))
+            .when()
+            .get(String.format("/api/team-calendars/%s", teamCalendar.id().value()))
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void adminShouldAccessTeamCalendarFromAnotherDomain() {
+        given(buildRequestSpec(ADMIN, ADMIN_PASSWORD, restApiPort))
+            .when()
+            .get(String.format("/api/team-calendars/%s", teamCalendar.id().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .body("_id", equalTo(teamCalendar.id().value()))
+            .body("name", equalTo(teamCalendar.name()));
+    }
+
+    @Test
+    void shouldReturnDifferentDataForDifferentTeamCalendarIds() {
+        String response1 = given()
+            .when()
+            .get(String.format("/api/team-calendars/%s", teamCalendar.id().value()))
+        .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+
+        String response2 = given()
+            .when()
+            .get(String.format("/api/team-calendars/%s", teamCalendar2.id().value()))
+        .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+
+        assertThatJson(response1).node("_id").isEqualTo(teamCalendar.id().value());
+        assertThatJson(response1).node("name").isEqualTo(teamCalendar.name());
+
+        assertThatJson(response2).node("_id").isEqualTo(teamCalendar2.id().value());
+        assertThatJson(response2).node("name").isEqualTo(teamCalendar2.name());
+    }
+
+    @Test
+    void shouldReturn404WhenTeamCalendarNotFound() {
+        TeamCalendarId fakeTeamCalendarId = new TeamCalendarId(new ObjectId().toHexString());
+
+        given()
+            .when()
+            .get(String.format("/api/team-calendars/%s", fakeTeamCalendarId.value()))
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void shouldReturn401WhenNoAuthenticationProvided() {
+        TeamCalendarId teamCalendarId = teamCalendar.id();
+
+        String fakePassword = UUID.randomUUID().toString();
+
+        given(buildRequestSpec(openPaaSUser.username().asString(), fakePassword, restApiPort))
+        .when()
+            .get(String.format("/api/team-calendars/%s", teamCalendarId.value()))
+        .then()
+            .statusCode(401);
+    }
+
+    private RequestSpecification buildRequestSpec(String username, String password, int port) {
+        PreemptiveBasicAuthScheme auth = new PreemptiveBasicAuthScheme();
+        auth.setUserName(username);
+        auth.setPassword(password);
+
+        return new RequestSpecBuilder()
+            .setPort(port)
+            .setAuth(auth)
+            .setAccept(JSON)
+            .setContentType(JSON)
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8))
+                .redirect(redirectConfig().followRedirects(false)))
+            .build();
+    }
+}

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/TeamCalendarRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/TeamCalendarRouteTest.java
@@ -62,7 +62,6 @@ import io.restassured.RestAssured;
 import io.restassured.authentication.PreemptiveBasicAuthScheme;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
-import net.javacrumbs.jsonunit.core.Option;
 
 public class TeamCalendarRouteTest {
     private static final String DEFAULT_USER_PASSWORD = "secret";
@@ -148,7 +147,6 @@ public class TeamCalendarRouteTest {
             .body().asString();
 
         assertThatJson(actualResponse)
-            .withOptions(Option.IGNORING_ARRAY_ORDER)
             .isEqualTo("""
                 {
                     "timestamps": {
@@ -161,36 +159,16 @@ public class TeamCalendarRouteTest {
                     "domain": {
                         "name": "open-paas.org",
                         "_id": "{domainId}",
-                        "schemaVersion": 1,
-                        "administrators": [
-                            {
-                                "user_id": "{domainAdminId1}",
-                                "timestamps": {
-                                    "creation": "1970-01-01T00:00:00.000Z"
-                                }
-                            },
-                            {
-                                "user_id": "{domainAdminId2}",
-                                "timestamps": {
-                                    "creation": "1970-01-01T00:00:00.000Z"
-                                }
-                            }
-                        ],
                         "timestamps": {
                             "creation": "${json-unit.ignore}"
                         },
                         "hostnames": [
                             "open-paas.org"
                         ],
-                        "injections": [],
-                        "company_name": "open-paas.org",
-                        "__v": 0
-                    },
-                    "__v": 0
+                        "company_name": "open-paas.org"
+                    }
                 }
                 """.replace("{teamCalendarId}", teamCalendarId.value())
-                .replace("{domainAdminId1}", openPaaSUser.id().value())
-                .replace("{domainAdminId2}", openPaaSUser2.id().value())
                 .replace("{domainId}", teamCalendar.domain().id().value()));
     }
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -107,6 +107,7 @@ import com.linagora.calendar.restapi.routes.ResourceIconRoute;
 import com.linagora.calendar.restapi.routes.ResourceParticipationRoute;
 import com.linagora.calendar.restapi.routes.ResourceRoute;
 import com.linagora.calendar.restapi.routes.SecretLinkRoute;
+import com.linagora.calendar.restapi.routes.TeamCalendarRoute;
 import com.linagora.calendar.restapi.routes.ThemeRoute;
 import com.linagora.calendar.restapi.routes.UserConfigurationPatchRoute;
 import com.linagora.calendar.restapi.routes.UserConfigurationsRoute;
@@ -191,6 +192,7 @@ public class RestApiModule extends AbstractModule {
         routes.addBinding().to(ResourceIconRoute.class);
         routes.addBinding().to(ResourceParticipationRoute.class);
         routes.addBinding().to(ResourceRoute.class);
+        routes.addBinding().to(TeamCalendarRoute.class);
         routes.addBinding().to(CalendarTicketRoutes.class);
         routes.addBinding().to(WebsocketRoute.class);
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/TeamCalendarRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/TeamCalendarRoute.java
@@ -19,6 +19,8 @@
 package com.linagora.calendar.restapi.routes;
 
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import jakarta.inject.Inject;
 
@@ -34,8 +36,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableList;
 import com.linagora.calendar.restapi.NotFoundException;
-import com.linagora.calendar.storage.OpenPaaSDomainAdminDAO;
+import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.TeamCalendarRepository;
@@ -58,12 +61,7 @@ public class TeamCalendarRoute extends CalendarRoute {
                                    @JsonProperty("_id") String id,
                                    String name,
                                    String displayName,
-                                   DomainRoute.ResponseDTO domain) {
-
-        @JsonProperty("__v")
-        public int getVersion() {
-            return 0;
-        }
+                                   DomainDTO domain) {
 
         record TimestampsDTO(
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
@@ -75,9 +73,49 @@ public class TeamCalendarRoute extends CalendarRoute {
         }
     }
 
+    public static class DomainDTO {
+        private final OpenPaaSDomain domain;
+
+        DomainDTO(OpenPaaSDomain domain) {
+            this.domain = domain;
+        }
+
+        @JsonProperty("timestamps")
+        public Timestamp getTimestamps() {
+            return new Timestamp();
+        }
+
+        @JsonProperty("hostnames")
+        public ImmutableList<String> getHostnames() {
+            return ImmutableList.of(domain.domain().asString());
+        }
+
+        @JsonProperty("_id")
+        public String getId() {
+            return domain.id().value();
+        }
+
+        @JsonProperty("name")
+        public String getName() {
+            return domain.domain().asString();
+        }
+
+        @JsonProperty("company_name")
+        public String getCompanyName() {
+            return domain.domain().asString();
+        }
+    }
+
+    public static class Timestamp {
+        @JsonProperty("creation")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
+        public ZonedDateTime getCreation() {
+            return ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
+        }
+    }
+
     private final TeamCalendarRepository teamCalendarRepository;
     private final OpenPaaSDomainDAO openPaaSDomainDAO;
-    private final OpenPaaSDomainAdminDAO domainAdminDAO;
     private final CrossDomainAccessControl crossDomainAccessControl;
 
     @Inject
@@ -85,12 +123,10 @@ public class TeamCalendarRoute extends CalendarRoute {
                              MetricFactory metricFactory,
                              TeamCalendarRepository teamCalendarRepository,
                              OpenPaaSDomainDAO openPaaSDomainDAO,
-                             OpenPaaSDomainAdminDAO domainAdminDAO,
                              CrossDomainAccessControl crossDomainAccessControl) {
         super(authenticator, metricFactory);
         this.teamCalendarRepository = teamCalendarRepository;
         this.openPaaSDomainDAO = openPaaSDomainDAO;
-        this.domainAdminDAO = domainAdminDAO;
         this.crossDomainAccessControl = crossDomainAccessControl;
     }
 
@@ -113,16 +149,14 @@ public class TeamCalendarRoute extends CalendarRoute {
                 .then());
     }
 
-    private Mono<DomainRoute.ResponseDTO> retrieveAuthorizedDomainResponse(OpenPaaSId domainId, MailboxSession session) {
+    private Mono<DomainDTO> retrieveAuthorizedDomainResponse(OpenPaaSId domainId, MailboxSession session) {
         return openPaaSDomainDAO.retrieve(domainId)
             .filter(domain -> !crossDomainAccessControl.denies(session, domain.domain()))
             .switchIfEmpty(Mono.error(NotFoundException::new))
-            .flatMap(domain -> domainAdminDAO.listAdmins(domainId)
-                .collectList()
-                .map(adminList -> new DomainRoute.ResponseDTO(domain, adminList)));
+            .map(DomainDTO::new);
     }
 
-    private TeamCalendarResponseDTO buildResponseDTO(TeamCalendar teamCalendar, DomainRoute.ResponseDTO domainResponseDTO) {
+    private TeamCalendarResponseDTO buildResponseDTO(TeamCalendar teamCalendar, DomainDTO domainResponseDTO) {
         TeamCalendarResponseDTO.TimestampsDTO timestampsDTO =
             new TeamCalendarResponseDTO.TimestampsDTO(teamCalendar.creation(), teamCalendar.updated());
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/TeamCalendarRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/TeamCalendarRoute.java
@@ -1,0 +1,132 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import java.time.Instant;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.jmap.Endpoint;
+import org.apache.james.jmap.http.Authenticator;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.metrics.api.MetricFactory;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.fge.lambdas.Throwing;
+import com.linagora.calendar.restapi.NotFoundException;
+import com.linagora.calendar.storage.OpenPaaSDomainAdminDAO;
+import com.linagora.calendar.storage.OpenPaaSDomainDAO;
+import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.TeamCalendarRepository;
+import com.linagora.calendar.storage.model.TeamCalendar;
+import com.linagora.calendar.storage.model.TeamCalendarId;
+
+import io.netty.handler.codec.http.HttpMethod;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.server.HttpServerRequest;
+import reactor.netty.http.server.HttpServerResponse;
+
+public class TeamCalendarRoute extends CalendarRoute {
+    private static final String TEAM_CALENDAR_ID_PATH_PARAM = "teamCalendarId";
+
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    record TeamCalendarResponseDTO(TimestampsDTO timestamps,
+                                   @JsonProperty("_id") String id,
+                                   String name,
+                                   String displayName,
+                                   DomainRoute.ResponseDTO domain) {
+
+        @JsonProperty("__v")
+        public int getVersion() {
+            return 0;
+        }
+
+        record TimestampsDTO(
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+            Instant creation,
+
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+            Instant updatedAt) {
+        }
+    }
+
+    private final TeamCalendarRepository teamCalendarRepository;
+    private final OpenPaaSDomainDAO openPaaSDomainDAO;
+    private final OpenPaaSDomainAdminDAO domainAdminDAO;
+    private final CrossDomainAccessControl crossDomainAccessControl;
+
+    @Inject
+    public TeamCalendarRoute(Authenticator authenticator,
+                             MetricFactory metricFactory,
+                             TeamCalendarRepository teamCalendarRepository,
+                             OpenPaaSDomainDAO openPaaSDomainDAO,
+                             OpenPaaSDomainAdminDAO domainAdminDAO,
+                             CrossDomainAccessControl crossDomainAccessControl) {
+        super(authenticator, metricFactory);
+        this.teamCalendarRepository = teamCalendarRepository;
+        this.openPaaSDomainDAO = openPaaSDomainDAO;
+        this.domainAdminDAO = domainAdminDAO;
+        this.crossDomainAccessControl = crossDomainAccessControl;
+    }
+
+    @Override
+    Endpoint endpoint() {
+        return new Endpoint(HttpMethod.GET, String.format("/api/team-calendars/{%s}", TEAM_CALENDAR_ID_PATH_PARAM));
+    }
+
+    @Override
+    Mono<Void> handleRequest(HttpServerRequest req, HttpServerResponse res, MailboxSession session) {
+        TeamCalendarId teamCalendarId = new TeamCalendarId(req.param(TEAM_CALENDAR_ID_PATH_PARAM));
+        return teamCalendarRepository.retrieve(teamCalendarId)
+            .switchIfEmpty(Mono.error(NotFoundException::new))
+            .flatMap(teamCalendar -> retrieveAuthorizedDomainResponse(teamCalendar.domainId(), session)
+                .map(domainResponse -> buildResponseDTO(teamCalendar, domainResponse)))
+            .map(Throwing.function(OBJECT_MAPPER::writeValueAsBytes))
+            .flatMap(bytes -> res.status(200)
+                .header("Content-Type", "application/json;charset=utf-8")
+                .sendByteArray(Mono.just(bytes))
+                .then());
+    }
+
+    private Mono<DomainRoute.ResponseDTO> retrieveAuthorizedDomainResponse(OpenPaaSId domainId, MailboxSession session) {
+        return openPaaSDomainDAO.retrieve(domainId)
+            .filter(domain -> !crossDomainAccessControl.denies(session, domain.domain()))
+            .switchIfEmpty(Mono.error(NotFoundException::new))
+            .flatMap(domain -> domainAdminDAO.listAdmins(domainId)
+                .collectList()
+                .map(adminList -> new DomainRoute.ResponseDTO(domain, adminList)));
+    }
+
+    private TeamCalendarResponseDTO buildResponseDTO(TeamCalendar teamCalendar, DomainRoute.ResponseDTO domainResponseDTO) {
+        TeamCalendarResponseDTO.TimestampsDTO timestampsDTO =
+            new TeamCalendarResponseDTO.TimestampsDTO(teamCalendar.creation(), teamCalendar.updated());
+
+        return new TeamCalendarResponseDTO(timestampsDTO, teamCalendar.id().value(),
+            teamCalendar.name(), teamCalendar.displayName(), domainResponseDTO);
+    }
+}


### PR DESCRIPTION
Closes #978

Adds `GET /api/team-calendars/{id}`, symmetrical to `GET /api/resources/{id}`.

## What it does

The endpoint returns the details of a single team calendar, mapping the data stored in database:

- `_id`, `name`, `displayName`
- `timestamps` (`creation` / `updatedAt`)
- the enriched `domain` representation (same shape as the resource endpoint, including domain administrators)

It reuses the existing `CrossDomainAccessControl` so that:
- any authenticated user of the domain can read a team calendar of that domain,
- the platform admin can read team calendars of any domain,
- a `404` is returned when the team calendar does not exist or belongs to a domain the caller may not access.

## Notes

The path is pluralized (`team-calendars`) to stay consistent with the existing `/api/resources/{id}` convention (the `team-calendar` object type from people search serializes in the singular, but REST collection paths are plural here).

## Tests

`TeamCalendarRouteTest` covers the nominal response body, cross-domain access control (user / admin / foreign domain), unknown id (`404`) and missing authentication (`401`).

---
*Generated automatically*
