### PR TITLE
fix(webadmin): disable generated passwords in test configs

### DIFF
--- a/app/docker-sample/conf-side-service/webadmin.properties
+++ b/app/docker-sample/conf-side-service/webadmin.properties
@@ -1,5 +1,6 @@
 enabled=true
 port=8000
 host=0.0.0.0
+password.generate=false
 
 https.enabled=false

--- a/app/src/test/resources/webadmin.properties
+++ b/app/src/test/resources/webadmin.properties
@@ -1,3 +1,4 @@
 enabled=true
 port=0
 host=127.0.0.1
+password.generate=false


### PR DESCRIPTION
Fix CI fail
Related: https://github.com/apache/james-project/commit/24c23e76d64a