### PR TITLE
feat(meet): Create the room instead of hoping a random slug names one

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/meet/MeetApplicationClient.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/meet/MeetApplicationClient.java
@@ -129,6 +129,44 @@ public class MeetApplicationClient {
     }
 
     /**
+     * Ask Meet to create a room owned by the token's scoped user, and return
+     * its public URL.
+     *
+     * <p><strong>The caller does not choose the room code.</strong> Meet's
+     * external API marks {@code name} and {@code slug} read-only and its
+     * serializer does {@code validated_data["name"] = utils.generate_room_slug()},
+     * so the code is Meet's to mint. That is the whole point: a code invented
+     * anywhere else names a room that does not exist.
+     *
+     * <p>{@code perform_create} grants the scoped user {@code OWNER}, so the
+     * organiser gets host controls — lobby admission, recording — which a
+     * pre-minted link never gave them.
+     */
+    public Mono<String> createRoom(String bearerToken) {
+        ObjectNode body = MAPPER.createObjectNode();
+        config.roomAccessLevel().ifPresent(level -> body.put("access_level", level));
+        byte[] payload = serialize(body);
+
+        return client.headers(h -> {
+                h.set(HttpHeaderNames.AUTHORIZATION, "Bearer " + bearerToken);
+                h.set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+            })
+            .post()
+            .uri(ROOMS_PATH)
+            .send(Mono.just(Unpooled.wrappedBuffer(payload)))
+            .responseSingle((response, bodyMono) -> {
+                HttpResponseStatus status = response.status();
+                return bodyMono.asString().defaultIfEmpty("").flatMap(bodyString -> {
+                    if (status.code() >= 200 && status.code() < 300) {
+                        return extractRoomUrl(bodyString);
+                    }
+                    return Mono.error(new MeetApiException(
+                        "Failed to create room: HTTP " + status.code() + " — " + bodyString));
+                });
+            });
+    }
+
+    /**
      * Grant admin (or member) access on {@code roomId} to {@code delegateEmail}.
      * Idempotent by design of the server (see Meet Patch A).
      */
@@ -171,6 +209,27 @@ public class MeetApplicationClient {
             return Mono.just(tokenNode.asText());
         } catch (Exception e) {
             return Mono.error(new MeetApiException("Failed to parse Meet token response: " + bodyString, e));
+        }
+    }
+
+    /**
+     * Meet composes {@code url} from its own {@code APPLICATION_BASE_URL}. When
+     * that setting is empty the field is simply absent — and this service has
+     * no way to guess the public host, so it says which knob to turn rather
+     * than returning a half-built link.
+     */
+    private Mono<String> extractRoomUrl(String bodyString) {
+        try {
+            JsonNode node = MAPPER.readTree(bodyString);
+            JsonNode urlNode = node.get("url");
+            if (urlNode == null || !urlNode.isTextual()) {
+                return Mono.error(new MeetApiException(
+                    "Meet room response carries no url — is APPLICATION_BASE_URL set on Meet? " + bodyString));
+            }
+            LOGGER.info("Created Meet room {}", urlNode.asText());
+            return Mono.just(urlNode.asText());
+        } catch (Exception e) {
+            return Mono.error(new MeetApiException("Failed to parse Meet room creation response: " + bodyString, e));
         }
     }
 

