### PR TITLE
chore - test(tests): replace fixed sleeps with Awaitility waits negative

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/AlarmEventSchedulerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/AlarmEventSchedulerTest.java
@@ -53,7 +53,7 @@ import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.CalDavEventRepository;
 import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.DavTestHelper;
-import com.linagora.calendar.dav.Fixture;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.scheduling.AlarmEventSchedulerConfiguration;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
@@ -178,7 +178,7 @@ public class AlarmEventSchedulerTest {
         // Given
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        Fixture.awaitAtMost.untilAsserted(() ->
+        awaitAtMost.untilAsserted(() ->
             assertThat(alarmStore.find(eventUid, organizer.username().asString())).isPresent());
 
         clearSmtpInbox();
@@ -190,7 +190,7 @@ public class AlarmEventSchedulerTest {
 
         Supplier<JsonPath> smtpMailsResponseSupplier = () -> given(mockSMTPRequestSpecification()).get("/smtpMails").jsonPath();
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             JsonPath jp = smtpMailsResponseSupplier.get();
             assertThat(jp.getList("")).hasSize(1);
             String organizerAddr = organizer.username().asString();
@@ -201,7 +201,7 @@ public class AlarmEventSchedulerTest {
                 .contains("Subject: Notification: Twake Calendar - Sprint planning #04");
         });
 
-        Fixture.awaitAtMost.untilAsserted(() ->
+        awaitAtMost.untilAsserted(() ->
             assertThat(alarmStore.find(eventUid, organizer.username().asString())).isEmpty());
     }
 
@@ -242,7 +242,7 @@ public class AlarmEventSchedulerTest {
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
         // Update attendee participation status
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             assertThatCode(() -> {
                 calDavEventRepository.updatePartStat(attendee1.username(), attendee1.id(), eventUid, PartStat.ACCEPTED).block();
                 calDavEventRepository.updatePartStat(attendee2.username(), attendee2.id(), eventUid, PartStat.ACCEPTED).block();
@@ -251,7 +251,7 @@ public class AlarmEventSchedulerTest {
         });
 
         // Then (DB state before trigger)
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             assertThat(alarmStore.find(eventUid.value(), attendee1.username().asString())).isPresent();
             assertThat(alarmStore.find(eventUid.value(), attendee2.username().asString())).isPresent();
             assertThat(alarmStore.find(eventUid.value(), attendee3.username().asString())).isEmpty(); // DECLINED
@@ -268,7 +268,7 @@ public class AlarmEventSchedulerTest {
 
         // Then (emails should be sent only to accepted attendees)
         String alarmEmailSubjectExpected = "Subject: Notification: Twake Calendar - Sprint planning #04";
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             JsonPath jp = smtpMailsResponseSupplier.get();
 
             // Attendee1
@@ -285,7 +285,7 @@ public class AlarmEventSchedulerTest {
         });
 
         // Then (cleanup: alarms removed after sending)
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             assertThat(alarmStore.find(eventUid.value(), attendee1.username().asString())).isEmpty();
             assertThat(alarmStore.find(eventUid.value(), attendee2.username().asString())).isEmpty();
         });

--- a/app/src/test/java/com/linagora/calendar/app/DisplayAlarmWebsocketFlowIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/DisplayAlarmWebsocketFlowIntegrationTest.java
@@ -61,7 +61,7 @@ import com.linagora.calendar.api.CalendarUtil;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.DavTestHelper;
-import com.linagora.calendar.dav.Fixture;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.scheduling.AlarmEventSchedulerConfiguration;
@@ -185,7 +185,7 @@ class DisplayAlarmWebsocketFlowIntegrationTest {
         davTestHelper.upsertCalendar(bob, ics, eventUid);
 
         // Wait for alarm event to be created
-        Fixture.awaitAtMost
+        awaitAtMost
             .untilAsserted(() -> {
                 Optional<AlarmEvent> alarmEventOpt = alarmStore.find(eventUid, bob.username().asString());
                 assertThat(alarmEventOpt).isPresent();
@@ -211,7 +211,7 @@ class DisplayAlarmWebsocketFlowIntegrationTest {
         clock.setInstant(start.minus(TRIGGER).plusSeconds(1).toInstant());
 
         // THEN: Bob receives the alarm notification via WebSocket
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             String alarmMessage = awaitMessage(messages, msg -> msg.contains("eventSummary"));
             String expected = """
                 {
@@ -241,7 +241,7 @@ class DisplayAlarmWebsocketFlowIntegrationTest {
         davTestHelper.upsertCalendar(alice, ics, eventUid);
 
         // Wait for Alice's alarm event to be created
-        Fixture.awaitAtMost
+        awaitAtMost
             .untilAsserted(() -> {
                 Optional<AlarmEvent> alarmEventOpt = alarmStore.find(eventUid, alice.username().asString());
                 assertThat(alarmEventOpt).isPresent();
@@ -276,7 +276,7 @@ class DisplayAlarmWebsocketFlowIntegrationTest {
             clock.setInstant(start.minus(TRIGGER).plusSeconds(1).toInstant());
 
             // THEN: Alice should receive her alarm notification
-            Fixture.awaitAtMost.untilAsserted(() -> {
+            awaitAtMost.untilAsserted(() -> {
                 String aliceAlarmMessage = awaitMessage(aliceMessages, msg -> msg.contains("eventSummary"));
                 assertThatJson(aliceAlarmMessage)
                     .node("alarms[0].eventSummary")

--- a/app/src/test/java/com/linagora/calendar/app/SaaSSubscriptionIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/SaaSSubscriptionIntegrationTest.java
@@ -55,7 +55,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.Fixture;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.saas.TWPCalendarSubscriptionModule;
 import com.linagora.calendar.storage.OpenPaaSUser;
@@ -148,7 +148,7 @@ class SaaSSubscriptionIntegrationTest {
             .setBasePath("/")
             .build();
 
-        Fixture.awaitAtMost.untilAsserted(() -> given(webadminRequestSpecification)
+        awaitAtMost.untilAsserted(() -> given(webadminRequestSpecification)
             .get("/healthcheck")
             .then()
             .statusCode(200)
@@ -178,7 +178,7 @@ class SaaSSubscriptionIntegrationTest {
         String message = createDomainSubscriptionMessage(domainName);
         publishDomainSubscriptionMessage(message);
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             assertThat(server.getProbe(CalendarDataProbe.class).domainId(Domain.of(domainName))).isNotNull();
         });
     }
@@ -190,14 +190,14 @@ class SaaSSubscriptionIntegrationTest {
 
         // First create the domain
         publishDomainSubscriptionMessage(createDomainSubscriptionMessage(domainName));
-        Fixture.awaitAtMost.untilAsserted(() ->
+        awaitAtMost.untilAsserted(() ->
             assertThat(server.getProbe(CalendarDataProbe.class).domainId(Domain.of(domainName))).isNotNull());
 
         // Then create the user
         String userMessage = createUserSubscriptionMessage(userEmail);
         publishUserSubscriptionMessage(userMessage);
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             OpenPaaSUser user = server.getProbe(CalendarDataProbe.class).getUser(Username.of(userEmail));
             assertThat(user).isNotNull();
             assertThat(user.username().asString()).isEqualTo(userEmail);
@@ -215,7 +215,7 @@ class SaaSSubscriptionIntegrationTest {
         publishDomainSubscriptionMessage(createDomainSubscriptionMessage(domain1));
         publishDomainSubscriptionMessage(createDomainSubscriptionMessage(domain2));
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             assertThat(server.getProbe(CalendarDataProbe.class).domainId(Domain.of(domain1))).isNotNull();
             assertThat(server.getProbe(CalendarDataProbe.class).domainId(Domain.of(domain2))).isNotNull();
         });
@@ -224,7 +224,7 @@ class SaaSSubscriptionIntegrationTest {
         publishUserSubscriptionMessage(createUserSubscriptionMessage(user1));
         publishUserSubscriptionMessage(createUserSubscriptionMessage(user2));
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             assertThat(server.getProbe(CalendarDataProbe.class).getUser(Username.of(user1))).isNotNull();
             assertThat(server.getProbe(CalendarDataProbe.class).getUser(Username.of(user2))).isNotNull();
         });
@@ -239,13 +239,13 @@ class SaaSSubscriptionIntegrationTest {
         String domainName = "after-invalid-" + UUID.randomUUID() + ".tld";
         publishDomainSubscriptionMessage(createDomainSubscriptionMessage(domainName));
 
-        Fixture.awaitAtMost.untilAsserted(() ->
+        awaitAtMost.untilAsserted(() ->
             assertThat(server.getProbe(CalendarDataProbe.class).domainId(Domain.of(domainName))).isNotNull());
     }
 
     @Test
     void shouldExposeWebAdminHealthcheck() {
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             String body = given(webadminRequestSpecification)
                 .when()
                 .get("/healthcheck")

--- a/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/ScheduledReconnectionHandlerTest.java
@@ -31,8 +31,8 @@ import org.apache.james.utils.GuiceProbe;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.multibindings.Multibinder;

--- a/app/src/test/java/com/linagora/calendar/app/TWPSyncSettingsIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TWPSyncSettingsIntegrationTest.java
@@ -260,6 +260,8 @@ class TWPSyncSettingsIntegrationTest {
 
         // publish AMQP message for non-existing user
         publishAmqpSettingsMessage(createSettingsUpdateMessage(unknownUser, Map.of(LANGUAGE_KEY, LANGUAGE_FR), FIRST_VERSION));
+        // Wait a bit for consumer to process & error handling to complete
+        Thread.sleep(500);
 
         // publish a valid message for an existing user
         publishAmqpSettingsMessage(createSettingsUpdateMessage(USERNAME, Map.of(LANGUAGE_KEY, LANGUAGE_FR), FIRST_VERSION + 1));

--- a/app/src/test/java/com/linagora/calendar/app/TWPSyncSettingsIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/TWPSyncSettingsIntegrationTest.java
@@ -49,7 +49,7 @@ import com.google.inject.Inject;
 import com.google.inject.multibindings.Multibinder;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.DavModuleTestHelper;
-import com.linagora.calendar.dav.Fixture;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.saas.TWPCalendarSettingsModule;
 import com.linagora.tmail.saas.rabbitmq.settings.TWPSettingsConsumer;
@@ -144,7 +144,7 @@ class TWPSyncSettingsIntegrationTest {
             .setBasePath("/")
             .build();
 
-        Fixture.awaitAtMost.untilAsserted(() -> given(webadminRequestSpecification)
+        awaitAtMost.untilAsserted(() -> given(webadminRequestSpecification)
             .get("/healthcheck")
         .then()
             .statusCode(200)
@@ -162,7 +162,7 @@ class TWPSyncSettingsIntegrationTest {
         String message = createSettingsUpdateMessage(USERNAME, Map.of(LANGUAGE_KEY, LANGUAGE_FR), FIRST_VERSION);
         publishAmqpSettingsMessage(message);
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             given()
                 .body(QUERY_LANGUAGE)
             .when()
@@ -201,7 +201,7 @@ class TWPSyncSettingsIntegrationTest {
         publishAmqpSettingsMessage(message);
 
         // Then: verify language is updated AND timezone is preserved
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             String updatedResponseJson =
                 given()
                     .body("""
@@ -230,27 +230,28 @@ class TWPSyncSettingsIntegrationTest {
     }
 
     @Test
-    void shouldApplyHighestVersionWhenMessagesArriveOutOfOrder() throws InterruptedException {
+    void shouldApplyHighestVersionWhenMessagesArriveOutOfOrder() {
         // When: publish out-of-order AMQP messages
         publishAmqpSettingsMessage(createSettingsUpdateMessage(USERNAME, Map.of(LANGUAGE_KEY, LANGUAGE_EN), FIRST_VERSION + 1));
         publishAmqpSettingsMessage(createSettingsUpdateMessage(USERNAME, Map.of(LANGUAGE_KEY, LANGUAGE_FR), FIRST_VERSION + 2));
         publishAmqpSettingsMessage(createSettingsUpdateMessage(USERNAME, Map.of(LANGUAGE_KEY, "vi"), FIRST_VERSION));
 
         // Then: wait until consumer finishes and highest version is applied
-        Thread.sleep(2000);
-        String responseJson =
-            given()
-                .body(QUERY_LANGUAGE)
-            .when()
-                .post("/api/configurations")
-            .then()
-                .statusCode(200)
-                .extract()
-                .asString();
+        awaitAtMost.untilAsserted(() -> {
+            String responseJson =
+                given()
+                    .body(QUERY_LANGUAGE)
+                .when()
+                    .post("/api/configurations")
+                .then()
+                    .statusCode(200)
+                    .extract()
+                    .asString();
 
-        String finalLanguage = JsonPath.from(responseJson)
-            .getString("[0].configurations.find { it.name == 'language' }.value");
-        assertThat(finalLanguage).isEqualTo(LANGUAGE_FR);
+            String finalLanguage = JsonPath.from(responseJson)
+                .getString("[0].configurations.find { it.name == 'language' }.value");
+            assertThat(finalLanguage).isEqualTo(LANGUAGE_FR);
+        });
     }
 
     @Test
@@ -259,14 +260,12 @@ class TWPSyncSettingsIntegrationTest {
 
         // publish AMQP message for non-existing user
         publishAmqpSettingsMessage(createSettingsUpdateMessage(unknownUser, Map.of(LANGUAGE_KEY, LANGUAGE_FR), FIRST_VERSION));
-        // Wait a bit for consumer to process & error handling to complete
-        Thread.sleep(500);
 
         // publish a valid message for an existing user
         publishAmqpSettingsMessage(createSettingsUpdateMessage(USERNAME, Map.of(LANGUAGE_KEY, LANGUAGE_FR), FIRST_VERSION + 1));
 
         // Then
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             String responseJson =
                 given()
                     .body(QUERY_LANGUAGE)
@@ -388,7 +387,7 @@ class TWPSyncSettingsIntegrationTest {
 
     @Test
     void shouldExposeWebAdminHealthcheck() {
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             String body = given(webadminRequestSpecification)
             .when()
                 .get("/healthcheck")

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/BookingLinkCreateRouteTest.java
@@ -18,7 +18,7 @@
 
 package com.linagora.calendar.app.restapi.routes;
 
-import static com.linagora.calendar.dav.Fixture.awaitAtMost;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.with;

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
@@ -19,7 +19,7 @@
 package com.linagora.calendar.app.restapi.routes;
 
 import static com.linagora.calendar.app.restapi.routes.ImportRouteTest.mailSenderConfigurationFunction;
-import static com.linagora.calendar.dav.Fixture.awaitAtMost;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -476,10 +477,13 @@ class EventParticipationRouteTest {
                 .jsonPath()
                 .getMap("links");
 
-            Thread.sleep(1000);
             jwtYesSet.add(extractJwtFromUrl(links.get("yes")));
             jwtNoSet.add(extractJwtFromUrl(links.get("no")));
             jwtMaybeSet.add(extractJwtFromUrl(links.get("maybe")));
+            long generatedAtSecond = Instant.now().getEpochSecond();
+            Awaitility.await()
+                .atMost(Duration.ofSeconds(2))
+                .until(() -> Instant.now().getEpochSecond() > generatedAtSecond);
         }
 
         assertSoftly(softly -> {

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/EventParticipationRouteTest.java
@@ -36,7 +36,6 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -480,10 +479,7 @@ class EventParticipationRouteTest {
             jwtYesSet.add(extractJwtFromUrl(links.get("yes")));
             jwtNoSet.add(extractJwtFromUrl(links.get("no")));
             jwtMaybeSet.add(extractJwtFromUrl(links.get("maybe")));
-            long generatedAtSecond = Instant.now().getEpochSecond();
-            Awaitility.await()
-                .atMost(Duration.ofSeconds(2))
-                .until(() -> Instant.now().getEpochSecond() > generatedAtSecond);
+            Thread.sleep(1000);
         }
 
         assertSoftly(softly -> {

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteSharedCalendarTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteSharedCalendarTest.java
@@ -20,7 +20,7 @@ package com.linagora.calendar.app.restapi.routes;
 
 import static com.linagora.calendar.app.AppTestHelper.OPENSEARCH_TEST_MODULE;
 import static com.linagora.calendar.dav.DavModuleTestHelper.FROM_SABRE_EXTENSION;
-import static com.linagora.calendar.dav.Fixture.awaitAtMost;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/OpensearchDavCalendarSearchRouteTest.java
@@ -21,6 +21,7 @@ package com.linagora.calendar.app.restapi.routes;
 import static com.linagora.calendar.app.AppTestHelper.OPENSEARCH_TEST_MODULE;
 import static com.linagora.calendar.dav.DavModuleTestHelper.FROM_SABRE_EXTENSION;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
@@ -51,7 +52,6 @@ import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.DavCalendarObject;
 import com.linagora.calendar.dav.DavTestHelper;
-import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.OpenPaaSUser;
 
@@ -308,7 +308,7 @@ class OpensearchDavCalendarSearchRouteTest implements CalendarSearchRouteContrac
             }
             """.formatted(openPaasUser.id().value(), openPaasUser.id().value(), summary);
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             String actualHref = given()
                 .auth().preemptive()
                 .basic(openPaasUser.username().asString(), PASSWORD)

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/ResourceParticipationRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/ResourceParticipationRouteTest.java
@@ -20,6 +20,7 @@ package com.linagora.calendar.app.restapi.routes;
 
 import static com.linagora.calendar.app.restapi.routes.ImportRouteTest.mailSenderConfigurationFunction;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.RedirectConfig.redirectConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
@@ -66,7 +67,6 @@ import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.DavCalendarObject;
 import com.linagora.calendar.dav.DavModuleTestHelper;
 import com.linagora.calendar.dav.DavTestHelper;
-import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.dav.SabreDavProvisioningService;
 import com.linagora.calendar.restapi.RestApiServerProbe;
@@ -193,7 +193,7 @@ public class ResourceParticipationRouteTest {
         .then()
             .statusCode(302);
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             VEvent vEvent = getCalendarEvent(organizer, eventUid);
             EventFields.Person resourceAttendee = EventParseUtils.getResources(vEvent).getFirst();
             assertThat(resourceAttendee)
@@ -272,7 +272,7 @@ public class ResourceParticipationRouteTest {
         String eventUidA = UUID.randomUUID().toString();
 
         davTestHelper.upsertCalendar(organizer, generateCalendarData(eventUidA, resourceEmailA), eventUidA);
-        Fixture.awaitAtMost.untilAsserted(() ->
+        awaitAtMost.untilAsserted(() ->
             assertThat(davTestHelper.findFirstEventId(resourceIdA, resource.domain())).isPresent());
 
         String eventPathIdA = davTestHelper.findFirstEventId(resourceIdA, resource.domain()).get();
@@ -313,7 +313,7 @@ public class ResourceParticipationRouteTest {
         .then()
             .statusCode(302);
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             VEvent vEvent = getCalendarEvent(organizer, eventUid);
             EventFields.Person resourceAttendee = EventParseUtils.getResources(vEvent).getFirst();
             assertThat(resourceAttendee)
@@ -348,7 +348,7 @@ public class ResourceParticipationRouteTest {
         .then()
             .statusCode(302);
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             VEvent vEvent = getCalendarEvent(organizer, eventUid);
             EventFields.Person resourceAttendee = EventParseUtils.getResources(vEvent).getFirst();
             assertThat(resourceAttendee)
@@ -364,7 +364,7 @@ public class ResourceParticipationRouteTest {
         .then()
             .statusCode(302);
 
-        Fixture.awaitAtMost.untilAsserted(() -> {
+        awaitAtMost.untilAsserted(() -> {
             VEvent vEvent = getCalendarEvent(organizer, eventUid);
             EventFields.Person resourceAttendee = EventParseUtils.getResources(vEvent).getFirst();
             assertThat(resourceAttendee)
@@ -530,7 +530,7 @@ public class ResourceParticipationRouteTest {
     private String createEventAndGetEventPathId(ResourceId resourceId, String eventUid) {
         String resourceEmail = Username.fromLocalPartWithDomain(resourceId.value(), TEST_DOMAIN).asString();
         davTestHelper.upsertCalendar(organizer, generateCalendarData(eventUid, resourceEmail), eventUid);
-        Fixture.awaitAtMost.untilAsserted(() -> assertThat(davTestHelper.findFirstEventId(resourceId, resource.domain())).isPresent());
+        awaitAtMost.untilAsserted(() -> assertThat(davTestHelper.findFirstEventId(resourceId, resource.domain())).isPresent());
         return davTestHelper.findFirstEventId(resourceId, resource.domain()).get();
     }
 }

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/TeamCalendarFlowIntegrationTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/TeamCalendarFlowIntegrationTest.java
@@ -19,7 +19,7 @@ package com.linagora.calendar.app.restapi.routes;
 
 import static com.linagora.calendar.app.AppTestHelper.OPENSEARCH_TEST_MODULE;
 import static com.linagora.calendar.dav.DavModuleTestHelper.FROM_SABRE_EXTENSION;
-import static com.linagora.calendar.dav.Fixture.awaitAtMost;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
@@ -1927,8 +1927,7 @@ class WebsocketRouteTest {
         String calendarUri = calendar.asUri().toString();
         // Trigger an initial esn-Sabre provisioning
         importIcsIntoCalendar(guiceServer, calendar, calendarUri, bob);
-        await().atMost(Duration.ofSeconds(5))
-            .untilAsserted(() -> assertThat(calDavClient.findUserCalendarList(bob).block().calendars()).isNotEmpty());
+        SECONDS.sleep(1);
 
         AddressBookURL addressBook = new AddressBookURL(bob.id(), "collected");
         String addressBookUri = addressBook.asUri().toString();

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/WebsocketRouteTest.java
@@ -1927,7 +1927,8 @@ class WebsocketRouteTest {
         String calendarUri = calendar.asUri().toString();
         // Trigger an initial esn-Sabre provisioning
         importIcsIntoCalendar(guiceServer, calendar, calendarUri, bob);
-        SECONDS.sleep(1);
+        await().atMost(Duration.ofSeconds(5))
+            .untilAsserted(() -> assertThat(calDavClient.findUserCalendarList(bob).block().calendars()).isNotEmpty());
 
         AddressBookURL addressBook = new AddressBookURL(bob.id(), "collected");
         String addressBookUri = addressBook.asUri().toString();

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCreateTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCreateTest.java
@@ -579,6 +579,7 @@ public class AlarmEventCreateTest {
     void shouldNotCrashWhenReceivingInvalidAMQPMessage() throws Exception {
         // Given an invalid AMQP message
         publishMessage(EventAlarmConsumer.Queue.CREATE.exchangeName(), "invalid json");
+        Thread.sleep(1000);
 
         // When: Organizer creates an event with VALARM
         String eventUid = UUID.randomUUID().toString();

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCreateTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/AlarmEventCreateTest.java
@@ -67,6 +67,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.linagora.calendar.api.CalendarUtil;
 import com.linagora.calendar.smtp.EventEmailFilter;
@@ -104,6 +106,11 @@ public class AlarmEventCreateTest {
 
     private static final SettingsBasedResolver settingsResolver = mock(SettingsBasedResolver.class);
     private static final EventEmailFilter eventEmailFilter = spy(EventEmailFilter.acceptAll());
+    private static final ConditionFactory negativeAwait = Awaitility.with()
+        .pollInterval(Duration.ofMillis(200))
+        .pollDelay(Duration.ZERO)
+        .await()
+        .during(Duration.ofSeconds(1));
 
     private static OpenPaaSUserDAO openPaaSUserDAO;
     private static ReactorRabbitMQChannelPool channelPool;
@@ -494,11 +501,11 @@ public class AlarmEventCreateTest {
         // When: Organizer creates an event with VALARM
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        Thread.sleep(1000);
         // Then: No AlarmEvent should be created for the organizer
-        assertThat(alarmEventDAO.find(new EventUid(eventUid),
-            organizer.username().asMailAddress()).blockOptional())
-            .isEmpty();
+        negativeAwait
+            .untilAsserted(() -> assertThat(alarmEventDAO.find(new EventUid(eventUid),
+                organizer.username().asMailAddress()).blockOptional())
+                .isEmpty());
     }
 
 
@@ -527,11 +534,11 @@ public class AlarmEventCreateTest {
         // When: Organizer creates an event with VALARM
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        Thread.sleep(1000);
         // Then: No AlarmEvent should be created for the organizer
-        assertThat(alarmEventDAO.find(new EventUid(eventUid),
-            organizer.username().asMailAddress()).blockOptional())
-            .isEmpty();
+        negativeAwait
+            .untilAsserted(() -> assertThat(alarmEventDAO.find(new EventUid(eventUid),
+                organizer.username().asMailAddress()).blockOptional())
+                .isEmpty());
     }
 
     @Test
@@ -561,19 +568,17 @@ public class AlarmEventCreateTest {
         // When: Organizer creates the event in CalDAV
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        Thread.sleep(1000);
-
         // Then: No AlarmEvent should be created for the external attendee
-        assertThat(alarmEventDAO.find(new EventUid(eventUid), new MailAddress(externalAttendeeEmail))
-            .blockOptional())
-            .isEmpty();
+        negativeAwait
+            .untilAsserted(() -> assertThat(alarmEventDAO.find(new EventUid(eventUid), new MailAddress(externalAttendeeEmail))
+                .blockOptional())
+                .isEmpty());
     }
 
     @Test
     void shouldNotCrashWhenReceivingInvalidAMQPMessage() throws Exception {
         // Given an invalid AMQP message
         publishMessage(EventAlarmConsumer.Queue.CREATE.exchangeName(), "invalid json");
-        Thread.sleep(1000);
 
         // When: Organizer creates an event with VALARM
         String eventUid = UUID.randomUUID().toString();

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
@@ -62,6 +62,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.dav.CalDavClient;
@@ -97,6 +99,11 @@ import io.restassured.specification.RequestSpecification;
 import reactor.core.publisher.Mono;
 
 public class CalendarDelegatedNotificationConsumerTest {
+    private static final ConditionFactory negativeAwait = Awaitility.with()
+        .pollInterval(Duration.ofMillis(200))
+        .pollDelay(Duration.ZERO)
+        .await()
+        .during(Duration.ofSeconds(1));
 
     @RegisterExtension
     @Order(1)
@@ -301,7 +308,7 @@ public class CalendarDelegatedNotificationConsumerTest {
     }
 
     @Test
-    void shouldNotSendMailWhenEventEmailFilterRejects() throws InterruptedException {
+    void shouldNotSendMailWhenEventEmailFilterRejects() {
         when(eventEmailFilter.shouldProcess(any())).thenReturn(false);
 
         String calendarName = "Bob Private FilterTest";
@@ -315,9 +322,8 @@ public class CalendarDelegatedNotificationConsumerTest {
         calDavClient.patchReadWriteDelegations(domain.id(), new CalendarURL(bob.id(), new OpenPaaSId(bobCalendar.id())),
             List.of(alice.username()), List.of()).block();
 
-        Thread.sleep(1000);
         // Then: no mail should be sent
-        awaitAtMost.untilAsserted(() ->
+        negativeAwait.untilAsserted(() ->
             assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
     }
 
@@ -351,7 +357,7 @@ public class CalendarDelegatedNotificationConsumerTest {
     }
 
     @Test
-    void shouldNotSendMailWhenSelfSubscribedToSharedCalendar() throws InterruptedException {
+    void shouldNotSendMailWhenSelfSubscribedToSharedCalendar() {
         // Given: Bob shares calendar with read access
         davTestHelper.updateCalendarAcl(bob, CalendarURL.from(bob.id()).asUri(), "{DAV:}read");
 
@@ -366,9 +372,8 @@ public class CalendarDelegatedNotificationConsumerTest {
         // When: Alice subscribes to the shared calendar herself
         davTestHelper.subscribeToSharedCalendar(alice, subscribedCalendarRequest);
 
-        Thread.sleep(1000);
         // Then: No notification email is sent
-        awaitAtMost.untilAsserted(() ->
+        negativeAwait.untilAsserted(() ->
             assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
     }
 }

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCalendarConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCalendarConsumerTest.java
@@ -42,8 +42,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import org.apache.commons.configuration2.MapConfiguration;
 
@@ -72,6 +72,11 @@ public class EventCalendarConsumerTest {
         .pollDelay(Duration.ofMillis(500))
         .await();
     private final ConditionFactory awaitAtMost = calmlyAwait.atMost(20, TimeUnit.SECONDS);
+    private final ConditionFactory negativeAwait = Awaitility.with()
+        .pollInterval(Duration.ofMillis(200))
+        .pollDelay(Duration.ZERO)
+        .await()
+        .during(Duration.ofSeconds(3));
 
     @RegisterExtension
     static SabreDavExtension sabreDavExtension = SabreDavExtension.shared();
@@ -163,7 +168,7 @@ public class EventCalendarConsumerTest {
     }
 
     @Test
-    void shouldNotSetNonDefaultCalendarPubliclyVisible(DockerSabreDavSetup dockerSabreDavSetup) throws InterruptedException {
+    void shouldNotSetNonDefaultCalendarPubliclyVisible(DockerSabreDavSetup dockerSabreDavSetup) {
         setupConsumer(DEFAULT_CALENDAR_PUBLIC_VISIBILITY);
 
         OpenPaaSUser user = sabreDavExtension.newTestUser();
@@ -177,34 +182,35 @@ public class EventCalendarConsumerTest {
         );
         calDavClient.createNewCalendar(user.username(), user.id(), newCalendar).block();
 
-        Thread.sleep(3000); // wait for the consumer to process the message
+        negativeAwait
+            .untilAsserted(() -> {
+                String actual = davTestHelper.getCalendarMetadata(user, new OpenPaaSId(newCalendarId)).block();
 
-        String actual = davTestHelper.getCalendarMetadata(user, new OpenPaaSId(newCalendarId)).block();
-
-        assertThatJson(actual)
-            .inPath("$.acl")
-            .isArray()
-            .doesNotContain("""
+                assertThatJson(actual)
+                    .inPath("$.acl")
+                    .isArray()
+                    .doesNotContain("""
                     {
                       "privilege": "{DAV:}read",
                       "principal": "{DAV:}authenticated",
                       "protected": true
                     }
                     """);
-        assertThatJson(actual)
-            .inPath("$.acl")
-            .isArray()
-            .contains("""
+                assertThatJson(actual)
+                    .inPath("$.acl")
+                    .isArray()
+                    .contains("""
                     {
                         "privilege": "{urn:ietf:params:xml:ns:caldav}read-free-busy",
                         "principal": "{DAV:}authenticated",
                         "protected": true
                     }
                     """);
+            });
     }
 
     @Test
-    void shouldNotSetDefaultCalendarPubliclyVisibleWhenItIsNotEnabledInConfig(DockerSabreDavSetup dockerSabreDavSetup) throws InterruptedException {
+    void shouldNotSetDefaultCalendarPubliclyVisibleWhenItIsNotEnabledInConfig(DockerSabreDavSetup dockerSabreDavSetup) {
         setupConsumer(DefaultCalendarPublicVisibility.PRIVATE);
 
         OpenPaaSUser user = sabreDavExtension.newTestUser();
@@ -212,30 +218,30 @@ public class EventCalendarConsumerTest {
         // To ensure calendar is activated
         davTestHelper.getCalendarMetadata(user).block();
 
-        Thread.sleep(3000); // wait for the consumer to process the message
+        negativeAwait
+            .untilAsserted(() -> {
+                String actual = davTestHelper.getCalendarMetadata(user).block();
 
-        String actual = davTestHelper.getCalendarMetadata(user).block();
-
-        assertThatJson(actual)
-            .inPath("$.acl")
-            .isArray()
-            .doesNotContain("""
+                assertThatJson(actual)
+                    .inPath("$.acl")
+                    .isArray()
+                    .doesNotContain("""
                     {
                       "privilege": "{DAV:}read",
                       "principal": "{DAV:}authenticated",
                       "protected": true
                     }
                     """);
-        assertThatJson(actual)
-            .inPath("$.acl")
-            .isArray()
-            .contains("""
+                assertThatJson(actual)
+                    .inPath("$.acl")
+                    .isArray()
+                    .contains("""
                     {
                         "privilege": "{urn:ietf:params:xml:ns:caldav}read-free-busy",
                         "principal": "{DAV:}authenticated",
                         "protected": true
                     }
                     """);
+            });
     }
 }
-

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCalendarNotificationConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCalendarNotificationConsumerTest.java
@@ -161,8 +161,8 @@ public class EventCalendarNotificationConsumerTest {
 
         // Verify only the correct listener receives the event
         awaitAtMost.untilAsserted(() -> assertThat(eventReceived.get()).isTrue());
-        Thread.sleep(100);
-        assertThat(eventReceived2.get()).isFalse();
+        awaitAtMost.during(Duration.ofMillis(100))
+            .untilAsserted(() -> assertThat(eventReceived2.get()).isFalse());
     }
 
     private void publishMessage(String exchange, String message) throws IOException {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCancelEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCancelEmailConsumerTest.java
@@ -67,8 +67,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.smtp.EventEmailFilter;

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCounterEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventCounterEmailConsumerTest.java
@@ -64,8 +64,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.smtp.EventEmailFilter;

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventIndexerConsumerTest.java
@@ -59,8 +59,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
@@ -330,12 +330,6 @@ public class EventIndexerConsumerTest {
             .replace("{attendee1}", attendee1.username().asString());
 
         davTestHelper.upsertCalendar(openPaasUser, calendarData, eventUid);
-
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
 
         assertEventExistsInSearch(openPaasUser.username(), summary, eventUid);
 
@@ -1072,7 +1066,7 @@ public class EventIndexerConsumerTest {
         }
 
         @Test
-        void shouldRecoverWhenIndexerFailsTemporarilyDuringIndexing() throws InterruptedException {
+        void shouldRecoverWhenIndexerFailsTemporarilyDuringIndexing() {
             Mockito.doReturn(Mono.defer(() -> Mono.error(new RuntimeException("mock exception"))))
                 .when(calendarSearchService).index(any());
 
@@ -1080,7 +1074,7 @@ public class EventIndexerConsumerTest {
             String calendarData = getSampleCalendar(eventUid);
             davTestHelper.upsertCalendar(openPaasUser, calendarData, eventUid);
 
-            Thread.sleep(500);
+            awaitAtMost.untilAsserted(() -> Mockito.verify(calendarSearchService, Mockito.atLeastOnce()).index(any()));
             Mockito.reset(calendarSearchService);
 
             davTestHelper.upsertCalendar(openPaasUser, calendarData, eventUid);
@@ -1089,7 +1083,7 @@ public class EventIndexerConsumerTest {
         }
 
         @Test
-        void shouldDeleteSuccessfullyAfterTemporaryIndexerFailure() throws InterruptedException {
+        void shouldDeleteSuccessfullyAfterTemporaryIndexerFailure() {
             String eventUid = UUID.randomUUID().toString();
             String calendarData = getSampleCalendar(eventUid);
             davTestHelper.upsertCalendar(openPaasUser, calendarData, eventUid);
@@ -1105,7 +1099,7 @@ public class EventIndexerConsumerTest {
                 .when(calendarSearchService).delete(any(), any());
 
             davTestHelper.deleteCalendar(openPaasUser, eventUid);
-            Thread.sleep(500);
+            awaitAtMost.untilAsserted(() -> Mockito.verify(calendarSearchService, Mockito.atLeastOnce()).delete(any(), any()));
 
             Mockito.reset(calendarSearchService);
             davTestHelper.deleteCalendar(openPaasUser, eventUid2);
@@ -1125,7 +1119,6 @@ public class EventIndexerConsumerTest {
                     amqpMessage.getBytes(UTF_8))))
                 .block();
 
-            Thread.sleep(200);
             String eventUid = UUID.randomUUID().toString();
             String calendarData = getSampleCalendar(eventUid);
             davTestHelper.upsertCalendar(openPaasUser, calendarData, eventUid);

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventInviteEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventInviteEmailConsumerTest.java
@@ -68,8 +68,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.smtp.EventEmailFilter;

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventPublicAgendaEmailConsumerTest.java
@@ -70,8 +70,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.linagora.calendar.api.EventParticipationActionLinkFactory;
 import com.linagora.calendar.api.Participation;

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
@@ -74,8 +74,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.api.EventParticipationActionLinkFactory;
@@ -85,7 +85,6 @@ import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.CalDavEventRepository;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
-import com.linagora.calendar.dav.Fixture;
 import com.linagora.calendar.smtp.EventEmailFilter;
 import com.linagora.calendar.smtp.MailSender;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
@@ -120,6 +119,11 @@ public class EventReplyEmailConsumerTest {
         .pollDelay(Duration.ofMillis(500))
         .await();
     private final ConditionFactory awaitAtMost = calmlyAwait.atMost(200, TimeUnit.SECONDS);
+    private final ConditionFactory negativeAwait = Awaitility.with()
+        .pollInterval(Duration.ofMillis(200))
+        .pollDelay(Duration.ZERO)
+        .await()
+        .during(Duration.ofSeconds(1));
 
     @RegisterExtension
     @Order(1)
@@ -404,7 +408,7 @@ public class EventReplyEmailConsumerTest {
     }
 
     @Test
-    void shouldRecoverWhenEventHandlerHasTemporaryException() throws InterruptedException {
+    void shouldRecoverWhenEventHandlerHasTemporaryException() {
         String eventUid = UUID.randomUUID().toString();
         String calendarData = generateCalendarData(
             eventUid,
@@ -417,10 +421,11 @@ public class EventReplyEmailConsumerTest {
         // Mock exception
         when(eventEmailFilter.shouldProcess(any(MailAddress.class)))
             .thenThrow(new RuntimeException("Temporary exception"));
+        Mockito.clearInvocations(eventEmailFilter);
 
         updateAttendeePartStat(eventUid, PartStat.ACCEPTED);
 
-        Thread.sleep(1000); // Wait for the exception to be processed
+        awaitAtMost.untilAsserted(() -> Mockito.verify(eventEmailFilter, Mockito.atLeastOnce()).shouldProcess(any(MailAddress.class)));
 
         // Recover
         Mockito.reset(eventEmailFilter);
@@ -440,7 +445,7 @@ public class EventReplyEmailConsumerTest {
     }
 
     @Test
-    void shouldNotSendEmailWhenRecipientIsNotInWhitelist() throws InterruptedException {
+    void shouldNotSendEmailWhenRecipientIsNotInWhitelist() {
         when(eventEmailFilter.shouldProcess(any(MailAddress.class)))
             .thenReturn(false);
 
@@ -457,8 +462,8 @@ public class EventReplyEmailConsumerTest {
         waitForEventCreation(attendee);
         updateAttendeePartStat(eventUid, PartStat.ACCEPTED);
 
-        Thread.sleep(1000); // Wait for the message to be processed
-        assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty();
+        negativeAwait
+            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
     }
 
     @Test
@@ -513,7 +518,7 @@ public class EventReplyEmailConsumerTest {
             .replace("{partStat}", PartStat.NEEDS_ACTION.getValue());
 
         davTestHelper.upsertCalendar(organizer, icalData, eventUid);
-        Fixture.awaitAtMost.untilAsserted(() ->
+        awaitAtMost.untilAsserted(() ->
             assertThat(davTestHelper.findFirstEventId(resourceId, openPaaSDomain.id()))
                 .withFailMessage("Event not created for resource: " + resourceId.value())
                 .isPresent());
@@ -522,8 +527,8 @@ public class EventReplyEmailConsumerTest {
         calDavEventRepository().updatePartStat(openPaaSDomain, resourceId, eventPathId, PartStat.ACCEPTED).block();
 
 
-        Thread.sleep(2000); // Wait for the message to be processed
-        assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty();
+        negativeAwait
+            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).isEmpty());
     }
 
     private CalDavEventRepository calDavEventRepository() throws SSLException {

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventReplyEmailConsumerTest.java
@@ -408,7 +408,7 @@ public class EventReplyEmailConsumerTest {
     }
 
     @Test
-    void shouldRecoverWhenEventHandlerHasTemporaryException() {
+    void shouldRecoverWhenEventHandlerHasTemporaryException() throws InterruptedException {
         String eventUid = UUID.randomUUID().toString();
         String calendarData = generateCalendarData(
             eventUid,
@@ -421,11 +421,10 @@ public class EventReplyEmailConsumerTest {
         // Mock exception
         when(eventEmailFilter.shouldProcess(any(MailAddress.class)))
             .thenThrow(new RuntimeException("Temporary exception"));
-        Mockito.clearInvocations(eventEmailFilter);
 
         updateAttendeePartStat(eventUid, PartStat.ACCEPTED);
 
-        awaitAtMost.untilAsserted(() -> Mockito.verify(eventEmailFilter, Mockito.atLeastOnce()).shouldProcess(any(MailAddress.class)));
+        Thread.sleep(1000); // Wait for the exception to be processed
 
         // Recover
         Mockito.reset(eventEmailFilter);

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
@@ -542,6 +542,7 @@ public class EventResourceConsumerTest {
     void shouldNotCrashWhenReceivingInvalidAMQPMessage(DockerSabreDavSetup dockerSabreDavSetup) throws Exception {
         // Given an invalid AMQP message
         publishMessage(EventResourceConsumer.Queue.CREATE.exchangeName(), "invalid json");
+        Thread.sleep(1000);
 
         // When creating resource projector with resourceAdmin as administrator
         OpenPaaSDomain domain = dockerSabreDavSetup.getOpenPaaSProvisioningService().getDomain().block();

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
@@ -72,8 +72,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.smtp.EventEmailFilter;
@@ -118,6 +118,11 @@ public class EventResourceConsumerTest {
         .pollDelay(Duration.ofMillis(500))
         .await();
     private final ConditionFactory awaitAtMost = calmlyAwait.atMost(20, TimeUnit.SECONDS);
+    private final ConditionFactory negativeAwait = Awaitility.with()
+        .pollInterval(Duration.ofMillis(200))
+        .pollDelay(Duration.ZERO)
+        .await()
+        .during(Duration.ofSeconds(3));
 
     @RegisterExtension
     @Order(1)
@@ -334,7 +339,7 @@ public class EventResourceConsumerTest {
     }
 
     @Test
-    void shouldNotSendResourceRequestEmailWhenNoAdmin(DockerSabreDavSetup dockerSabreDavSetup) throws InterruptedException {
+    void shouldNotSendResourceRequestEmailWhenNoAdmin(DockerSabreDavSetup dockerSabreDavSetup) {
         OpenPaaSDomain domain = dockerSabreDavSetup.getOpenPaaSProvisioningService().getDomain().block();
         ResourceId resourceId = createResource(domain, resourceAdmin);
 
@@ -351,13 +356,12 @@ public class EventResourceConsumerTest {
             resourceId.value());
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        Thread.sleep(3000); // Wait a bit to ensure no email is sent
-
-        awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(0));
+        negativeAwait
+            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(0));
     }
 
     @Test
-    void shouldNotSendResourceRequestEmailWhenResourceHasBeenDeleted(DockerSabreDavSetup dockerSabreDavSetup) throws InterruptedException {
+    void shouldNotSendResourceRequestEmailWhenResourceHasBeenDeleted(DockerSabreDavSetup dockerSabreDavSetup) {
         OpenPaaSDomain domain = dockerSabreDavSetup.getOpenPaaSProvisioningService().getDomain().block();
         ResourceId resourceId = createResource(domain, resourceAdmin);
         resourceService.retrieve(resourceId, !ONLY_ACTIVE)
@@ -377,9 +381,8 @@ public class EventResourceConsumerTest {
             resourceId.value());
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        Thread.sleep(3000); // Wait a bit to ensure no email is sent
-
-        awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(0));
+        negativeAwait
+            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(0));
     }
 
     @Test
@@ -531,16 +534,14 @@ public class EventResourceConsumerTest {
             resourceId.value());
         davTestHelper.upsertCalendar(organizer, calendarData, eventUid);
 
-        Thread.sleep(3000); // Wait a bit to ensure no email is sent
-
-        awaitAtMost.untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(0));
+        negativeAwait
+            .untilAsserted(() -> assertThat(smtpMailsResponseSupplier.get().getList("")).hasSize(0));
     }
 
     @Test
     void shouldNotCrashWhenReceivingInvalidAMQPMessage(DockerSabreDavSetup dockerSabreDavSetup) throws Exception {
         // Given an invalid AMQP message
         publishMessage(EventResourceConsumer.Queue.CREATE.exchangeName(), "invalid json");
-        Thread.sleep(1000);
 
         // When creating resource projector with resourceAdmin as administrator
         OpenPaaSDomain domain = dockerSabreDavSetup.getOpenPaaSProvisioningService().getDomain().block();

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventUpdateEmailConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventUpdateEmailConsumerTest.java
@@ -67,8 +67,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.smtp.EventEmailFilter;

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/ItipLocalDeliveryConsumerTest.java
@@ -55,8 +55,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentMatchers;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -602,9 +602,11 @@ public class ItipLocalDeliveryConsumerTest {
         publishToConsumer(payload);
 
         // An invalid address is necessarily not local: the message is ignored (acked), not dead-lettered.
-        Thread.sleep(1000);
-        assertThat(channel.basicGet(ItipLocalDeliveryConsumer.DEAD_LETTER_QUEUE, true)).isNull();
-        WireMock.verify(0, WireMock.postRequestedFor(WireMock.urlEqualTo("/itip")));
+        AWAIT_AT_MOST.during(Duration.ofSeconds(1))
+            .untilAsserted(() -> {
+                assertThat(channel.basicGet(ItipLocalDeliveryConsumer.DEAD_LETTER_QUEUE, true)).isNull();
+                WireMock.verify(0, WireMock.postRequestedFor(WireMock.urlEqualTo("/itip")));
+            });
     }
 
     @Test

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/TestFixture.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/TestFixture.java
@@ -26,8 +26,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.james.events.RetryBackoffConfiguration;
 import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 public interface TestFixture {
     ConditionFactory calmlyAwait = Awaitility.with()

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/Fixture.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/Fixture.java
@@ -21,8 +21,8 @@ package com.linagora.calendar.dav;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.shaded.org.awaitility.core.ConditionFactory;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 public interface Fixture {
 

--- a/calendar-redis/src/test/java/org/apache/james/events/CalendarRedisEventBusTest.java
+++ b/calendar-redis/src/test/java/org/apache/james/events/CalendarRedisEventBusTest.java
@@ -178,10 +178,10 @@ public class CalendarRedisEventBusTest implements SingleEventBusKeyContract, Mul
 
         eventBus.dispatch(EVENT, ImmutableSet.of(KEY_1)).block();
 
-        TimeUnit.SECONDS.sleep(1);
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(listener.getEvents()).hasSize(1);
-            softly.assertThat(otherListener.getEvents()).isEmpty();
-        });
+        awaitAtMostThirtySeconds.during(Duration.ofSeconds(1))
+            .untilAsserted(() -> SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(listener.getEvents()).hasSize(1);
+                softly.assertThat(otherListener.getEvents()).isEmpty();
+            }));
     }
 }

--- a/calendar-scheduling/src/test/java/com/linagora/calendar/scheduling/AlarmEventSchedulerContract.java
+++ b/calendar-scheduling/src/test/java/com/linagora/calendar/scheduling/AlarmEventSchedulerContract.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 
 import org.apache.james.core.MailAddress;
 import org.apache.james.utils.UpdatableTickingClock;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Test;
 
 import com.github.fge.lambdas.Throwing;
@@ -41,6 +43,11 @@ import io.restassured.path.json.JsonPath;
 
 public interface AlarmEventSchedulerContract {
     boolean NO_RECURRING = false;
+    ConditionFactory negativeAwait = Awaitility.with()
+        .pollInterval(Duration.ofMillis(200))
+        .pollDelay(Duration.ZERO)
+        .await()
+        .during(Duration.ofSeconds(1));
 
     AlarmEventScheduler scheduler();
 
@@ -132,12 +139,12 @@ public interface AlarmEventSchedulerContract {
 
         alarmEventDAO().create(event).block();
 
-        Thread.sleep(1000);
-        assertThat(getSmtpMailbox().getList("")).hasSize(0);
+        negativeAwait
+            .untilAsserted(() -> assertThat(getSmtpMailbox().getList("")).hasSize(0));
     }
 
     @Test
-    default void shouldNotSendAlarmEmailWhenEventStartTimeLessThanNow() throws InterruptedException {
+    default void shouldNotSendAlarmEmailWhenEventStartTimeLessThanNow() {
         scheduler().start();
         Instant now = clock().instant();
         AlarmEvent event = new AlarmEvent(
@@ -167,8 +174,8 @@ public interface AlarmEventSchedulerContract {
             AlarmAction.EMAIL);
         alarmEventDAO().create(event).block();
 
-        Thread.sleep(1000);
-        assertThat(getSmtpMailbox().getList("")).hasSize(0);
+        negativeAwait
+            .untilAsserted(() -> assertThat(getSmtpMailbox().getList("")).hasSize(0));
     }
 
 }

--- a/calendar-smtp/pom.xml
+++ b/calendar-smtp/pom.xml
@@ -93,5 +93,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/calendar-smtp/src/test/java/com/linagora/calendar/smtp/MailSenderTest.java
+++ b/calendar-smtp/src/test/java/com/linagora/calendar/smtp/MailSenderTest.java
@@ -21,6 +21,7 @@ package com.linagora.calendar.smtp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.awaitility.Awaitility.await;
 
 import org.junit.jupiter.api.AfterEach;
 import org.mockito.Mockito;
@@ -314,9 +315,11 @@ class MailSenderTest {
 
         mailSender.send(mail).block();
 
-        Thread.sleep(1000);
-        JsonPath response = RestAssured.get("/smtpMails").jsonPath();
-        assertThat(response.getList("")).hasSize(0);
+        await().during(Duration.ofSeconds(1))
+            .untilAsserted(() -> {
+                JsonPath response = RestAssured.get("/smtpMails").jsonPath();
+                assertThat(response.getList("")).hasSize(0);
+            });
     }
 
     @Test

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
@@ -48,7 +48,7 @@ import com.linagora.calendar.api.booking.AvailabilityRule.WeeklyAvailabilityRule
 import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.DavTestHelper;
-import com.linagora.calendar.dav.Fixture;
+import static com.linagora.calendar.storage.TestFixture.awaitAtMost;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.routes.BookingLinkExtraAttendeeResolver;
 import com.linagora.calendar.storage.CalendarURL;
@@ -358,7 +358,7 @@ public class BookingLinkUserRoutesTest {
     }
 
     private CalendarURL findMirrorCalendar(OpenPaaSUser user) {
-        return Fixture.awaitAtMost.until(() -> calDavClient.findUserCalendarList(user)
+        return awaitAtMost.until(() -> calDavClient.findUserCalendarList(user)
             .map(response -> response.calendars()
                 .keySet()
                 .stream()

--- a/storage-api/src/test/java/com/linagora/calendar/storage/TestFixture.java
+++ b/storage-api/src/test/java/com/linagora/calendar/storage/TestFixture.java
@@ -19,7 +19,19 @@
 package com.linagora.calendar.storage;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 
 public interface TestFixture {
     TechnicalTokenService TECHNICAL_TOKEN_SERVICE_TESTING = new TechnicalTokenService.Impl("technicalTokenSecret", Duration.ofSeconds(120));
+
+    ConditionFactory calmlyAwait = Awaitility.with()
+        .pollInterval(Duration.ofMillis(500))
+        .and()
+        .with()
+        .pollDelay(Duration.ofMillis(500))
+        .await();
+    ConditionFactory awaitAtMost = calmlyAwait.atMost(20, TimeUnit.SECONDS);
 }

--- a/storage-mongodb/src/test/java/com/linagora/calendar/storage/mongodb/MongoAlarmEventLeaseProviderTest.java
+++ b/storage-mongodb/src/test/java/com/linagora/calendar/storage/mongodb/MongoAlarmEventLeaseProviderTest.java
@@ -33,7 +33,7 @@ import org.apache.james.core.MailAddress;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.awaitility.Awaitility;
 
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.storage.AlarmEvent;


### PR DESCRIPTION
Improve asynchronous test reliability by replacing fixed sleeps and shaded Awaitility usage with explicit Awaitility-based waits.

## Why
Fixed sleeps make tests slower and flaky because they either wait longer than necessary or fail when asynchronous processing takes slightly longer. Condition-based waits make the test suite more deterministic and responsive.
