### PR TITLE
ISSUE-621-feat(resource): support DAV rights for resource administrators

### DIFF
--- a/app/src/test/java/com/linagora/calendar/app/ResourceProbe.java
+++ b/app/src/test/java/com/linagora/calendar/app/ResourceProbe.java
@@ -25,6 +25,7 @@ import jakarta.inject.Inject;
 import org.apache.james.utils.GuiceProbe;
 
 import com.linagora.calendar.dav.ResourceService;
+import com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
 import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -64,6 +65,10 @@ public class ResourceProbe implements GuiceProbe {
             .map(userId -> userDAO.retrieve(userId).block().username())
             .toList()).block();
         return resource;
+    }
+
+    public void updateAdmins(Resource resource, List<ResourceAdministrator> administrators) {
+        resourceService.updateAdmins(resource, administrators).block();
     }
 
     public Resource saveInDomain(OpenPaaSId domainId, OpenPaaSId owner, String name, String icon) {

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/EntityRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/EntityRouteTest.java
@@ -52,7 +52,9 @@ import com.linagora.calendar.app.TwakeCalendarGuiceServer;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.app.ResourceProbe;
 import com.linagora.calendar.app.restapi.routes.PeopleSearchRouteTest.TeamCalendarProbe;
+import com.linagora.calendar.dav.DavRight;
 import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
@@ -127,6 +129,10 @@ public class EntityRouteTest {
 
         resource = server.getProbe(ResourceProbe.class)
             .save(openPaaSUser, "meeting-room", "room", List.of(openPaaSUser.id(), openPaaSUser2.id()));
+        server.getProbe(ResourceProbe.class)
+            .updateAdmins(resource, List.of(
+                new ResourceAdministrator(openPaaSUser.username(), DavRight.READ_WRITE),
+                new ResourceAdministrator(openPaaSUser2.username(), DavRight.ADMINISTRATION)));
         teamCalendar = server.getProbe(TeamCalendarProbe.class)
             .save(domain, "engineering", "Engineering Team");
 
@@ -170,12 +176,16 @@ public class EntityRouteTest {
                             {
                                 "id": "{adminId1}",
                                 "objectType": "user",
-                                "_id": "{adminId1}"
+                                "_id": "{adminId1}",
+                                "davRight": "dav:read-write",
+                                "access": 3
                             },
                             {
                                 "id": "{adminId2}",
                                 "objectType": "user",
-                                "_id": "{adminId2}"
+                                "_id": "{adminId2}",
+                                "davRight": "dav:administration",
+                                "access": 5
                             }
                         ],
                         "creator": "{creatorId}",

--- a/app/src/test/java/com/linagora/calendar/app/restapi/routes/ResourceRouteTest.java
+++ b/app/src/test/java/com/linagora/calendar/app/restapi/routes/ResourceRouteTest.java
@@ -51,7 +51,9 @@ import com.linagora.calendar.app.TwakeCalendarExtension;
 import com.linagora.calendar.app.TwakeCalendarGuiceServer;
 import com.linagora.calendar.app.modules.CalendarDataProbe;
 import com.linagora.calendar.app.ResourceProbe;
+import com.linagora.calendar.dav.DavRight;
 import com.linagora.calendar.dav.DavModuleTestHelper;
+import com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.RestApiServerProbe;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
@@ -121,6 +123,10 @@ public class ResourceRouteTest {
 
         resource = server.getProbe(ResourceProbe.class)
             .save(openPaaSUser, "meeting-room", "room", List.of(openPaaSUser.id(), openPaaSUser2.id()));
+        server.getProbe(ResourceProbe.class)
+            .updateAdmins(resource, List.of(
+                new ResourceAdministrator(openPaaSUser.username(), DavRight.READ_WRITE),
+                new ResourceAdministrator(openPaaSUser2.username(), DavRight.ADMINISTRATION)));
         resource2 = server.getProbe(ResourceProbe.class)
             .save(openPaaSUser2, "Laptop HP", "laptop");
 
@@ -165,12 +171,16 @@ public class ResourceRouteTest {
                         {
                             "id": "{adminId1}",
                             "objectType": "user",
-                            "_id": "{adminId1}"
+                            "_id": "{adminId1}",
+                            "davRight": "dav:read-write",
+                            "access": 3
                         },
                         {
                             "id": "{adminId2}",
                             "objectType": "user",
-                            "_id": "{adminId2}"
+                            "_id": "{adminId2}",
+                            "davRight": "dav:administration",
+                            "access": 5
                         }
                     ],
                     "creator": "{creatorId}",

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDelegatedNotificationConsumerTest.java
@@ -71,6 +71,8 @@ import com.linagora.calendar.dav.CalDavClient.NewCalendar;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.ResourceService;
+import com.linagora.calendar.dav.DavRight;
+import com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.dav.dto.SubscribedCalendarRequest;
 import com.linagora.calendar.smtp.EventEmailFilter;
@@ -352,7 +354,7 @@ public class CalendarDelegatedNotificationConsumerTest {
             "tv",
             resourceName);
         resourceService.create(resourceInsertRequest, administrators.stream()
-            .map(OpenPaaSUser::username)
+            .map(user -> new ResourceAdministrator(user.username(), DavRight.ADMINISTRATION))
             .toList()).block();
     }
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarListNotificationConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarListNotificationConsumerTest.java
@@ -61,6 +61,8 @@ import com.linagora.calendar.dav.CalDavClient.NewCalendar;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.ResourceService;
+import com.linagora.calendar.dav.DavRight;
+import com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.dav.dto.SubscribedCalendarRequest;
 import com.linagora.calendar.storage.CalendarListChangedEvent;
@@ -816,13 +818,13 @@ public class CalendarListNotificationConsumerTest {
             ResourceInsertRequest resourceInsertRequest = new ResourceInsertRequest(
                 creator.id(), "resource description", domainId, "tv", resourceName);
             return resourceService.create(resourceInsertRequest, administrators.stream()
-                .map(OpenPaaSUser::username)
+                .map(user -> new ResourceAdministrator(user.username(), DavRight.ADMINISTRATION))
                 .toList()).block();
         }
 
         private void clearResourceAdmins(ResourceId resourceId) {
             Resource resource = resourceService.retrieve(resourceId, ONLY_ACTIVE).block();
-            resourceService.updateAdmins(resource, List.of()).block();
+            resourceService.updateAdmins(resource, List.<ResourceService.ResourceAdministrator>of()).block();
         }
     }
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/EventResourceConsumerTest.java
@@ -83,6 +83,8 @@ import com.linagora.calendar.dav.CalDavEventRepository;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.DockerSabreDavSetup;
 import com.linagora.calendar.dav.ResourceService;
+import com.linagora.calendar.dav.DavRight;
+import com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
 import com.linagora.calendar.smtp.MailSender;
 import com.linagora.calendar.smtp.MailSenderConfiguration;
 import com.linagora.calendar.smtp.MockSmtpServerExtension;
@@ -690,7 +692,7 @@ public class EventResourceConsumerTest {
             "Projector");
 
         return resourceService.create(request, List.of(administrators).stream()
-            .map(OpenPaaSUser::username)
+            .map(user -> new ResourceAdministrator(user.username(), DavRight.ADMINISTRATION))
             .toList()).block();
     }
 }

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/DavRight.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/DavRight.java
@@ -1,0 +1,57 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  https://www.gnu.org/licenses/agpl-3.0.en.html                   *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum DavRight {
+    READ("dav:read", 2),
+    READ_WRITE("dav:read-write", 3),
+    ADMINISTRATION("dav:administration", 5);
+
+    private final String value;
+    private final int access;
+
+    DavRight(String value, int access) {
+        this.value = value;
+        this.access = access;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public int access() {
+        return access;
+    }
+
+    public static Optional<DavRight> fromAccess(int access) {
+        return Arrays.stream(values())
+            .filter(right -> right.access == access)
+            .findFirst();
+    }
+
+    public static DavRight fromValue(String value) {
+        return Arrays.stream(values())
+            .filter(right -> right.value.equals(value))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Unsupported DAV right: " + value));
+    }
+}

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/ResourceService.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/ResourceService.java
@@ -21,6 +21,7 @@ package com.linagora.calendar.dav;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -33,6 +34,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.AddSharee;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.RemoveSharee;
+import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.Share;
 import com.linagora.calendar.dav.dto.CalendarDetailsResponse.CalendarInvite;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.MailtoUri;