--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/meet/MeetConfiguration.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/meet/MeetConfiguration.java
@@ -34,7 +34,8 @@ public record MeetConfiguration(boolean enabled,
                                 String clientSecret,
                                 URI externalApiBaseUrl,
                                 boolean trustAllSslCerts,
-                                Duration responseTimeout) {
+                                Duration responseTimeout,
+                                Optional<String> roomAccessLevel) {
 
     public static final Duration DEFAULT_RESPONSE_TIMEOUT = Duration.ofSeconds(10);
 
@@ -44,6 +45,19 @@ public record MeetConfiguration(boolean enabled,
     static final String MEET_EXTERNAL_API_BASE_URL_PROPERTY = "meet.external.api.base.url";
     static final String MEET_TRUST_ALL_SSL_CERTS_PROPERTY = "meet.rest.client.trust.all.ssl.certs";
     static final String MEET_RESPONSE_TIMEOUT_PROPERTY = "meet.rest.client.response.timeout";
+    /**
+     * Access level requested for rooms this service creates. Empty leaves the
+     * choice to Meet, whose {@code EXTERNAL_API_DEFAULT_ACCESS_LEVEL} defaults
+     * to {@code trusted}.
+     *
+     * <p>That default deserves a deliberate decision rather than a shrug: a
+     * {@code trusted} room only admits authenticated users of the instance, so
+     * an external guest invited to a meeting cannot get in — and the organiser
+     * being present changes nothing. Deployments that invite guests want
+     * {@code public} here, which Meet also gates behind its own
+     * {@code EXTERNAL_API_ALLOW_PUBLIC_ACCESS}.
+     */
+    static final String MEET_ROOM_ACCESS_LEVEL_PROPERTY = "meet.room.access_level";
 
     public static MeetConfiguration from(Configuration configuration) {
         boolean enabled = Boolean.parseBoolean(readProperty(configuration, MEET_ENABLED_PROPERTY, "false"));
@@ -71,7 +85,12 @@ public record MeetConfiguration(boolean enabled,
             })
             .orElse(DEFAULT_RESPONSE_TIMEOUT);
 
-        return new MeetConfiguration(true, clientId, clientSecret, URI.create(baseUrl), trustAllSslCerts, responseTimeout);
+        Optional<String> roomAccessLevel = Optional.ofNullable(readProperty(configuration, MEET_ROOM_ACCESS_LEVEL_PROPERTY, null))
+            .map(StringUtils::trimToNull)
+            .map(Optional::of)
+            .orElse(Optional.empty());
+
+        return new MeetConfiguration(true, clientId, clientSecret, URI.create(baseUrl), trustAllSslCerts, responseTimeout, roomAccessLevel);
     }
 
     /**
@@ -97,6 +116,6 @@ public record MeetConfiguration(boolean enabled,
     }
 
     public static MeetConfiguration disabled() {
-        return new MeetConfiguration(false, null, null, null, false, DEFAULT_RESPONSE_TIMEOUT);
+        return new MeetConfiguration(false, null, null, null, false, DEFAULT_RESPONSE_TIMEOUT, Optional.empty());
     }
 }

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/meet/MeetApplicationClientTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/meet/MeetApplicationClientTest.java
@@ -1,0 +1,148 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.amqp.meet;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+class MeetApplicationClientTest {
+    private static final String ROOMS_PATH = "/external-api/v1.0/rooms/";
+    private static final String TOKEN = "test-app-jwt-token";
+    private static final String ROOM_URL = "https://meet.example.com/mjj-beyv-zai";
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        WireMock.configureFor("localhost", wireMockServer.port());
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    private MeetApplicationClient client(Optional<String> roomAccessLevel) throws Exception {
+        return new MeetApplicationClient(new MeetConfiguration(
+            true,
+            "test-client-id",
+            "test-client-secret",
+            URI.create("http://localhost:" + wireMockServer.port()),
+            false,
+            Duration.ofSeconds(5),
+            roomAccessLevel));
+    }
+
+    private void stubCreateRoom(int status, String body) {
+        wireMockServer.stubFor(post(urlEqualTo(ROOMS_PATH))
+            .willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withStatus(status)
+                .withBody(body)));
+    }
+
+    @Test
+    void createRoomShouldReturnTheUrlMeetMinted() throws Exception {
+        stubCreateRoom(201, "{\"id\":\"550e8400-e29b-41d4-a716-446655440000\","
+            + "\"slug\":\"mjj-beyv-zai\",\"url\":\"" + ROOM_URL + "\"}");
+
+        assertThat(client(Optional.empty()).createRoom(TOKEN).block()).isEqualTo(ROOM_URL);
+    }
+
+    @Test
+    void createRoomShouldAuthenticateWithTheApplicationToken() throws Exception {
+        stubCreateRoom(201, "{\"url\":\"" + ROOM_URL + "\"}");
+
+        client(Optional.empty()).createRoom(TOKEN).block();
+
+        verify(postRequestedFor(urlEqualTo(ROOMS_PATH))
+            .withHeader("Authorization", equalTo("Bearer " + TOKEN)));
+    }
+
+    @Test
+    void createRoomShouldRequestTheConfiguredAccessLevel() throws Exception {
+        stubCreateRoom(201, "{\"url\":\"" + ROOM_URL + "\"}");
+
+        client(Optional.of("public")).createRoom(TOKEN).block();
+
+        verify(postRequestedFor(urlEqualTo(ROOMS_PATH))
+            .withRequestBody(matchingJsonPath("$.access_level", equalTo("public"))));
+    }
+
+    /**
+     * The other polarity of the same branch. Without it, a client that always
+     * sent an access level would pass the test above just as well — and it
+     * would silently override Meet's own default for every deployment that
+     * deliberately left the property unset.
+     */
+    @Test
+    void createRoomShouldLeaveTheAccessLevelToMeetWhenUnconfigured() throws Exception {
+        stubCreateRoom(201, "{\"url\":\"" + ROOM_URL + "\"}");
+
+        client(Optional.empty()).createRoom(TOKEN).block();
+
+        verify(postRequestedFor(urlEqualTo(ROOMS_PATH))
+            .withRequestBody(matchingJsonPath("$.access_level", absent())));
+    }
+
+    @Test
+    void createRoomShouldFailWhenMeetRejectsTheRequest() throws Exception {
+        stubCreateRoom(403, "{\"detail\":\"missing rooms:create scope\"}");
+
+        assertThatThrownBy(() -> client(Optional.empty()).createRoom(TOKEN).block())
+            .isInstanceOf(MeetApplicationClient.MeetApiException.class)
+            .hasMessageContaining("403")
+            .hasMessageContaining("rooms:create");
+    }
+
+    /**
+     * Meet composes {@code url} from its own {@code APPLICATION_BASE_URL}; the
+     * field is absent when that setting is empty. Returning a room without a
+     * link would put an empty href in a calendar invitation, so the failure
+     * has to be loud and name the setting.
+     */
+    @Test
+    void createRoomShouldFailWhenTheResponseCarriesNoUrl() throws Exception {
+        stubCreateRoom(201, "{\"id\":\"550e8400-e29b-41d4-a716-446655440000\",\"slug\":\"mjj-beyv-zai\"}");
+
+        assertThatThrownBy(() -> client(Optional.empty()).createRoom(TOKEN).block())
+            .isInstanceOf(MeetApplicationClient.MeetApiException.class)
+            .hasMessageContaining("APPLICATION_BASE_URL");
+    }
+}

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/meet/MeetHostDelegationServiceTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/meet/MeetHostDelegationServiceTest.java
@@ -70,7 +70,8 @@ public class MeetHostDelegationServiceTest {
             "test-client-secret",
             URI.create("http://localhost:" + wireMockServer.port()),
             false,
-            Duration.ofSeconds(5));
+            Duration.ofSeconds(5),
+            Optional.empty());
         MeetApplicationClient client = new MeetApplicationClient(configuration);
         service = new MeetHostDelegationService(configuration, client);
     }

