### PR TITLE
ISSUE-980 GET /api/entity/{id}

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/EntityRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/EntityRouteTest.java
@@ -1,0 +1,331 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.app.restapi.routes;
+
+import static com.linagora.calendar.app.restapi.routes.ImportRouteTest.mailSenderConfigurationFunction;
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.EncoderConfig.encoderConfig;
+import static io.restassured.config.RedirectConfig.redirectConfig;
+import static io.restassured.config.RestAssuredConfig.newConfig;
+import static io.restassured.http.ContentType.JSON;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.utils.GuiceProbe;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.inject.multibindings.Multibinder;
+import com.linagora.calendar.app.AppTestHelper;
+import com.linagora.calendar.app.DomainAdminProbe;
+import com.linagora.calendar.app.TwakeCalendarConfiguration;
+import com.linagora.calendar.app.TwakeCalendarExtension;
+import com.linagora.calendar.app.TwakeCalendarGuiceServer;
+import com.linagora.calendar.app.modules.CalendarDataProbe;
+import com.linagora.calendar.app.restapi.routes.PeopleSearchRouteTest.ResourceProbe;
+import com.linagora.calendar.app.restapi.routes.PeopleSearchRouteTest.TeamCalendarProbe;
+import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.dav.SabreDavExtension;
+import com.linagora.calendar.restapi.RestApiServerProbe;
+import com.linagora.calendar.smtp.MailSenderConfiguration;
+import com.linagora.calendar.smtp.MockSmtpServerExtension;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.model.Resource;
+import com.linagora.calendar.storage.model.TeamCalendar;
+
+import io.restassured.RestAssured;
+import io.restassured.authentication.PreemptiveBasicAuthScheme;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import net.javacrumbs.jsonunit.core.Option;
+
+public class EntityRouteTest {
+    private static final String DEFAULT_USER_PASSWORD = "secret";
+    private static final String ADMIN = "admin@linagora.com";
+    private static final String ADMIN_PASSWORD = "secret";
+
+    @RegisterExtension
+    @Order(1)
+    static final MockSmtpServerExtension SMTP_EXTENSION = new MockSmtpServerExtension();
+
+    @RegisterExtension
+    @Order(2)
+    static SabreDavExtension SABRE_DAV_EXTENSION = SabreDavExtension.shared();
+
+    @RegisterExtension
+    @Order(3)
+    static final TwakeCalendarExtension TCALENDAR_EXTENSION = new TwakeCalendarExtension(
+        TwakeCalendarConfiguration.builder()
+            .configurationFromClasspath()
+            .userChoice(TwakeCalendarConfiguration.UserChoice.MEMORY)
+            .dbChoice(TwakeCalendarConfiguration.DbChoice.MONGODB),
+        AppTestHelper.OIDC_BY_PASS_MODULE,
+        DavModuleTestHelper.FROM_SABRE_EXTENSION.apply(SABRE_DAV_EXTENSION),
+        binder -> {
+            Multibinder.newSetBinder(binder, GuiceProbe.class)
+                .addBinding().to(ResourceProbe.class);
+            Multibinder.newSetBinder(binder, GuiceProbe.class)
+                .addBinding().to(TeamCalendarProbe.class);
+            Multibinder.newSetBinder(binder, GuiceProbe.class)
+                .addBinding().to(DomainAdminProbe.class);
+            binder.bind(MailSenderConfiguration.class)
+                .toInstance(mailSenderConfigurationFunction.apply(SMTP_EXTENSION));
+        });
+
+    @AfterAll
+    static void afterAll() {
+        RestAssured.reset();
+    }
+
+    private OpenPaaSUser openPaaSUser;
+    private OpenPaaSUser openPaaSUser2;
+    private Domain domain;
+    private Resource resource;
+    private TeamCalendar teamCalendar;
+    private int restApiPort;
+
+    @BeforeEach
+    void setUp(TwakeCalendarGuiceServer server) {
+        openPaaSUser = SABRE_DAV_EXTENSION.newTestUser(Optional.of("openPaaSUser1"));
+        openPaaSUser2 = SABRE_DAV_EXTENSION.newTestUser(Optional.of("openPaaSUser2"));
+
+        server.getProbe(CalendarDataProbe.class)
+            .addUserToRepository(openPaaSUser.username(), DEFAULT_USER_PASSWORD);
+        server.getProbe(CalendarDataProbe.class)
+            .addUserToRepository(openPaaSUser2.username(), DEFAULT_USER_PASSWORD);
+
+        domain = openPaaSUser.username().getDomainPart().orElseThrow();
+
+        resource = server.getProbe(ResourceProbe.class)
+            .save(openPaaSUser, "meeting-room", "room", List.of(openPaaSUser.id(), openPaaSUser2.id()));
+        teamCalendar = server.getProbe(TeamCalendarProbe.class)
+            .save(domain, "engineering", "Engineering Team");
+
+        restApiPort = server.getProbe(RestApiServerProbe.class).getPort().getValue();
+
+        RestAssured.requestSpecification = buildRequestSpec(openPaaSUser.username().asString(), DEFAULT_USER_PASSWORD, restApiPort);
+
+        server.getProbe(DomainAdminProbe.class)
+            .addAdmin(resource.domain(), openPaaSUser.id());
+        server.getProbe(DomainAdminProbe.class)
+            .addAdmin(resource.domain(), openPaaSUser2.id());
+    }
+
+    @Test
+    void shouldReturnResourceWrappedEntity() {
+        String actualResponse = given()
+            .when()
+            .get(String.format("/api/entity/%s", resource.id().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .extract()
+            .body().asString();
+
+        assertThatJson(actualResponse)
+            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .isEqualTo("""
+                {
+                    "resource": {
+                        "timestamps": {
+                            "creation": "${json-unit.ignore}",
+                            "updatedAt": "${json-unit.ignore}"
+                        },
+                        "deleted": false,
+                        "_id": "{resourceId}",
+                        "name": "meeting-room",
+                        "description": "meeting-room description",
+                        "type": "resource",
+                        "icon": "room",
+                        "administrators": [
+                            {
+                                "id": "{adminId1}",
+                                "objectType": "user",
+                                "_id": "{adminId1}"
+                            },
+                            {
+                                "id": "{adminId2}",
+                                "objectType": "user",
+                                "_id": "{adminId2}"
+                            }
+                        ],
+                        "creator": "{creatorId}",
+                        "domain": {
+                            "name": "open-paas.org",
+                            "_id": "{domainId}",
+                            "schemaVersion": 1,
+                            "administrators": [
+                                {
+                                    "user_id": "{domainAdminId1}",
+                                    "timestamps": {
+                                        "creation": "1970-01-01T00:00:00.000Z"
+                                    }
+                                },
+                                {
+                                    "user_id": "{domainAdminId2}",
+                                    "timestamps": {
+                                        "creation": "1970-01-01T00:00:00.000Z"
+                                    }
+                                }
+                            ],
+                            "timestamps": {
+                                "creation": "${json-unit.ignore}"
+                            },
+                            "hostnames": [
+                                "open-paas.org"
+                            ],
+                            "injections": [],
+                            "company_name": "open-paas.org",
+                            "__v": 0
+                        },
+                        "__v": 0
+                    }
+                }
+                """.replace("{resourceId}", resource.id().value())
+                .replace("{adminId1}", openPaaSUser.id().value())
+                .replace("{adminId2}", openPaaSUser2.id().value())
+                .replace("{domainAdminId1}", openPaaSUser.id().value())
+                .replace("{domainAdminId2}", openPaaSUser2.id().value())
+                .replace("{creatorId}", openPaaSUser.id().value())
+                .replace("{domainId}", resource.domain().value()));
+    }
+
+    @Test
+    void shouldReturnUserWrappedEntity() {
+        given()
+            .when()
+            .get(String.format("/api/entity/%s", openPaaSUser.id().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .body("user._id", equalTo(openPaaSUser.id().value()))
+            .body("user.preferredEmail", equalTo(openPaaSUser.username().asString()))
+            .body("user.objectType", equalTo("user"))
+            .body("resource", nullValue())
+            .body("domain", nullValue())
+            .body("teamCalendar", nullValue());
+    }
+
+    @Test
+    void shouldReturnDomainWrappedEntity() {
+        given()
+            .when()
+            .get(String.format("/api/entity/%s", resource.domain().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .body("domain._id", equalTo(resource.domain().value()))
+            .body("domain.name", equalTo(domain.asString()))
+            .body("user", nullValue())
+            .body("resource", nullValue())
+            .body("teamCalendar", nullValue());
+    }
+
+    @Test
+    void shouldReturnTeamCalendarWrappedEntity() {
+        given()
+            .when()
+            .get(String.format("/api/entity/%s", teamCalendar.id().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .body("teamCalendar._id", equalTo(teamCalendar.id().value()))
+            .body("teamCalendar.name", equalTo(teamCalendar.name()))
+            .body("teamCalendar.displayName", equalTo(teamCalendar.displayName()))
+            .body("user", nullValue())
+            .body("resource", nullValue())
+            .body("domain", nullValue());
+    }
+
+    @Test
+    void shouldReturn404WhenEntityNotFound() {
+        String unknownId = new ObjectId().toHexString();
+
+        given()
+            .when()
+            .get(String.format("/api/entity/%s", unknownId))
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void shouldReturn404WhenAccessingEntityFromAnotherDomain(TwakeCalendarGuiceServer server) {
+        Domain otherDomain = Domain.of("domain999.tld");
+        Username otherDomainUser = Username.fromLocalPartWithDomain(UUID.randomUUID().toString(), otherDomain);
+        server.getProbe(CalendarDataProbe.class)
+            .addDomain(otherDomain)
+            .addUserToRepository(otherDomainUser, DEFAULT_USER_PASSWORD);
+
+        given(buildRequestSpec(otherDomainUser.asString(), DEFAULT_USER_PASSWORD, restApiPort))
+            .when()
+            .get(String.format("/api/entity/%s", resource.id().value()))
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void adminShouldAccessEntityFromAnotherDomain() {
+        given(buildRequestSpec(ADMIN, ADMIN_PASSWORD, restApiPort))
+            .when()
+            .get(String.format("/api/entity/%s", teamCalendar.id().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .body("teamCalendar._id", equalTo(teamCalendar.id().value()))
+            .body("teamCalendar.name", equalTo(teamCalendar.name()));
+    }
+
+    @Test
+    void shouldReturn401WhenNoAuthenticationProvided() {
+        String fakePassword = UUID.randomUUID().toString();
+
+        given(buildRequestSpec(openPaaSUser.username().asString(), fakePassword, restApiPort))
+        .when()
+            .get(String.format("/api/entity/%s", resource.id().value()))
+        .then()
+            .statusCode(401);
+    }
+
+    private RequestSpecification buildRequestSpec(String username, String password, int port) {
+        PreemptiveBasicAuthScheme auth = new PreemptiveBasicAuthScheme();
+        auth.setUserName(username);
+        auth.setPassword(password);
+
+        return new RequestSpecBuilder()
+            .setPort(port)
+            .setAuth(auth)
+            .setAccept(JSON)
+            .setContentType(JSON)
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8))
+                .redirect(redirectConfig().followRedirects(false)))
+            .build();
+    }
+}

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/EntityRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/EntityRouteTest.java
@@ -57,6 +57,7 @@ import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
 import com.linagora.calendar.smtp.MockSmtpServerExtension;
+import com.linagora.calendar.storage.OpenPaaSId;
 import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.model.Resource;
 import com.linagora.calendar.storage.model.TeamCalendar;
@@ -292,7 +293,56 @@ public class EntityRouteTest {
     }
 
     @Test
-    void adminShouldAccessEntityFromAnotherDomain() {
+    void shouldReturn404WhenAccessingUserFromAnotherDomain(TwakeCalendarGuiceServer server) {
+        OpenPaaSUser otherDomainUser = addUser(server, randomDomain());
+
+        given()
+            .when()
+            .get(String.format("/api/entity/%s", otherDomainUser.id().value()))
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void shouldReturn404WhenAccessingTeamCalendarFromAnotherDomain(TwakeCalendarGuiceServer server) {
+        Domain otherDomain = randomDomain();
+        server.getProbe(CalendarDataProbe.class)
+            .addDomain(otherDomain);
+        TeamCalendar otherDomainTeamCalendar = server.getProbe(TeamCalendarProbe.class)
+            .save(otherDomain, "support", "Support Team");
+
+        given()
+            .when()
+            .get(String.format("/api/entity/%s", otherDomainTeamCalendar.id().value()))
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void shouldReturn404WhenAccessingDomainFromAnotherDomain(TwakeCalendarGuiceServer server) {
+        OpenPaaSId otherDomainId = addDomain(server, randomDomain());
+
+        given()
+            .when()
+            .get(String.format("/api/entity/%s", otherDomainId.value()))
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void adminShouldAccessUserFromAnotherDomain() {
+        given(buildRequestSpec(ADMIN, ADMIN_PASSWORD, restApiPort))
+            .when()
+            .get(String.format("/api/entity/%s", openPaaSUser.id().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .body("user._id", equalTo(openPaaSUser.id().value()))
+            .body("user.preferredEmail", equalTo(openPaaSUser.username().asString()));
+    }
+
+    @Test
+    void adminShouldAccessTeamCalendarFromAnotherDomain() {
         given(buildRequestSpec(ADMIN, ADMIN_PASSWORD, restApiPort))
             .when()
             .get(String.format("/api/entity/%s", teamCalendar.id().value()))
@@ -301,6 +351,30 @@ public class EntityRouteTest {
             .contentType(JSON)
             .body("teamCalendar._id", equalTo(teamCalendar.id().value()))
             .body("teamCalendar.name", equalTo(teamCalendar.name()));
+    }
+
+    @Test
+    void adminShouldAccessResourceFromAnotherDomain() {
+        given(buildRequestSpec(ADMIN, ADMIN_PASSWORD, restApiPort))
+            .when()
+            .get(String.format("/api/entity/%s", resource.id().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .body("resource._id", equalTo(resource.id().value()))
+            .body("resource.name", equalTo(resource.name()));
+    }
+
+    @Test
+    void adminShouldAccessDomainFromAnotherDomain() {
+        given(buildRequestSpec(ADMIN, ADMIN_PASSWORD, restApiPort))
+            .when()
+            .get(String.format("/api/entity/%s", resource.domain().value()))
+        .then()
+            .statusCode(200)
+            .contentType(JSON)
+            .body("domain._id", equalTo(resource.domain().value()))
+            .body("domain.name", equalTo(domain.asString()));
     }
 
     @Test
@@ -327,5 +401,23 @@ public class EntityRouteTest {
             .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8))
                 .redirect(redirectConfig().followRedirects(false)))
             .build();
+    }
+
+    private OpenPaaSUser addUser(TwakeCalendarGuiceServer server, Domain domain) {
+        Username username = Username.fromLocalPartWithDomain(UUID.randomUUID().toString(), domain);
+        OpenPaaSId id = server.getProbe(CalendarDataProbe.class)
+            .addDomain(domain)
+            .addUser(username, DEFAULT_USER_PASSWORD);
+        return new OpenPaaSUser(username, id, "", "");
+    }
+
+    private OpenPaaSId addDomain(TwakeCalendarGuiceServer server, Domain domain) {
+        CalendarDataProbe calendarDataProbe = server.getProbe(CalendarDataProbe.class)
+            .addDomain(domain);
+        return calendarDataProbe.domainId(domain);
+    }
+
+    private Domain randomDomain() {
+        return Domain.of("domain-" + UUID.randomUUID() + ".tld");
     }
 }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/EntityRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/EntityRouteTest.java
@@ -182,7 +182,6 @@ public class EntityRouteTest {
                         "domain": {
                             "name": "open-paas.org",
                             "_id": "{domainId}",
-                            "schemaVersion": 1,
                             "administrators": [
                                 {
                                     "user_id": "{domainAdminId1}",
@@ -203,11 +202,8 @@ public class EntityRouteTest {
                             "hostnames": [
                                 "open-paas.org"
                             ],
-                            "injections": [],
-                            "company_name": "open-paas.org",
-                            "__v": 0
-                        },
-                        "__v": 0
+                            "company_name": "open-paas.org"
+                        }
                     }
                 }
                 """.replace("{resourceId}", resource.id().value())

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -89,6 +89,7 @@ import com.linagora.calendar.restapi.routes.ConfigurationRoute;
 import com.linagora.calendar.restapi.routes.DomainRoute;
 import com.linagora.calendar.restapi.routes.DomainSettingsRoute;
 import com.linagora.calendar.restapi.routes.DownloadCalendarRoute;
+import com.linagora.calendar.restapi.routes.EntityRoute;
 import com.linagora.calendar.restapi.routes.EventParticipationRoute;
 import com.linagora.calendar.restapi.routes.FileUploadRoute;
 import com.linagora.calendar.restapi.routes.ImportResultNotifier;
@@ -169,6 +170,7 @@ public class RestApiModule extends AbstractModule {
         routes.addBinding().to(BookingLinkReservationRoute.class);
         routes.addBinding().to(DomainRoute.class);
         routes.addBinding().to(DomainSettingsRoute.class);
+        routes.addBinding().to(EntityRoute.class);
         routes.addBinding().to(ThemeRoute.class);
         routes.addBinding().to(LogoRoute.class);
         routes.addBinding().to(JwtRoutes.class);

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EntityRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EntityRoute.java
@@ -19,10 +19,14 @@
 package com.linagora.calendar.restapi.routes;
 
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.james.jmap.Endpoint;
 import org.apache.james.jmap.http.Authenticator;
 import org.apache.james.mailbox.MailboxSession;
@@ -36,7 +40,10 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.fge.lambdas.Throwing;
+import com.google.common.collect.ImmutableList;
 import com.linagora.calendar.restapi.NotFoundException;
+import com.linagora.calendar.storage.DomainAdministrator;
+import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSDomainAdminDAO;
 import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -45,6 +52,8 @@ import com.linagora.calendar.storage.OpenPaaSUserDAO;
 import com.linagora.calendar.storage.ResourceDAO;
 import com.linagora.calendar.storage.TeamCalendarRepository;
 import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
+import com.linagora.calendar.storage.model.Resource;
+import com.linagora.calendar.storage.model.ResourceAdministrator;
 import com.linagora.calendar.storage.model.ResourceId;
 import com.linagora.calendar.storage.model.TeamCalendar;
 import com.linagora.calendar.storage.model.TeamCalendarId;
@@ -70,19 +79,19 @@ public class EntityRoute extends CalendarRoute {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     record EntityResponseDTO(@JsonProperty("user") UserRoute.ResponseDTO user,
-                             @JsonProperty("resource") ResourceRoute.ResourceResponseDTO resource,
-                             @JsonProperty("domain") DomainRoute.ResponseDTO domain,
+                             @JsonProperty("resource") ResourceResponseDTO resource,
+                             @JsonProperty("domain") DomainResponseDTO domain,
                              @JsonProperty("teamCalendar") TeamCalendarResponseDTO teamCalendar) {
 
         static EntityResponseDTO forUser(UserRoute.ResponseDTO user) {
             return new EntityResponseDTO(user, null, null, null);
         }
 
-        static EntityResponseDTO forResource(ResourceRoute.ResourceResponseDTO resource) {
+        static EntityResponseDTO forResource(ResourceResponseDTO resource) {
             return new EntityResponseDTO(null, resource, null, null);
         }
 
-        static EntityResponseDTO forDomain(DomainRoute.ResponseDTO domain) {
+        static EntityResponseDTO forDomain(DomainResponseDTO domain) {
             return new EntityResponseDTO(null, null, domain, null);
         }
 
@@ -91,29 +100,129 @@ public class EntityRoute extends CalendarRoute {
         }
     }
 
+    record ResourceResponseDTO(TimestampsDTO timestamps,
+                               boolean deleted,
+                               @JsonProperty("_id") String id,
+                               String name,
+                               String description,
+                               String type,
+                               String icon,
+                               List<AdministratorDTO> administrators,
+                               String creator,
+                               DomainDTO domain) {
+
+        record AdministratorDTO(@JsonProperty("id") String idRef,
+                                @JsonProperty("objectType") String objectType) {
+
+            static AdministratorDTO from(ResourceAdministrator entity) {
+                return new AdministratorDTO(entity.refId().value(), entity.objectType());
+            }
+
+            @JsonProperty("_id")
+            public String getId() {
+                return idRef;
+            }
+        }
+
+        static ResourceResponseDTO from(Resource resource, DomainDTO domain) {
+            List<AdministratorDTO> administrators = CollectionUtils.emptyIfNull(resource.administrators())
+                .stream()
+                .map(AdministratorDTO::from)
+                .toList();
+
+            return new ResourceResponseDTO(new TimestampsDTO(resource.creation(), resource.updated()),
+                resource.deleted(), resource.id().value(), resource.name(), resource.description(),
+                resource.type(), resource.icon(), administrators, resource.creator().value(), domain);
+        }
+    }
+
     record TeamCalendarResponseDTO(TimestampsDTO timestamps,
                                    @JsonProperty("_id") String id,
                                    String name,
                                    String displayName,
-                                   DomainRoute.ResponseDTO domain) {
+                                   DomainDTO domain) {
 
-        @JsonProperty("__v")
-        public int getVersion() {
-            return 0;
-        }
-
-        record TimestampsDTO(
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
-            Instant creation,
-
-            @JsonInclude(JsonInclude.Include.NON_NULL)
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
-            Instant updatedAt) {
-        }
-
-        static TeamCalendarResponseDTO from(TeamCalendar teamCalendar, DomainRoute.ResponseDTO domain) {
+        static TeamCalendarResponseDTO from(TeamCalendar teamCalendar, DomainDTO domain) {
             return new TeamCalendarResponseDTO(new TimestampsDTO(teamCalendar.creation(), teamCalendar.updated()),
                 teamCalendar.id().value(), teamCalendar.name(), teamCalendar.displayName(), domain);
+        }
+    }
+
+    record TimestampsDTO(
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+        Instant creation,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+        Instant updatedAt) {
+    }
+
+    public static class DomainDTO {
+        private final OpenPaaSDomain domain;
+
+        DomainDTO(OpenPaaSDomain domain) {
+            this.domain = domain;
+        }
+
+        @JsonProperty("timestamps")
+        public Timestamp getTimestamps() {
+            return new Timestamp();
+        }
+
+        @JsonProperty("hostnames")
+        public ImmutableList<String> getHostnames() {
+            return ImmutableList.of(domain.domain().asString());
+        }
+
+        @JsonProperty("_id")
+        public String getId() {
+            return domain.id().value();
+        }
+
+        @JsonProperty("name")
+        public String getName() {
+            return domain.domain().asString();
+        }
+
+        @JsonProperty("company_name")
+        public String getCompanyName() {
+            return domain.domain().asString();
+        }
+    }
+
+    public static class DomainResponseDTO extends DomainDTO {
+        private final ImmutableList<AdministratorDTO> admins;
+
+        public record AdministratorDTO(@JsonProperty("user_id") String userId) {
+
+            static AdministratorDTO from(DomainAdministrator admin) {
+                return new AdministratorDTO(admin.userId().value());
+            }
+
+            @JsonProperty("timestamps")
+            public Timestamp getTimestamps() {
+                return new Timestamp();
+            }
+        }
+
+        DomainResponseDTO(OpenPaaSDomain domain, List<DomainAdministrator> adminList) {
+            super(domain);
+            this.admins = adminList.stream()
+                .map(AdministratorDTO::from)
+                .collect(ImmutableList.toImmutableList());
+        }
+
+        @JsonProperty("administrators")
+        public ImmutableList<AdministratorDTO> getAdministrators() {
+            return admins;
+        }
+    }
+
+    public static class Timestamp {
+        @JsonProperty("creation")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
+        public ZonedDateTime getCreation() {
+            return ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
         }
     }
 
@@ -168,7 +277,7 @@ public class EntityRoute extends CalendarRoute {
     private Mono<EntityResponseDTO> asResourceEntity(String id, MailboxSession session) {
         return resourceDAO.findById(new ResourceId(id))
             .flatMap(resource -> retrieveAuthorizedDomainResponse(resource.domain(), session)
-                .map(domain -> EntityResponseDTO.forResource(ResourceRoute.ResourceResponseDTO.from(resource, domain))));
+                .map(domain -> EntityResponseDTO.forResource(ResourceResponseDTO.from(resource, domain))));
     }
 
     private Mono<EntityResponseDTO> asUserEntity(String id, MailboxSession session) {
@@ -198,12 +307,16 @@ public class EntityRoute extends CalendarRoute {
             .map(tuple -> new UserRoute.ResponseDTO(user, tuple.getT1().id(), tuple.getT2().zoneId().toString()));
     }
 
-    private Mono<DomainRoute.ResponseDTO> retrieveAuthorizedDomainResponse(OpenPaaSId domainId, MailboxSession session) {
+    private Mono<OpenPaaSDomain> retrieveAuthorizedDomain(OpenPaaSId domainId, MailboxSession session) {
         return domainDAO.retrieve(domainId)
             .filter(domain -> !crossDomainAccessControl.denies(session, domain.domain()))
-            .switchIfEmpty(Mono.error(NotFoundException::new))
-            .flatMap(domain -> domainAdminDAO.listAdmins(domainId)
+            .switchIfEmpty(Mono.error(NotFoundException::new));
+    }
+
+    private Mono<DomainResponseDTO> retrieveAuthorizedDomainResponse(OpenPaaSId domainId, MailboxSession session) {
+        return retrieveAuthorizedDomain(domainId, session)
+            .flatMap(domain -> domainAdminDAO.listAdmins(domain.id())
                 .collectList()
-                .map(adminList -> new DomainRoute.ResponseDTO(domain, adminList)));
+                .map(adminList -> new DomainResponseDTO(domain, adminList)));
     }
 }

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EntityRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EntityRoute.java
@@ -153,9 +153,9 @@ public class EntityRoute extends CalendarRoute {
     @Override
     Mono<Void> handleRequest(HttpServerRequest req, HttpServerResponse res, MailboxSession session) {
         String id = req.param(ENTITY_ID_PATH_PARAM);
-        return asResourceEntity(id, session)
-            .switchIfEmpty(asUserEntity(id, session))
+        return asUserEntity(id, session)
             .switchIfEmpty(asTeamCalendarEntity(id, session))
+            .switchIfEmpty(asResourceEntity(id, session))
             .switchIfEmpty(asDomainEntity(id, session))
             .switchIfEmpty(Mono.error(NotFoundException::new))
             .map(Throwing.function(OBJECT_MAPPER::writeValueAsBytes))

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EntityRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EntityRoute.java
@@ -1,0 +1,209 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import java.time.Instant;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.apache.james.jmap.Endpoint;
+import org.apache.james.jmap.http.Authenticator;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.metrics.api.MetricFactory;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.fge.lambdas.Throwing;
+import com.linagora.calendar.restapi.NotFoundException;
+import com.linagora.calendar.storage.OpenPaaSDomainAdminDAO;
+import com.linagora.calendar.storage.OpenPaaSDomainDAO;
+import com.linagora.calendar.storage.OpenPaaSId;
+import com.linagora.calendar.storage.OpenPaaSUser;
+import com.linagora.calendar.storage.OpenPaaSUserDAO;
+import com.linagora.calendar.storage.ResourceDAO;
+import com.linagora.calendar.storage.TeamCalendarRepository;
+import com.linagora.calendar.storage.configuration.resolver.SettingsBasedResolver;
+import com.linagora.calendar.storage.model.ResourceId;
+import com.linagora.calendar.storage.model.TeamCalendar;
+import com.linagora.calendar.storage.model.TeamCalendarId;
+
+import io.netty.handler.codec.http.HttpMethod;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.server.HttpServerRequest;
+import reactor.netty.http.server.HttpServerResponse;
+
+/**
+ * Aggregates the {@code /api/resources/{id}}, {@code /api/users/{id}}, {@code /api/domains/{id}}
+ * and {@code /api/team-calendars/{id}} lookups behind a single {@code /api/entity/{id}} endpoint.
+ * The returned object wraps the matched entity under a discriminating key: {@code user}, {@code resource},
+ * {@code domain} or {@code teamCalendar}. A missing or cross-domain-forbidden id yields a 404.
+ */
+public class EntityRoute extends CalendarRoute {
+    private static final String ENTITY_ID_PATH_PARAM = "id";
+
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .registerModule(new Jdk8Module())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record EntityResponseDTO(@JsonProperty("user") UserRoute.ResponseDTO user,
+                             @JsonProperty("resource") ResourceRoute.ResourceResponseDTO resource,
+                             @JsonProperty("domain") DomainRoute.ResponseDTO domain,
+                             @JsonProperty("teamCalendar") TeamCalendarResponseDTO teamCalendar) {
+
+        static EntityResponseDTO forUser(UserRoute.ResponseDTO user) {
+            return new EntityResponseDTO(user, null, null, null);
+        }
+
+        static EntityResponseDTO forResource(ResourceRoute.ResourceResponseDTO resource) {
+            return new EntityResponseDTO(null, resource, null, null);
+        }
+
+        static EntityResponseDTO forDomain(DomainRoute.ResponseDTO domain) {
+            return new EntityResponseDTO(null, null, domain, null);
+        }
+
+        static EntityResponseDTO forTeamCalendar(TeamCalendarResponseDTO teamCalendar) {
+            return new EntityResponseDTO(null, null, null, teamCalendar);
+        }
+    }
+
+    record TeamCalendarResponseDTO(TimestampsDTO timestamps,
+                                   @JsonProperty("_id") String id,
+                                   String name,
+                                   String displayName,
+                                   DomainRoute.ResponseDTO domain) {
+
+        @JsonProperty("__v")
+        public int getVersion() {
+            return 0;
+        }
+
+        record TimestampsDTO(
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+            Instant creation,
+
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+            Instant updatedAt) {
+        }
+
+        static TeamCalendarResponseDTO from(TeamCalendar teamCalendar, DomainRoute.ResponseDTO domain) {
+            return new TeamCalendarResponseDTO(new TimestampsDTO(teamCalendar.creation(), teamCalendar.updated()),
+                teamCalendar.id().value(), teamCalendar.name(), teamCalendar.displayName(), domain);
+        }
+    }
+
+    private final ResourceDAO resourceDAO;
+    private final OpenPaaSUserDAO userDAO;
+    private final OpenPaaSDomainDAO domainDAO;
+    private final OpenPaaSDomainAdminDAO domainAdminDAO;
+    private final TeamCalendarRepository teamCalendarRepository;
+    private final SettingsBasedResolver settingsResolver;
+    private final CrossDomainAccessControl crossDomainAccessControl;
+
+    @Inject
+    public EntityRoute(Authenticator authenticator,
+                       MetricFactory metricFactory,
+                       ResourceDAO resourceDAO,
+                       OpenPaaSUserDAO userDAO,
+                       OpenPaaSDomainDAO domainDAO,
+                       OpenPaaSDomainAdminDAO domainAdminDAO,
+                       TeamCalendarRepository teamCalendarRepository,
+                       @Named("language_timezone") SettingsBasedResolver settingsResolver,
+                       CrossDomainAccessControl crossDomainAccessControl) {
+        super(authenticator, metricFactory);
+        this.resourceDAO = resourceDAO;
+        this.userDAO = userDAO;
+        this.domainDAO = domainDAO;
+        this.domainAdminDAO = domainAdminDAO;
+        this.teamCalendarRepository = teamCalendarRepository;
+        this.settingsResolver = settingsResolver;
+        this.crossDomainAccessControl = crossDomainAccessControl;
+    }
+
+    @Override
+    Endpoint endpoint() {
+        return new Endpoint(HttpMethod.GET, String.format("/api/entity/{%s}", ENTITY_ID_PATH_PARAM));
+    }
+
+    @Override
+    Mono<Void> handleRequest(HttpServerRequest req, HttpServerResponse res, MailboxSession session) {
+        String id = req.param(ENTITY_ID_PATH_PARAM);
+        return asResourceEntity(id, session)
+            .switchIfEmpty(asUserEntity(id, session))
+            .switchIfEmpty(asTeamCalendarEntity(id, session))
+            .switchIfEmpty(asDomainEntity(id, session))
+            .switchIfEmpty(Mono.error(NotFoundException::new))
+            .map(Throwing.function(OBJECT_MAPPER::writeValueAsBytes))
+            .flatMap(bytes -> res.status(200)
+                .header("Content-Type", "application/json;charset=utf-8")
+                .sendByteArray(Mono.just(bytes))
+                .then());
+    }
+
+    private Mono<EntityResponseDTO> asResourceEntity(String id, MailboxSession session) {
+        return resourceDAO.findById(new ResourceId(id))
+            .flatMap(resource -> retrieveAuthorizedDomainResponse(resource.domain(), session)
+                .map(domain -> EntityResponseDTO.forResource(ResourceRoute.ResourceResponseDTO.from(resource, domain))));
+    }
+
+    private Mono<EntityResponseDTO> asUserEntity(String id, MailboxSession session) {
+        return userDAO.retrieve(new OpenPaaSId(id))
+            .flatMap(user -> {
+                if (crossDomainAccessControl.denies(session, user.username().getDomainPart().get())) {
+                    return Mono.error(NotFoundException::new);
+                }
+                return buildUserResponse(user).map(EntityResponseDTO::forUser);
+            });
+    }
+
+    private Mono<EntityResponseDTO> asTeamCalendarEntity(String id, MailboxSession session) {
+        return teamCalendarRepository.retrieve(new TeamCalendarId(id))
+            .flatMap(teamCalendar -> retrieveAuthorizedDomainResponse(teamCalendar.domainId(), session)
+                .map(domain -> EntityResponseDTO.forTeamCalendar(TeamCalendarResponseDTO.from(teamCalendar, domain))));
+    }
+
+    private Mono<EntityResponseDTO> asDomainEntity(String id, MailboxSession session) {
+        return retrieveAuthorizedDomainResponse(new OpenPaaSId(id), session)
+            .map(EntityResponseDTO::forDomain);
+    }
+
+    private Mono<UserRoute.ResponseDTO> buildUserResponse(OpenPaaSUser user) {
+        return Mono.zip(domainDAO.retrieve(user.username().getDomainPart().get()),
+                settingsResolver.resolveOrDefault(user.username()))
+            .map(tuple -> new UserRoute.ResponseDTO(user, tuple.getT1().id(), tuple.getT2().zoneId().toString()));
+    }
+
+    private Mono<DomainRoute.ResponseDTO> retrieveAuthorizedDomainResponse(OpenPaaSId domainId, MailboxSession session) {
+        return domainDAO.retrieve(domainId)
+            .filter(domain -> !crossDomainAccessControl.denies(session, domain.domain()))
+            .switchIfEmpty(Mono.error(NotFoundException::new))
+            .flatMap(domain -> domainAdminDAO.listAdmins(domainId)
+                .collectList()
+                .map(adminList -> new DomainRoute.ResponseDTO(domain, adminList)));
+    }
+}

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ResourceRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ResourceRoute.java
@@ -95,6 +95,17 @@ public class ResourceRoute extends CalendarRoute {
                 return idRef;
             }
         }
+
+        static ResourceResponseDTO from(Resource resource, DomainRoute.ResponseDTO domain) {
+            List<AdministratorDTO> administrators = CollectionUtils.emptyIfNull(resource.administrators())
+                .stream()
+                .map(AdministratorDTO::from)
+                .toList();
+
+            return new ResourceResponseDTO(new TimestampsDTO(resource.creation(), resource.updated()),
+                resource.deleted(), resource.id().value(), resource.name(), resource.description(),
+                resource.type(), resource.icon(), administrators, resource.creator().value(), domain);
+        }
     }
 
     private final ResourceDAO resourceDAO;
@@ -126,7 +137,7 @@ public class ResourceRoute extends CalendarRoute {
         return resourceDAO.findById(resourceId)
             .switchIfEmpty(Mono.error(NotFoundException::new))
             .flatMap(resource -> retrieveAuthorizedDomainResponse(resource.domain(), session)
-                .map(domainResponse -> buildResponseDTO(resource, domainResponse)))
+                .map(domainResponse -> ResourceResponseDTO.from(resource, domainResponse)))
             .map(Throwing.function(OBJECT_MAPPER::writeValueAsBytes))
             .flatMap(bytes -> res.status(200)
                 .header("Content-Type", "application/json;charset=utf-8")
@@ -145,19 +156,5 @@ public class ResourceRoute extends CalendarRoute {
         return domainAdminDAO.listAdmins(domainId)
             .collectList()
             .map(adminList -> new DomainRoute.ResponseDTO(domain, adminList));
-    }
-
-    private ResourceResponseDTO buildResponseDTO(Resource resource,  DomainRoute.ResponseDTO domainResponseDTO) {
-        List<ResourceResponseDTO.AdministratorDTO> administrators = CollectionUtils.emptyIfNull(resource.administrators())
-            .stream()
-            .map(ResourceResponseDTO.AdministratorDTO::from)
-            .toList();
-
-        ResourceResponseDTO.TimestampsDTO timestampsDTO = new ResourceResponseDTO.TimestampsDTO(resource.creation(), resource.updated());
-
-        return new ResourceResponseDTO(timestampsDTO, resource.deleted(), resource.id().value(),
-            resource.name(), resource.description(), resource.type(), resource.icon(),
-            administrators, resource.creator().value(),
-            domainResponseDTO);
     }
 }

--- a/docs/apis/openpaasApi.md
+++ b/docs/apis/openpaasApi.md
@@ -588,6 +588,70 @@ Will return
 
 Most fields are hard coded to please the SPAs.
 
+### GET /api/entity/{id}
+
+```
+GET /api/entity/{id}
+```
+
+Aggregates `GET /api/resources/{id}`, `GET /api/users/{id}`, `GET /api/domains/{id}` and
+`GET /api/team-calendars/{id}` behind a single endpoint. It resolves the type of the entity from its id and
+returns the matching entity wrapped under a discriminating key: `user`, `resource`, `domain` or `teamCalendar`.
+The wrapped payload is identical to the one served by the corresponding dedicated endpoint.
+
+Cross-domain access is denied: a non-existent id, or an entity belonging to a domain the authenticated user may
+not access, returns a `404`.
+
+A user response:
+
+```json
+{
+  "user": {
+    "preferredEmail": "btellier@linagora.com",
+    "_id": "abcdef",
+    "objectType": "user",
+    "...": "..."
+  }
+}
+```
+
+A resource response:
+
+```json
+{
+  "resource": {
+    "_id": "abc123",
+    "name": "Meeting Room A",
+    "...": "..."
+  }
+}
+```
+
+A domain response:
+
+```json
+{
+  "domain": {
+    "_id": "abc123",
+    "name": "linagora.com",
+    "...": "..."
+  }
+}
+```
+
+A team calendar response:
+
+```json
+{
+  "teamCalendar": {
+    "_id": "abc123",
+    "name": "engineering",
+    "displayName": "Engineering Team",
+    "...": "..."
+  }
+}
+```
+
 ### GET /api/technicalToken/introspect
 
 Technical tokes are used by the side service to interact with Sabre (this is mandatory for resource management and


### PR DESCRIPTION
Closes #980

Adds a single `GET /api/entity/{id}` endpoint that aggregates the existing `GET /api/resources/{id}`, `GET /api/users/{id}`, `GET /api/domains/{id}` and `GET /api/team-calendars/{id}` lookups.

It resolves the type of an entity from its id and returns the matching entity wrapped under a discriminating key, reusing the DTOs already served by the dedicated endpoints:

- `{"user": {...}}`
- `{"resource": {...}}`
- `{"domain": {...}}`
- `{"teamCalendar": {...}}`

Cross-domain access control is preserved: a missing id, or an entity from a domain the authenticated user may not access, returns `404` (admins bypass the check, as elsewhere).

### Notes

- The team-calendar branch mirrors the response shape proposed in #979 (ISSUE-978). That PR is still open, so this route carries its own `TeamCalendarResponseDTO` for now; the two can be consolidated once #979 lands.
- `ResourceRoute` was refactored to expose a static `ResourceResponseDTO.from(...)` factory so the entity route reuses the exact same serialization.

### Acceptance

- [x] Implementation (`EntityRoute`, registered in `RestApiModule`)
- [x] Test class (`EntityRouteTest`, new class, 8 tests)
- [x] Documentation in `openpaasApi.md`

---
*Generated automatically*