@@ -50,17 +55,65 @@ import reactor.core.publisher.Mono;
 
 @Singleton
 public class ResourceService {
-    public record ResourceWithAdministration(Resource resource, List<OpenPaaSUser> administrators) {
+    public record ResourceAdministrator(Username username, DavRight davRight) {
+        public static Optional<ResourceAdministrator> from(CalendarInvite invite) {
+            if (!MailtoUri.hasMailtoPrefix(invite.href())) {
+                return Optional.empty();
+            }
+            return invite.access()
+                .flatMap(DavRight::fromAccess)
+                .filter(right -> right != DavRight.READ)
+                .map(right -> new ResourceAdministrator(Username.of(MailtoUri.stripMailtoPrefix(invite.href())), right));
+        }
+
+        public static AddSharee asAddSharee(ResourceAdministrator administrator) {
+            return switch (administrator.davRight) {
+                case READ_WRITE -> AddSharee.readWrite("mailto:" + administrator.username.asString());
+                case ADMINISTRATION -> AddSharee.administration("mailto:" + administrator.username.asString());
+                default -> throw new IllegalArgumentException("Unsupported resource administrator DAV right: " + administrator.davRight);
+            };
+        }
     }
 
-    private record AdminChanges(Set<OpenPaaSId> toAdd, Set<OpenPaaSId> toRemove) {
+    public record ResourceWithAdministration(Resource resource, List<ResolvedAdministrator> administratorsWithRight) {
+        public record ResolvedAdministrator(OpenPaaSUser user, DavRight davRight) {
+        }
+
+        public List<OpenPaaSUser> administrators() {
+            return administratorsWithRight.stream()
+                .map(ResolvedAdministrator::user)
+                .toList();
+        }
+    }
+
+    private record AdminChanges(Set<ResourceAdministrator> toAddOrUpdate, Set<Username> toRemove) {
+        public static AdminChanges adding(Collection<ResourceAdministrator> administrators) {
+            return new AdminChanges(Set.copyOf(administrators), Set.of());
+        }
+
+        public static AdminChanges between(Collection<ResourceAdministrator> currentAdministrators,
+                                           Collection<ResourceAdministrator> newAdministrators) {
+            Set<ResourceAdministrator> currentAdministratorSet = Set.copyOf(currentAdministrators);
+            Set<ResourceAdministrator> newAdministratorSet = Set.copyOf(newAdministrators);
+            Set<Username> currentUsernames = currentAdministratorSet.stream()
+                .map(ResourceAdministrator::username)
+                .collect(Collectors.toSet());
+            Set<Username> newUsernames = newAdministratorSet.stream()
+                .map(ResourceAdministrator::username)
+                .collect(Collectors.toSet());
+            return new AdminChanges(Set.copyOf(Sets.difference(newAdministratorSet, currentAdministratorSet)),
+                Set.copyOf(Sets.difference(currentUsernames, newUsernames)));
+        }
+
+        public boolean isEmpty() {
+            return toAddOrUpdate.isEmpty() && toRemove.isEmpty();
+        }
     }
 
     public static final boolean ONLY_ACTIVE = true;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceService.class);
     private static final Map<String, String> WITH_RIGHTS = Map.of("withRights", "true");
-    private static final int READ_WRITE_ACCESS = 3;
 
     private final OpenPaaSUserDAO userDAO;
     private final ResourceDAO resourceDAO;
@@ -73,19 +126,15 @@ public class ResourceService {
         this.calDavClient = calDavClient;
     }
 
-    public Mono<ResourceId> create(ResourceInsertRequest request, Collection<Username> admins) {
+    public Mono<ResourceId> create(ResourceInsertRequest request, List<ResourceAdministrator> admins) {
         return resolveValidAdministrators(admins)
-            .map(administrators -> administrators.stream()
-                .map(OpenPaaSUser::username)
-                .toList())
-            .flatMap(adminUsernames -> resourceDAO.insert(request)
-                .flatMap(resourceId -> calDavClient.grantReadWriteRights(request.domain(), resourceId, adminUsernames)
-                    .doOnError(err -> LOGGER.error("Error granting rights for resource {}", resourceId.value(), err))
-                    .thenReturn(resourceId)));
+            .flatMap(administrators -> resourceDAO.insert(request)
+                .delayUntil(resourceId -> applyCalDavPatch(request.domain(), resourceId, AdminChanges.adding(administrators))));
     }
 
     public Mono<Void> delete(Resource resource) {
-        return resolveAdminUsernames(resource.domain(), resource.id())
+        return fetchAdministratorsFromSabre(resource.domain(), resource.id())
+            .map(ResourceAdministrator::username)
             .collectList()
             .flatMap(adminUsers -> calDavClient.revokeWriteRights(resource.domain(), resource.id(), adminUsers)
                 .doOnError(error -> LOGGER.error("Error revoking write rights for resource {}", resource.id().value(), error)))
@@ -93,15 +142,18 @@ public class ResourceService {
     }
 
     public Mono<Boolean> isAdministrator(Resource resource, Username username) {
-        return resolveAdminUsers(resource.domain(), resource.id())
-            .filter(user -> user.username().equals(username))
-            .hasElements();
+        return fetchAdministratorsFromSabre(resource.domain(), resource.id())
+            .any(administrator -> administrator.username().equals(username));
     }
 
-
     public Mono<List<OpenPaaSUser>> listAdminUsers(Resource resource) {
-        return resolveAdminUsers(resource.domain(), resource.id())
+        return listAdministratorsWithRights(resource)
+            .map(ResourceWithAdministration.ResolvedAdministrator::user)
             .collectList();
+    }
+
+    public Mono<List<ResourceAdministrator>> listAdministrators(Resource resource) {
+        return fetchAdministratorsFromSabre(resource.domain(), resource.id()).collectList();
     }
 
     public Flux<Resource> listByDomain(OpenPaaSId domainId) {
@@ -115,13 +167,9 @@ public class ResourceService {
 
     public Mono<ResourceWithAdministration> retrieveWithAdministration(ResourceId resourceId, boolean includeActive) {
         return retrieve(resourceId, includeActive)
-            .flatMap(resource -> listAdminUsers(resource)
+            .flatMap(resource -> listAdministratorsWithRights(resource)
+                .collectList()
                 .map(administrators -> new ResourceWithAdministration(resource, administrators)));
-    }
-
-    public Mono<ResourceWithAdministration> retrieveWithAdministration(ResourceId resourceId, OpenPaaSId domainId, boolean includeActive) {
-        return retrieveWithAdministration(resourceId, includeActive)
-            .filter(resourceWithAdministration -> resourceWithAdministration.resource().domain().equals(domainId));
     }
 
     public Mono<Resource> retrieve(ResourceId resourceId, OpenPaaSId domainId, boolean includeActive) {
@@ -134,73 +182,60 @@ public class ResourceService {
             .then();
     }
 
-    public Mono<Void> updateAdmins(Resource resource, Collection<Username> administrators) {
+    public Mono<Void> updateAdmins(Resource resource, Collection<ResourceAdministrator> administrators) {
         return resolveValidAdministrators(administrators)
-            .flatMap(newAdmins -> detectUserAdminChanges(resource, newAdmins)
-                .flatMap(changes -> applyCalDavPatch(resource, changes))
-                .then());
+            .flatMap(newAdmins -> listAdministrators(resource)
+                .map(currentAdmins -> AdminChanges.between(currentAdmins, newAdmins)))
+            .flatMap(changes -> applyCalDavPatch(resource.domain(), resource.id(), changes));
     }
 
-    private Mono<Void> applyCalDavPatch(Resource resource, AdminChanges changes) {
-        return Mono.zip(findUsernamesByIds(changes.toAdd()), findUsernamesByIds(changes.toRemove()))
-            .flatMap(tuple -> calDavClient.patchReadWriteDelegations(
-                resource.domain(), CalendarURL.from(resource.id().asOpenPaaSId()), tuple.getT1(), tuple.getT2()))
-            .doOnError(err -> LOGGER.error("Error patching CalDAV delegation for resource {}", resource.id().value(), err));
+    public Mono<Void> updateAdmins(Resource resource, List<Username> administrators) {
+        return updateAdmins(resource, administrators.stream()
+            .map(username -> new ResourceAdministrator(username, DavRight.READ_WRITE))
+            .toList());
     }
 
-    private Mono<AdminChanges> detectUserAdminChanges(Resource currentResource, Collection<OpenPaaSUser> newAdmins) {
-        Mono<Set<OpenPaaSId>> currentIdsMono = listAdminUsers(currentResource)
-            .map(adminUsers -> adminUsers.stream().map(OpenPaaSUser::id)
-                .collect(Collectors.toSet()));
-        Set<OpenPaaSId> newIds = newAdmins.stream()
-            .map(OpenPaaSUser::id)
-            .collect(Collectors.toSet());
-
-        return currentIdsMono.map(currentIds -> {
-            Set<OpenPaaSId> toAdd = Sets.difference(newIds, currentIds);
-            Set<OpenPaaSId> toRemove = Sets.difference(currentIds, newIds);
-            return new AdminChanges(toAdd, toRemove);
-        });
+    private Mono<Void> applyCalDavPatch(OpenPaaSId domainId, ResourceId resourceId, AdminChanges changes) {
+        if (changes.isEmpty()) {
+            return Mono.empty();
+        }
+        List<RemoveSharee> removals = changes.toRemove().stream()
+            .map(username -> new RemoveSharee("mailto:" + username.asString()))
+            .toList();
+        return calDavClient.updateCalendarShares(domainId, CalendarURL.from(resourceId.asOpenPaaSId()),
+                new CalendarSharingUpdate(new Share(changes.toAddOrUpdate().stream()
+                    .map(ResourceAdministrator::asAddSharee)
+                    .toList(), removals)))
+            .doOnError(err -> LOGGER.error("Error patching CalDAV delegation for resource {}", resourceId.value(), err));
     }
 
-    private Mono<List<Username>> findUsernamesByIds(Collection<OpenPaaSId> ids) {
-        return Flux.fromIterable(ids)
-            .flatMap(id -> userDAO.retrieve(id)
-                .map(OpenPaaSUser::username)
-                .switchIfEmpty(Mono.error(() -> new IllegalArgumentException("User id '" + id + "' does not exist"))), ReactorUtils.LOW_CONCURRENCY)
-            .collectList();
-    }
-
-    private boolean isReadWriteMailtoInvite(CalendarInvite invite) {
-        return MailtoUri.hasMailtoPrefix(invite.href())
-            && invite.access().filter(access -> access == READ_WRITE_ACCESS).isPresent();
-    }
-
-    private Flux<OpenPaaSUser> resolveAdminUsers(OpenPaaSId domainId, ResourceId resourceId) {
-        return resolveAdminUsernames(domainId, resourceId)
-            .flatMap(username -> userDAO.retrieve(username)
-                .switchIfEmpty(Mono.defer(() -> {
-                    LOGGER.warn("Ignoring resource administrator '{}' for resource '{}' because user does not exist",
-                        username.asString(), resourceId.value());
-                    return Mono.empty();
-                })), ReactorUtils.LOW_CONCURRENCY)
-            .distinct(OpenPaaSUser::id);
-    }
-
-    private Flux<Username> resolveAdminUsernames(OpenPaaSId domainId, ResourceId resourceId) {
+    private Flux<ResourceAdministrator> fetchAdministratorsFromSabre(OpenPaaSId domainId, ResourceId resourceId) {
         CalendarURL calendarURL = CalendarURL.from(resourceId.asOpenPaaSId());
         return calDavClient.fetchCalendarDetails(domainId, calendarURL, WITH_RIGHTS)
             .flatMapMany(response -> Flux.fromIterable(response.invites()))
-            .filter(this::isReadWriteMailtoInvite)
-            .map(invite -> Username.of(MailtoUri.stripMailtoPrefix(invite.href())))
-            .distinct();
+            .flatMap(invite -> Mono.justOrEmpty(ResourceAdministrator.from(invite)))
+            .distinct(ResourceAdministrator::username);
     }
 
-    private Mono<List<OpenPaaSUser>> resolveValidAdministrators(Collection<Username> administrators) {
-        return Flux.fromIterable(administrators)
-            .flatMap(username -> userDAO.retrieve(username)
-                .switchIfEmpty(Mono.error(() -> new ResourceAdministratorNotFoundException(username))))
-            .collectMap(OpenPaaSUser::username)
-            .map(adminMap -> adminMap.values().stream().toList());
+    private Flux<ResourceWithAdministration.ResolvedAdministrator> listAdministratorsWithRights(Resource resource) {
+        return fetchAdministratorsFromSabre(resource.domain(), resource.id())
+            .flatMap(administrator -> userDAO.retrieve(administrator.username())
+                .map(user -> new ResourceWithAdministration.ResolvedAdministrator(user, administrator.davRight()))
+                .switchIfEmpty(Mono.defer(() -> {
+                    LOGGER.warn("Ignoring resource administrator '{}' for resource '{}' because user does not exist",
+                        administrator.username().asString(), resource.id().value());
+                    return Mono.empty();
+                })), ReactorUtils.LOW_CONCURRENCY)
+            .distinct(administrator -> administrator.user().id());
     }
+
+    private Mono<List<ResourceAdministrator>> resolveValidAdministrators(Collection<ResourceAdministrator> administrators) {
+        return Flux.fromIterable(administrators)
+            .flatMap(admin -> userDAO.retrieve(admin.username())
+                .map(ignored -> admin)
+                .switchIfEmpty(Mono.error(() -> new ResourceAdministratorNotFoundException(admin.username()))))
+            .distinct(ResourceAdministrator::username)
+            .collectList();
+    }
+
 }

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/ResourceServiceTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/ResourceServiceTest.java
@@ -18,6 +18,9 @@
 
 package com.linagora.calendar.dav;
 
+import static com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
+import static com.linagora.calendar.dav.ResourceService.ResourceWithAdministration.ResolvedAdministrator;
+import static com.linagora.calendar.dav.ResourceService.ONLY_ACTIVE;
 import static com.linagora.calendar.storage.TestFixture.TECHNICAL_TOKEN_SERVICE_TESTING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -73,7 +76,7 @@ class ResourceServiceTest {
     }
 
     @Test
-    void listAdminUsersShouldReturnOnlyReadWriteMailtoUsers() {
+    void listAdministratorsShouldReturnReadWriteAndAdministrationMailtoUsers() {
         OpenPaaSUser creator = sabreDavExtension.newTestUser(Optional.of("creator_"));
         OpenPaaSUser readWriteUser = sabreDavExtension.newTestUser(Optional.of("admin_"));
         OpenPaaSUser reader = sabreDavExtension.newTestUser(Optional.of("reader_"));
@@ -85,11 +88,35 @@ class ResourceServiceTest {
             AddSharee.read(mailto(reader)),
             AddSharee.administration(mailto(davAdmin)));
 
-        List<OpenPaaSUser> actual = testee.listAdminUsers(resource)
+        List<ResourceService.ResourceAdministrator> actual = testee.listAdministrators(resource)
             .block();
 
         assertThat(actual)
-            .containsExactly(readWriteUser);
+            .containsExactlyInAnyOrder(
+                new ResourceAdministrator(readWriteUser.username(), DavRight.READ_WRITE),
+                new ResourceAdministrator(davAdmin.username(), DavRight.ADMINISTRATION));
+    }
+
+    @Test
+    void retrieveWithAdministrationShouldKeepAdministratorsAndTheirDavRights() {
+        OpenPaaSUser creator = sabreDavExtension.newTestUser(Optional.of("creator_"));
+        OpenPaaSUser readWriteUser = sabreDavExtension.newTestUser(Optional.of("admin_"));
+        OpenPaaSUser davAdmin = sabreDavExtension.newTestUser(Optional.of("dav_admin_"));
+        Resource resource = createResource(creator);
+
+        share(resource.id(),
+            AddSharee.readWrite(mailto(readWriteUser)),
+            AddSharee.administration(mailto(davAdmin)));
+
+        ResourceService.ResourceWithAdministration actual = testee.retrieveWithAdministration(resource.id(), ONLY_ACTIVE)
+            .block();
+
+        assertThat(actual.administratorsWithRight())
+            .containsExactlyInAnyOrder(
+                new ResolvedAdministrator(readWriteUser, DavRight.READ_WRITE),
+                new ResolvedAdministrator(davAdmin, DavRight.ADMINISTRATION));
+        assertThat(actual.administrators())
+            .containsExactlyInAnyOrder(readWriteUser, davAdmin);
     }
 
     @Test
@@ -153,7 +180,8 @@ class ResourceServiceTest {
             "Resource " + UUID.randomUUID());
         long resourceCountBefore = resourceDAO.findAll().count().block();
 
-        assertThatThrownBy(() -> testee.create(request, List.of(missingAdministrator)).block())
+        assertThatThrownBy(() -> testee.create(request, List.of(new ResourceAdministrator(
+            missingAdministrator, DavRight.ADMINISTRATION))).block())
             .isInstanceOf(ResourceAdministratorNotFoundException.class)
             .hasMessage("Resource administrator '%s' must exist".formatted(missingAdministrator.asString()));
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EntityRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/EntityRoute.java
@@ -44,6 +44,7 @@ import com.github.fge.lambdas.Throwing;
 import com.google.common.collect.ImmutableList;
 import com.linagora.calendar.dav.ResourceService;
 import com.linagora.calendar.dav.ResourceService.ResourceWithAdministration;
+import com.linagora.calendar.dav.ResourceService.ResourceWithAdministration.ResolvedAdministrator;
 import com.linagora.calendar.restapi.NotFoundException;
 import com.linagora.calendar.storage.DomainAdministrator;
 import com.linagora.calendar.storage.OpenPaaSDomain;
@@ -112,10 +113,12 @@ public class EntityRoute extends CalendarRoute {
                                String creator,
                                DomainDTO domain) {
 
-        record AdministratorDTO(@JsonProperty("id") String idRef) {
+        record AdministratorDTO(@JsonProperty("id") String idRef,
+                                String davRight,
+                                int access) {
 
-            static AdministratorDTO from(OpenPaaSUser user) {
-                return new AdministratorDTO(user.id().value());
+            static AdministratorDTO from(ResolvedAdministrator administrator) {
+                return new AdministratorDTO(administrator.user().id().value(), administrator.davRight().value(), administrator.davRight().access());
             }
 
             @JsonProperty("_id")
@@ -131,7 +134,7 @@ public class EntityRoute extends CalendarRoute {
 
         static ResourceResponseDTO from(ResourceWithAdministration resourceWithAdministration, DomainDTO domain) {
             Resource resource = resourceWithAdministration.resource();
-            List<AdministratorDTO> administrators = resourceWithAdministration.administrators().stream()
+            List<AdministratorDTO> administrators = resourceWithAdministration.administratorsWithRight().stream()
                 .map(AdministratorDTO::from)
                 .toList();
 

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ResourceRoute.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/routes/ResourceRoute.java
@@ -39,12 +39,12 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.fge.lambdas.Throwing;
 import com.linagora.calendar.dav.ResourceService;
 import com.linagora.calendar.dav.ResourceService.ResourceWithAdministration;
+import com.linagora.calendar.dav.ResourceService.ResourceWithAdministration.ResolvedAdministrator;
 import com.linagora.calendar.restapi.NotFoundException;
 import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSDomainAdminDAO;
 import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSId;
-import com.linagora.calendar.storage.OpenPaaSUser;
 import com.linagora.calendar.storage.model.Resource;
 import com.linagora.calendar.storage.model.ResourceId;
 
@@ -85,10 +85,12 @@ public class ResourceRoute extends CalendarRoute {
             Instant updatedAt) {
         }
 
-        record AdministratorDTO(@JsonProperty("id") String idRef) {
+        record AdministratorDTO(@JsonProperty("id") String idRef,
+                                String davRight,
+                                int access) {
 
-            static AdministratorDTO from(OpenPaaSUser user) {
-                return new AdministratorDTO(user.id().value());
+            static AdministratorDTO from(ResolvedAdministrator administrator) {
+                return new AdministratorDTO(administrator.user().id().value(), administrator.davRight().value(), administrator.davRight().access());
             }
 
             @JsonProperty("_id")
@@ -104,7 +106,7 @@ public class ResourceRoute extends CalendarRoute {
 
         static ResourceResponseDTO from(ResourceWithAdministration resourceWithAdministration, DomainRoute.ResponseDTO domain) {
             Resource resource = resourceWithAdministration.resource();
-            List<AdministratorDTO> administrators = resourceWithAdministration.administrators().stream()
+            List<AdministratorDTO> administrators = resourceWithAdministration.administratorsWithRight().stream()
                 .map(AdministratorDTO::from)
                 .toList();
 

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/ResourceRoutes.java
@@ -39,11 +39,11 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linagora.calendar.dav.DavRight;
 import com.linagora.calendar.dav.ResourceAdministratorNotFoundException;
 import com.linagora.calendar.dav.ResourceService;
-import com.linagora.calendar.dav.ResourceService.ResourceWithAdministration;
+import com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
 import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSDomainDAO;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -69,63 +69,51 @@ public class ResourceRoutes implements Routes {
     public static final String RESOURCES_PATH = DOMAINS + "/" + DOMAIN_PARAM + "/resources";
     private static final String RESOURCE_PATH = RESOURCES_PATH + "/:id";
 
-    public record AdministratorDTO(String email) {
-        @JsonCreator
-        public AdministratorDTO(@JsonProperty("email") String email) {
-            this.email = email;
+    public record AdministratorDTO(@JsonProperty(value = "email", required = true) String email,
+                                   @JsonProperty("davRight") String davRight) {
+        private static final DavRight RIGHT_DEFAULT = DavRight.READ_WRITE;
+
+        public static AdministratorDTO from(ResourceAdministrator administrator) {
+            return new AdministratorDTO(administrator.username().asString(), administrator.davRight().value());
+        }
+
+        public ResourceAdministrator toResourceAdministrator() {
+            if (StringUtils.isBlank(email)) {
+                throw new IllegalArgumentException("Administrator must provide 'email'");
+            }
+            DavRight right = DavRight.fromValue(Optional.ofNullable(davRight).orElse(RIGHT_DEFAULT.value()));
+            return new ResourceAdministrator(Username.of(email), right);
         }
     }
 
     public record ResourceDTO(String name, boolean deleted, String description, String id, String icon, String domain,
                               List<AdministratorDTO> administrators,
                               String creator) {
-        public static ResourceDTO fromDomainObject(Resource domainObject, Domain domain, List<OpenPaaSUser> administrators, String creator) {
-            return new ResourceDTO(domainObject.name(), domainObject.deleted(), domainObject.description(), domainObject.id().value(),
-                domainObject.icon(), domain.asString(), toAdministratorDTOs(administrators), creator);
-        }
-
-        private static List<AdministratorDTO> toAdministratorDTOs(List<OpenPaaSUser> administrators) {
-            return administrators.stream()
-                .map(user -> new AdministratorDTO(user.username().asString()))
-                .toList();
+        public static ResourceDTO from(Resource resource, Domain domain, List<ResourceAdministrator> administrators, String creator) {
+            return new ResourceDTO(resource.name(), resource.deleted(), resource.description(), resource.id().value(),
+                resource.icon(), domain.asString(), administrators.stream().map(AdministratorDTO::from).toList(), creator);
         }
     }
 
-    public record ResourceCreationDTO(String name, String description, String icon,
-                                      List<AdministratorDTO> administrators, String creator) {
-        @JsonCreator
-        public ResourceCreationDTO(@JsonProperty("name") String name,
-                                   @JsonProperty("description") String description,
-                                   @JsonProperty("icon") String icon,
-                                   @JsonProperty("administrators") List<AdministratorDTO> administrators,
-                                   @JsonProperty("creator") String creator) {
-            this.name = name;
-            this.description = description;
-            this.icon = icon;
-            this.administrators = administrators;
-            this.creator = creator;
+    public record ResourceCreationDTO(@JsonProperty("name") String name,
+                                      @JsonProperty("description") String description,
+                                      @JsonProperty("icon") String icon,
+                                      @JsonProperty("administrators") List<AdministratorDTO> administrators,
+                                      @JsonProperty("creator") String creator) {
+        public ResourceInsertRequest toInsertRequest(OpenPaaSId creatorId, OpenPaaSId domainId) {
+            return new ResourceInsertRequest(creatorId, description, domainId, icon, name);
         }
     }
 
-    public record ResourceUpdateDTO(String id, Optional<String> name, Optional<String> description,
-                                    Optional<String> icon,
-                                    Optional<String> domain, Optional<List<AdministratorDTO>> administrators,
-                                    Optional<String> creator) {
-        @JsonCreator
-        public ResourceUpdateDTO(@JsonProperty("id") String id,
-                                 @JsonProperty("name") Optional<String> name,
-                                 @JsonProperty("description") Optional<String> description,
-                                 @JsonProperty("icon") Optional<String> icon,
-                                 @JsonProperty("domain") Optional<String> domain,
-                                 @JsonProperty("administrators") Optional<List<AdministratorDTO>> administrators,
-                                 @JsonProperty("creator") Optional<String> creator) {
-            this.id = id;
-            this.name = name;
-            this.description = description;
-            this.icon = icon;
-            this.domain = domain;
-            this.administrators = administrators;
-            this.creator = creator;
+    public record ResourceUpdateDTO(@JsonProperty("id") String id,
+                                    @JsonProperty("name") Optional<String> name,
+                                    @JsonProperty("description") Optional<String> description,
+                                    @JsonProperty("icon") Optional<String> icon,
+                                    @JsonProperty("domain") Optional<String> domain,
+                                    @JsonProperty("administrators") Optional<List<AdministratorDTO>> administrators,
+                                    @JsonProperty("creator") Optional<String> creator) {
+        public ResourceUpdateRequest toUpdateRequest() {
+            return new ResourceUpdateRequest(name, description, icon);
         }
     }
 
@@ -166,7 +154,7 @@ public class ResourceRoutes implements Routes {
     private List<ResourceDTO> listResources(Request req) {
         OpenPaaSDomain domain = asDomainObject(req);
         return resourceService.listByDomain(domain.id())
-            .flatMap(this::toDto, ReactorUtils.LOW_CONCURRENCY)
+            .flatMap(resource -> resolveResourceDTO(resource, domain.domain()), ReactorUtils.LOW_CONCURRENCY)
             .collectList()
             .block();
     }
@@ -175,8 +163,8 @@ public class ResourceRoutes implements Routes {
         OpenPaaSDomain domain = asDomainObject(req);
         ResourceId id = new ResourceId(req.params("id"));
 
-        return resourceService.retrieveWithAdministration(id, domain.id(), !ONLY_ACTIVE)
-            .flatMap(this::toDto)
+        return resourceService.retrieve(id, domain.id(), !ONLY_ACTIVE)
+            .flatMap(resource -> resolveResourceDTO(resource, domain.domain()))
             .blockOptional()
             .orElseThrow(() -> resourceNotFound(id));
     }
@@ -196,26 +184,20 @@ public class ResourceRoutes implements Routes {
     private String createResource(Request req, Response res) throws JsonExtractException {
         OpenPaaSDomain domain = asDomainObject(req);
         ResourceCreationDTO creationDTO = creationDTOJsonExtractor.parse(req.body());
-
         Mono<OpenPaaSId> creatorIdMono = retrieveExistingUser(Username.of(creationDTO.creator))
             .map(OpenPaaSUser::id);
-
-        List<Username> administrators = administratorUsernamesFromDTO(creationDTO.administrators);
+        List<ResourceAdministrator> administrators = toResourceAdministrators(creationDTO.administrators);
 
         return creatorIdMono
-            .flatMap(creatorId -> resourceService.create(buildInsertRequest(creatorId, creationDTO, domain.id()), administrators))
+            .flatMap(creatorId -> resourceService.create(creationDTO.toInsertRequest(creatorId, domain.id()), administrators))
             .map(resourceId -> {
                 res.header(HttpHeader.LOCATION.asString(), DOMAINS + "/" + domain.domain().asString() + "/resources/" + resourceId.value());
                 res.status(HttpStatus.CREATED_201);
                 return StringUtils.EMPTY;
             })
             .onErrorMap(ResourceAdministratorNotFoundException.class, this::badRequest)
+            .onErrorMap(IllegalArgumentException.class, this::badRequest)
             .block();
-    }
-
-    private ResourceInsertRequest buildInsertRequest(OpenPaaSId creatorId,
-                                                     ResourceCreationDTO creationDTO, OpenPaaSId domainId) {
-        return new ResourceInsertRequest(creatorId, creationDTO.description, domainId, creationDTO.icon, creationDTO.name);
     }
 
     private String updateResource(Request req, Response res) throws JsonExtractException {
@@ -228,21 +210,26 @@ public class ResourceRoutes implements Routes {
             .doOnSuccess(_ -> res.status(HttpStatus.NO_CONTENT_204))
             .thenReturn(StringUtils.EMPTY)
             .onErrorMap(ResourceAdministratorNotFoundException.class, this::badRequest)
+            .onErrorMap(IllegalArgumentException.class, this::badRequest)
             .onErrorMap(ResourceNotFoundException.class, exception -> resourceNotFound(resourceId))
             .block();
     }
 
     private Mono<Void> updateResourceFromDTO(Resource resource, ResourceUpdateDTO dto) {
         return dto.administrators()
-            .map(administrators -> resourceService.updateAdmins(resource, administratorUsernamesFromDTO(administrators)))
+            .map(administrators -> resourceService.updateAdmins(resource, toResourceAdministrators(administrators)))
             .orElse(Mono.empty())
-            .then(resourceService.update(resource.id(), buildUpdateRequest(dto)));
+            .then(resourceService.update(resource.id(), dto.toUpdateRequest()));
     }
 
-    private List<Username> administratorUsernamesFromDTO(List<AdministratorDTO> administrators) {
-        return Optional.ofNullable(administrators).orElse(List.of()).stream()
-            .map(dto -> Username.of(dto.email()))
-            .toList();
+    private List<ResourceAdministrator> toResourceAdministrators(List<AdministratorDTO> administrators) {
+        try {
+            return Optional.ofNullable(administrators).orElse(List.of()).stream()
+                .map(AdministratorDTO::toResourceAdministrator)
+                .toList();
+        } catch (IllegalArgumentException e) {
+            throw badRequest(e);
+        }
     }
 
     private OpenPaaSDomain asDomainObject(Request request) {
@@ -271,22 +258,11 @@ public class ResourceRoutes implements Routes {
             .switchIfEmpty(Mono.error(() -> new ResourceNotFoundException(resourceId)));
     }
 
-    private Mono<ResourceDTO> toDto(Resource resource) {
+    private Mono<ResourceDTO> resolveResourceDTO(Resource resource, Domain domain) {
         return Mono.zip(
-                domainDAO.retrieve(resource.domain()),
                 userDAO.retrieve(resource.creator()),
-                resourceService.listAdminUsers(resource))
-            .map(tuple -> ResourceDTO.fromDomainObject(resource, tuple.getT1().domain(), tuple.getT3(), tuple.getT2().username().asString()));
-    }
-
-    private Mono<ResourceDTO> toDto(ResourceWithAdministration resourceWithAdministration) {
-        Resource resource = resourceWithAdministration.resource();
-
-        return Mono.zip(
-                domainDAO.retrieve(resource.domain()),
-                userDAO.retrieve(resource.creator()))
-            .map(tuple -> ResourceDTO.fromDomainObject(
-                resource, tuple.getT1().domain(), resourceWithAdministration.administrators(), tuple.getT2().username().asString()));
+                resourceService.listAdministrators(resource))
+            .map(tuple -> ResourceDTO.from(resource, domain, tuple.getT2(), tuple.getT1().username().asString()));
     }
 
     private Mono<OpenPaaSUser> retrieveExistingUser(Username username) {
@@ -310,10 +286,6 @@ public class ResourceRoutes implements Routes {
             .message(exception.getMessage())
             .cause(exception)
             .haltError();
-    }
-
-    private ResourceUpdateRequest buildUpdateRequest(ResourceUpdateDTO dto) {
-        return new ResourceUpdateRequest(dto.name(), dto.description(), dto.icon());
     }
 
 }

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/BookingLinkUserRoutesTest.java
@@ -50,6 +50,8 @@ import com.linagora.calendar.api.booking.AvailabilityRules;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.DavTestHelper;
 import com.linagora.calendar.dav.ResourceService;
+import com.linagora.calendar.dav.DavRight;
+import com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.restapi.routes.BookingLinkExtraAttendeeResolver;
 import com.linagora.calendar.restapi.routes.BookingLinkResourceResolver;
@@ -121,7 +123,7 @@ public class BookingLinkUserRoutesTest {
         OpenPaaSDomain domain = domainDAO.retrieve(owner.username().getDomainPart().orElseThrow()).block();
         return resourceService.create(new ResourceInsertRequest(owner.id(),
                 "Projector description", domain.id(), "projector", "Projector"),
-            List.of(owner.username())).block();
+            List.of(new ResourceAdministrator(owner.username(), DavRight.ADMINISTRATION))).block();
     }
 
     @AfterEach

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/ResourceRoutesTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/ResourceRoutesTest.java
@@ -46,6 +46,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.linagora.calendar.dav.CalDavClient;
 import com.linagora.calendar.dav.ResourceService;
+import com.linagora.calendar.dav.DavRight;
+import com.linagora.calendar.dav.ResourceService.ResourceAdministrator;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.storage.OpenPaaSDomain;
 import com.linagora.calendar.storage.OpenPaaSUser;
@@ -98,7 +100,7 @@ class ResourceRoutesTest {
         return resourceService.create(
             new ResourceInsertRequest(creator.id(), "Descripting", domain.id(), "laptop", "Resource name"),
             List.of(administrators).stream()
-                .map(OpenPaaSUser::username)
+                .map(user -> new ResourceAdministrator(user.username(), DavRight.ADMINISTRATION))
                 .toList()).block();
     }
 
@@ -159,7 +161,7 @@ class ResourceRoutesTest {
             .asString();
 
         assertThatJson(string)
-            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .withOptions(Option.IGNORING_ARRAY_ORDER, Option.IGNORING_EXTRA_FIELDS)
             .isEqualTo("""
                            [
                            {
@@ -201,7 +203,7 @@ class ResourceRoutesTest {
 
 
         assertThatJson(string)
-            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .withOptions(Option.IGNORING_ARRAY_ORDER, Option.IGNORING_EXTRA_FIELDS)
             .isEqualTo("""
                            {
                                "name": "Resource name",
@@ -258,6 +260,7 @@ class ResourceRoutesTest {
             .asString();
 
         assertThatJson(string)
+            .withOptions(Option.IGNORING_EXTRA_FIELDS)
             .isEqualTo("""
                            {
                                "name": "Resource name 2",
@@ -302,7 +305,7 @@ class ResourceRoutesTest {
             .asString();
 
         assertThatJson(string)
-            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .withOptions(Option.IGNORING_ARRAY_ORDER, Option.IGNORING_EXTRA_FIELDS)
             .isEqualTo("""
                            {
                                "name": "Resource name 2",
@@ -400,7 +403,7 @@ class ResourceRoutesTest {
 
         assertThatJson(string)
             .whenIgnoringPaths("[0].id")
-            .withOptions(Option.IGNORING_ARRAY_ORDER)
+            .withOptions(Option.IGNORING_ARRAY_ORDER, Option.IGNORING_EXTRA_FIELDS)
             .isEqualTo("""
                            [{
                                "name": "Resource name",
@@ -677,7 +680,145 @@ class ResourceRoutesTest {
             .as("DAV invite list should contain admin delegation entry")
             .isNotEmpty()
             .anySatisfy(invite ->
-                assertThat(invite.get("href").asText()).contains(admin.username().asString()));
+                assertThat(invite.get("href").asText()).contains(admin.username().asString())
+                    .satisfies(_ -> assertThat(invite.get("access").asInt()).isEqualTo(3)));
+
+        String resource = when()
+            .get("/domains/" + DOMAIN + "/resources/" + resourceId)
+            .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+
+        assertThatJson(resource)
+            .inPath("$.administrators[0].davRight")
+            .isEqualTo("dav:read-write");
+    }
+
+    @Test
+    void createResourceShouldSupportAdministrationRight() {
+        OpenPaaSUser creator = sabreDavExtension.newTestUser();
+        OpenPaaSUser admin = sabreDavExtension.newTestUser();
+
+        String location = given()
+            .body("""
+                {
+                    "name": "Managed Room",
+                    "description": "Room with ACL administrator",
+                    "creator": "%s",
+                    "icon": "door",
+                    "administrators": [
+                        {
+                            "email": "%s",
+                            "davRight": "dav:administration"
+                        }
+                    ]
+                }
+                """.formatted(creator.username().asString(), admin.username().asString()))
+            .post("/domains/" + DOMAIN + "/resources")
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("Location");
+
+        String resourceId = location.substring(location.lastIndexOf('/') + 1);
+        OpenPaaSDomain openPaaSDomain = domainDAO.retrieve(creator.username().getDomainPart().get()).block();
+        ArrayNode invites = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(openPaaSDomain.id(), new ResourceId(resourceId))
+            .block();
+
+        assertThat(invites)
+            .anySatisfy(invite -> {
+                assertThat(invite.get("href").asText()).contains(admin.username().asString());
+                assertThat(invite.get("access").asInt()).isEqualTo(5);
+            });
+
+        String resource = when()
+            .get("/domains/" + DOMAIN + "/resources/" + resourceId)
+            .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+
+        assertThatJson(resource)
+            .inPath("$.administrators[0].davRight")
+            .isEqualTo("dav:administration");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"abcxyz", "dav:unsupported"})
+    void createResourceShouldRejectUnsupportedAdministratorRight(String davRight) {
+        OpenPaaSUser creator = sabreDavExtension.newTestUser();
+        OpenPaaSUser administrator = sabreDavExtension.newTestUser();
+
+        String response = given()
+            .body("""
+                {
+                    "name": "Invalid right room",
+                    "description": "Room with invalid administrator right",
+                    "creator": "%s",
+                    "icon": "door",
+                    "administrators": [{ "email": "%s", "davRight": "%s" }]
+                }
+                """.formatted(creator.username().asString(), administrator.username().asString(), davRight))
+            .post("/domains/" + DOMAIN + "/resources")
+            .then()
+            .statusCode(400)
+            .extract()
+            .asString();
+
+        assertThatJson(response)
+            .inPath("$.message")
+            .isEqualTo("Unsupported DAV right: " + davRight);
+    }
+
+    @Test
+    void updateResourceShouldSupportUpdateAdministratorDavRight() {
+        OpenPaaSUser creator = sabreDavExtension.newTestUser();
+        OpenPaaSUser admin = sabreDavExtension.newTestUser();
+
+        String location = given()
+            .body("""
+                {
+                    "name": "Upgradeable Room",
+                    "description": "Room with upgradeable administrator",
+                    "creator": "%s",
+                    "icon": "door",
+                    "administrators": [{ "email": "%s" }]
+                }
+                """.formatted(creator.username().asString(), admin.username().asString()))
+            .post("/domains/" + DOMAIN + "/resources")
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("Location");
+
+        String resourceId = location.substring(location.lastIndexOf('/') + 1);
+        given()
+            .body("""
+                {
+                    "administrators": [
+                        {
+                            "email": "%s",
+                            "davRight": "dav:administration"
+                        }
+                    ]
+                }
+                """.formatted(admin.username().asString()))
+            .patch("/domains/" + DOMAIN + "/resources/" + resourceId)
+            .then()
+            .statusCode(204);
+
+        OpenPaaSDomain openPaaSDomain = domainDAO.retrieve(creator.username().getDomainPart().get()).block();
+        ArrayNode invites = sabreDavExtension.davTestHelper()
+            .getCalendarDelegateInvites(openPaaSDomain.id(), new ResourceId(resourceId))
+            .block();
+
+        assertThat(invites)
+            .anySatisfy(invite -> {
+                assertThat(invite.get("href").asText()).contains(admin.username().asString());
+                assertThat(invite.get("access").asInt()).isEqualTo(5);
+            });
     }
 
     @Test

--- a/docs/apis/openpaasApi.md
+++ b/docs/apis/openpaasApi.md
@@ -432,7 +432,9 @@ Example response:
     {
       "_id": "adminId",
       "id": "adminId",
-      "objectType": "user"
+      "objectType": "user",
+      "davRight": "dav:read-write",
+      "access": 3
     }
   ],
   "timestamps": {
@@ -444,9 +446,11 @@ Example response:
 }
 ```
 
+`davRight` and integer `access` are resolved from Sabre: 3 is `dav:read-write`, 5 is `dav:administration`.
+
 ### GET /linagora.esn.resource/api/resources/{resourceId} (Deprecated)
 
-Deprecated in favor of `GET /api/resources/{resourceId}`, kept for OpenPaaS backward compatibility.
+Deprecated in favor of `GET /api/resources/{resourceId}`. It returns the same administrator fields.
 
 
 ### GET /images/icon/{icon}.svg

--- a/docs/apis/webadmin.md
+++ b/docs/apis/webadmin.md
@@ -443,8 +443,14 @@ Will list existing resources for that domain:
     "domain": "linagora.com",
     "creator":"user1@linagora.com",
     "administrators": [
-      {"email": "user1@linagora.com"},
-      {"email": "user2@linagora.com"}
+      {
+        "email": "user1@linagora.com",
+        "davRight": "dav:read-write"
+      },
+      {
+        "email": "user2@linagora.com",
+        "davRight": "dav:administration"
+      }
     ]
   }
 ]
@@ -473,8 +479,14 @@ Will return the corresponding resource:
     "icon": "laptop",
     "domain": "linagora.com",
     "administrators": [
-      {"email": "user1@linagora.com"},
-      {"email": "user2@linagora.com"}
+      {
+        "email": "user1@linagora.com",
+        "davRight": "dav:read-write"
+      },
+      {
+        "email": "user2@linagora.com",
+        "davRight": "dav:administration"
+      }
     ]
   }
 ```
@@ -501,8 +513,14 @@ POST /domains/linagora.com/resources
   "creator":"user1@linagora.com",
   "icon": "laptop",
   "administrators": [
-    {"email": "user1@linagora.com"},
-    {"email": "user2@linagora.com"}
+    {
+      "email": "user1@linagora.com",
+      "davRight": "dav:read-write"
+    },
+    {
+      "email": "user2@linagora.com",
+      "davRight": "dav:administration"
+    }
   ]
 }
 ```
@@ -529,9 +547,8 @@ Status codes:
 A resource without administrator is not subject to the validation flow: any event request with this resource is
 automatically accepted.
 
-Please note that resource administrators:
- - are emailed upon events created that book the resource
- - have delegation write access to the calendar of the resource
+An administrator has `email` and an optional `davRight`: `dav:read-write` (access 3, default) or
+`dav:administration` (access 5). Responses return `davRight`.
 
 ### Updating a resource
 
@@ -542,7 +559,10 @@ PATCH /domains/linagora.com/resources/RESOURCE_ID
   "description": "Descripting 2",
   "icon": "battery",
   "administrators": [
-    {"email": "user2@linagora.com"}
+    {
+      "email": "user2@linagora.com",
+      "davRight": "dav:administration"
+    }
   ]
 }
 ```
@@ -551,9 +571,7 @@ Would update the resource accordingly. Each field is optional; omitting a field 
 
 Status codes: 204 if updated, 400 if invalid (e.g. administrator not found), 404 if domain or resource not found.
 
-Please note that resource administrators:
- - are emailed upon events created that book the resource
- - have delegation write access to the calendar of the resource. Removing an administrator revokes this delegation right.
+Both rights can update event participation; only `dav:administration` can manage the resource ACL.
 
 ## Team calendar routes
 


### PR DESCRIPTION
Add DAV-native administrator rights for resources, with Sabre remaining the source of truth.

Previously, resource administrators created through WebAdmin were always granted access 3 (`dav:read-write`). 
This prevented them from managing the resource ACL. With `davRight` support, administrators can now be assigned a more specific DAV right.

When `davRight` is omitted, the API falls back to access 3 (`dav:read-write`) for backward compatibility.