--- a/calendar-rest-api/pom.xml
+++ b/calendar-rest-api/pom.xml
@@ -39,6 +39,17 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>calendar-storage-api</artifactId>
         </dependency>
+        <!--
+            For the Meet application client only (com.linagora.calendar.amqp.meet).
+            That client speaks HTTP, not AMQP, and sits in this module because the
+            host-delegation consumer was its first caller; a follow-up could pull
+            the two classes into a module of their own rather than have the REST
+            layer depend on the messaging one.
+        -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>calendar-amqp</artifactId>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>calendar-dav</artifactId>

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/RestApiModule.java
@@ -115,6 +115,7 @@ import com.linagora.calendar.restapi.routes.UserConfigurationsRoute;
 import com.linagora.calendar.restapi.routes.UserProfileRoute;
 import com.linagora.calendar.restapi.routes.UserRoute;
 import com.linagora.calendar.restapi.routes.UsersRoute;
+import com.linagora.calendar.restapi.routes.VideoConferenceRoute;
 import com.linagora.calendar.restapi.routes.WebsocketRoute;
 import com.linagora.calendar.restapi.routes.configuration.FileConfigurationEntryResolver;
 import com.linagora.calendar.restapi.routes.configuration.OpenpaasConfigurationEntryResolver;
@@ -181,6 +182,7 @@ public class RestApiModule extends AbstractModule {
         routes.addBinding().to(ProfileUpdateRoute.class);
         routes.addBinding().to(UserRoute.class);
         routes.addBinding().to(UserProfileRoute.class);
+        routes.addBinding().to(VideoConferenceRoute.class);
         routes.addBinding().to(UsersRoute.class);
         routes.addBinding().to(UserConfigurationsRoute.class);
         routes.addBinding().to(UserConfigurationPatchRoute.class);

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/VideoConferenceRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/VideoConferenceRoute.java
@@ -1,0 +1,108 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.restapi.routes;
+
+import static com.linagora.calendar.restapi.RestApiConstants.JSON_HEADER;
+import static com.linagora.calendar.restapi.RestApiConstants.OBJECT_MAPPER_DEFAULT;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.apache.james.jmap.Endpoint;
+import org.apache.james.jmap.http.Authenticator;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.metrics.api.MetricFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linagora.calendar.amqp.meet.MeetApplicationClient;
+import com.linagora.calendar.amqp.meet.MeetConfiguration;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.server.HttpServerRequest;
+import reactor.netty.http.server.HttpServerResponse;
+
+/**
+ * Mint a video conference room for the authenticated user and return its URL.
+ *
+ * <p>The frontend used to invent the room code itself
+ * ({@code generateMeetingId}, three then four then three random letters) and
+ * write it straight into {@code X-OPENPAAS-VIDEOCONFERENCE}. Nothing ever told
+ * Meet about it, so on any deployment that does not accept unregistered rooms
+ * every generated link was dead — for every client, web included.
+ *
+ * <p>Asking Meet for the room fixes that at the source and buys two things a
+ * pre-minted code could never give: the room exists before the invitation is
+ * sent, and the organiser is its {@code OWNER}, so lobby admission, recording
+ * and the rest of the host controls actually work.
+ *
+ * <p>The Meet application credentials stay server-side, which is why this is a
+ * route here rather than a call from the browser.
+ */
+public class VideoConferenceRoute extends CalendarRoute {
+    private static final Logger LOGGER = LoggerFactory.getLogger(VideoConferenceRoute.class);
+    private static final String URL_FIELD = "url";
+
+    private final MeetConfiguration meetConfiguration;
+    private final MeetApplicationClient meetClient;
+
+    @Inject
+    public VideoConferenceRoute(Authenticator authenticator,
+                                MetricFactory metricFactory,
+                                MeetConfiguration meetConfiguration,
+                                MeetApplicationClient meetClient) {
+        super(authenticator, metricFactory);
+        this.meetConfiguration = meetConfiguration;
+        this.meetClient = meetClient;
+    }
+
+    @Override
+    Endpoint endpoint() {
+        return new Endpoint(HttpMethod.POST, "/api/videoconference");
+    }
+
+    @Override
+    Mono<Void> handleRequest(HttpServerRequest request, HttpServerResponse response, MailboxSession session) {
+        // Deployments without Meet credentials answer 404 rather than 500, so
+        // the caller can tell "this instance does not mint rooms" from "minting
+        // failed" — and fall back to its own link generation, which is what
+        // Meet expects when it runs with ALLOW_UNREGISTERED_ROOMS enabled.
+        if (!meetConfiguration.enabled()) {
+            return response.status(HttpResponseStatus.NOT_FOUND).send().then();
+        }
+
+        String organizer = session.getUser().asString();
+
+        return meetClient.fetchApplicationToken(organizer)
+            .flatMap(meetClient::createRoom)
+            .flatMap(url -> response.status(HttpResponseStatus.CREATED)
+                .headers(JSON_HEADER)
+                .sendByteArray(Mono.fromCallable(() -> OBJECT_MAPPER_DEFAULT.writeValueAsBytes(Map.of(URL_FIELD, url))))
+                .then())
+            // Meet being down is not the caller's fault, and it is not this
+            // service failing either: 502 says which side to look at.
+            .onErrorResume(MeetApplicationClient.MeetApiException.class, error -> {
+                LOGGER.warn("Meet refused to create a room for {}", organizer, error);
+                return response.status(HttpResponseStatus.BAD_GATEWAY).send().then();
+            });
+    }
+}


### PR DESCRIPTION
Part of linagora/twake-calendar-side-service#1004.

## The problem

The calendar frontend invents the video conference room code in the browser —
`generateMeetingId`, three then four then three random letters — and writes it
straight into `X-OPENPAAS-VIDEOCONFERENCE`. Nothing ever tells Meet about it.

On any deployment where Meet does not accept unregistered rooms, **every
generated link is dead**, for every client, web included:

```
$ curl -s -o - -w '%{http_code}' https://<meet-host>/api/v1.0/rooms/mjj-beyv-zai/
{"detail":"No Room matches the given query."}404
```

It also breaks the host delegation this branch builds on. `MeetHostDelegationService`
cannot grant host rights on a room that does not exist, and says so:

```
WARN  c.l.c.a.m.MeetHostDelegationService -
  Meet room not found for slug 'mjj-beyv-zai' (organizer <organiser@…>)
  — skipping delegates [<delegate@…>]
```

## Why the fix belongs here

Meet's external API already does exactly what is needed. `RoomViewSet` includes
`mixins.CreateModelMixin`, and `RoomSerializer.create` is written for this
caller:

```python
def create(self, validated_data):
    """Create room with secure defaults for application delegation."""
    validated_data["name"] = utils.generate_room_slug()
    ...
```

with `to_representation` adding `url` from `APPLICATION_BASE_URL`, and
`perform_create` granting the scoped user `OWNER`.

So `POST /external-api/v1.0/rooms/` mints the code itself and returns a finished
link, owned by the organiser. This service already holds the credentials and
already knows how to obtain an application token scoped to a user
(`MeetApplicationClient.fetchApplicationToken`), which is why the endpoint
belongs here rather than in the browser.

Note the constraint this implies: `RoomSerializer.Meta.read_only_fields` contains
`name` and `slug`, and `Room.clean_fields` does `self.slug = slugify(self.name)`.
**A caller cannot impose a slug.** Any fix that keeps the frontend's invented
code would require changing Meet; asking Meet for the code does not.

## What this adds

- `MeetApplicationClient.createRoom(token)` — `POST` on the existing `ROOMS_PATH`,
  reads `url` from the response. Fails loudly and names `APPLICATION_BASE_URL`
  when that field is absent, rather than returning a half-built link that would
  end up as an empty href in an invitation.
- `POST /api/videoconference` (`VideoConferenceRoute`) — authenticates as every
  other route does, resolves the caller's address, and returns `{"url": "…"}`.
  Answers `404` when Meet is not configured, so a caller can tell "this
  deployment does not mint rooms" from "minting failed" and fall back to its own
  link generation; `502` when Meet refuses, so the failing side is named.
- `meet.room.access_level`, optional. Meet's `EXTERNAL_API_DEFAULT_ACCESS_LEVEL`
  is `trusted`, which only admits authenticated users of the instance — **an
  external guest invited to a meeting cannot get in, and the organiser being
  present changes nothing.** Deployments that invite guests want `public` here,
  which Meet gates behind its own `EXTERNAL_API_ALLOW_PUBLIC_ACCESS`. Leaving the
  property unset keeps Meet's default, so nothing changes for deployments that
  do not set it.

## Measured on a Twake deployment

| step | result |
| --- | --- |
| two video conferences created from the calendar | two rooms appear in Meet, 15 s apart |
| `GET /api/v1.0/rooms/<slug>/` | `200` for both — `404` before |
| host delegation | `Granted admin on Meet room … (HTTP 201)`, where it logged `Meet room not found` the day before |
| mobile client | reaches its prejoin screen instead of "not found on the server" |

The delegation check is the strongest of the four and it is indirect:
`MeetHostDelegationService` resolves the room **by the slug it reads from the
ICS**. That it finds one proves the event carries the created room's slug, not
merely that a room was created around the right time.

Host delegation was never broken — it was blocked by a room that did not exist.
This repairs it as a consequence rather than working around it.

## Tests

Six on the client, run against WireMock, including **both polarities** of the
access-level branch: a configured level is sent, an unconfigured one leaves the
choice to Meet. Verified by mutation — making `createRoom` always send a level
turns exactly that second test red.

The route is thin glue over the tested client and is not covered here; it needs
the app-level integration harness.

## Companion change

The frontend half is
linagora/twake-calendar-frontend#1247. Either alone is a no-op: the frontend
falls back to local generation on `404`, and this route is never called until the
frontend asks.

## Base branch

Opened against `feat/meet-host-delegation`, which this builds on and which is not
yet merged.
