### PR TITLE
chore - extract calendar sharing update model

### DIFF
--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalDavClient.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import javax.net.ssl.SSLException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Strings;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.james.core.Username;
@@ -111,54 +110,6 @@ public class CalDavClient extends DavClient {
 
         public static CalendarPropertiesUpdate withName(String name) {
             return new CalendarPropertiesUpdate(Optional.of(name), Optional.empty(), Optional.empty());
-        }
-    }
-
-    public record CalendarSharingUpdate(@JsonProperty(value = "share", required = true) Share share) {
-        private static final String MAILTO_PREFIX = "mailto:";
-
-        public CalendarSharingUpdate {
-            Preconditions.checkArgument(share != null, "'share' field is required");
-        }
-
-        public record Share(@JsonProperty("set") List<AddSharee> set,
-                            @JsonProperty("remove") List<RemoveSharee> remove) {
-            public Share {
-                set = Optional.ofNullable(set).orElse(List.of());
-                remove = Optional.ofNullable(remove).orElse(List.of());
-            }
-        }
-
-        @JsonInclude(JsonInclude.Include.NON_ABSENT)
-        public record AddSharee(@JsonProperty("dav:href") String davHref,
-                                @JsonProperty("dav:read") Optional<Boolean> read,
-                                @JsonProperty("dav:read-write") Optional<Boolean> readWrite,
-                                @JsonProperty("dav:administration") Optional<Boolean> administration) {
-            public static AddSharee read(String davHref) {
-                return new AddSharee(davHref, Optional.of(true), Optional.empty(), Optional.empty());
-            }
-
-            public static AddSharee readWrite(String davHref) {
-                return new AddSharee(davHref, Optional.empty(), Optional.of(true), Optional.empty());
-            }
-
-            public static AddSharee administration(String davHref) {
-                return new AddSharee(davHref, Optional.empty(), Optional.empty(), Optional.of(true));
-            }
-
-            public AddSharee {
-                Preconditions.checkArgument(Strings.CI.startsWith(davHref, MAILTO_PREFIX),
-                    "'dav:href' must be a '" + MAILTO_PREFIX + "' URI");
-                Preconditions.checkArgument(read.isPresent() || readWrite.isPresent() || administration.isPresent(),
-                    "One of 'dav:read', 'dav:read-write', 'dav:administration' must be provided");
-            }
-        }
-
-        public record RemoveSharee(@JsonProperty("dav:href") String davHref) {
-            public RemoveSharee {
-                Preconditions.checkArgument(Strings.CI.startsWith(davHref, MAILTO_PREFIX),
-                    "'dav:href' must be a '" + MAILTO_PREFIX + "' URI");
-            }
         }
     }
 

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/CalendarSharingUpdate.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/CalendarSharingUpdate.java
@@ -1,0 +1,187 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.Strings;
+import org.apache.james.core.Username;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+public record CalendarSharingUpdate(@JsonProperty(value = "share", required = true) Share share) {
+    private static final String MAILTO_PREFIX = "mailto:";
+
+    public static class InvalidDavRightException extends IllegalArgumentException {
+        public InvalidDavRightException() {
+            super("Exactly one of 'dav:read', 'dav:read-write', 'dav:administration' must be true");
+        }
+    }
+
+    public CalendarSharingUpdate {
+        Preconditions.checkArgument(share != null, "'share' field is required");
+    }
+
+    public static CalendarSharingUpdate grant(AddSharee... additions) {
+        return builder().grantAll(List.of(additions)).build();
+    }
+
+    public static CalendarSharingUpdate grant(Username username, DavRight davRight) {
+        return grant(AddSharee.of(username, davRight));
+    }
+
+    public static CalendarSharingUpdate revoke(Username... usernames) {
+        return builder().revokeAll(Arrays.stream(usernames).map(RemoveSharee::of).toList()).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public record Share(@JsonProperty("set") List<AddSharee> set,
+                        @JsonProperty("remove") List<RemoveSharee> remove) {
+        public Share {
+            set = List.copyOf(Objects.requireNonNullElse(set, List.of()));
+            remove = List.copyOf(Objects.requireNonNullElse(remove, List.of()));
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record AddSharee(@JsonProperty("dav:href") String davHref,
+                            @JsonIgnore DavRight davRight) {
+        public AddSharee {
+            Preconditions.checkArgument(Strings.CI.startsWith(davHref, MAILTO_PREFIX),
+                "'dav:href' must be a '" + MAILTO_PREFIX + "' URI");
+            Objects.requireNonNull(davRight, "davRight must not be null");
+        }
+
+        @JsonCreator
+        public static AddSharee fromJson(@JsonProperty("dav:href") String davHref,
+                                         @JsonProperty("dav:read") Boolean read,
+                                         @JsonProperty("dav:read-write") Boolean readWrite,
+                                         @JsonProperty("dav:administration") Boolean administration) {
+            List<DavRight> enabledRights = new ArrayList<>();
+            if (Boolean.TRUE.equals(read)) {
+                enabledRights.add(DavRight.READ);
+            }
+            if (Boolean.TRUE.equals(readWrite)) {
+                enabledRights.add(DavRight.READ_WRITE);
+            }
+            if (Boolean.TRUE.equals(administration)) {
+                enabledRights.add(DavRight.ADMINISTRATION);
+            }
+            if (enabledRights.size() != 1) {
+                throw new InvalidDavRightException();
+            }
+            return new AddSharee(davHref, enabledRights.getFirst());
+        }
+
+        public static AddSharee of(String davHref, DavRight davRight) {
+            return new AddSharee(davHref, davRight);
+        }
+
+        public static AddSharee of(Username username, DavRight davRight) {
+            return of(toDavHref(username), davRight);
+        }
+
+        @JsonProperty("dav:read")
+        public Boolean read() {
+            return davRight == DavRight.READ ? true : null;
+        }
+
+        @JsonProperty("dav:read-write")
+        public Boolean readWrite() {
+            return davRight == DavRight.READ_WRITE ? true : null;
+        }
+
+        @JsonProperty("dav:administration")
+        public Boolean administration() {
+            return davRight == DavRight.ADMINISTRATION ? true : null;
+        }
+    }
+
+    public record RemoveSharee(@JsonProperty("dav:href") String davHref) {
+        public RemoveSharee {
+            Preconditions.checkArgument(Strings.CI.startsWith(davHref, MAILTO_PREFIX),
+                "'dav:href' must be a '" + MAILTO_PREFIX + "' URI");
+        }
+
+        public static RemoveSharee of(Username username) {
+            return new RemoveSharee(toDavHref(username));
+        }
+    }
+
+    public static final class Builder {
+        private final List<AddSharee> additions = new ArrayList<>();
+        private final List<RemoveSharee> removals = new ArrayList<>();
+
+        public Builder grant(Username username, DavRight davRight) {
+            return grant(AddSharee.of(username, davRight));
+        }
+
+        public Builder grant(String davHref, DavRight davRight) {
+            return grant(AddSharee.of(davHref, davRight));
+        }
+
+        public Builder grant(AddSharee sharee) {
+            additions.add(sharee);
+            return this;
+        }
+
+        public Builder grantAll(Collection<AddSharee> sharees) {
+            additions.addAll(sharees);
+            return this;
+        }
+
+        public Builder revoke(Username username) {
+            return revoke(RemoveSharee.of(username));
+        }
+
+        public Builder revoke(String davHref) {
+            return revoke(new RemoveSharee(davHref));
+        }
+
+        public Builder revoke(RemoveSharee sharee) {
+            removals.add(sharee);
+            return this;
+        }
+
+        public Builder revokeAll(Collection<RemoveSharee> sharees) {
+            removals.addAll(sharees);
+            return this;
+        }
+
+        public CalendarSharingUpdate build() {
+            return new CalendarSharingUpdate(new Share(additions, removals));
+        }
+
+        private Builder() {
+        }
+    }
+
+    private static String toDavHref(Username username) {
+        return MAILTO_PREFIX + username.asString();
+    }
+}

--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/ResourceService.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/ResourceService.java
@@ -34,10 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.AddSharee;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.RemoveSharee;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.Share;
+import com.linagora.calendar.dav.CalendarSharingUpdate.AddSharee;
 import com.linagora.calendar.dav.dto.CalendarDetailsResponse.CalendarInvite;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.MailtoUri;
@@ -66,12 +63,8 @@ public class ResourceService {
                 .map(right -> new ResourceAdministrator(Username.of(MailtoUri.stripMailtoPrefix(invite.href())), right));
         }
 
-        public static AddSharee asAddSharee(ResourceAdministrator administrator) {
-            return switch (administrator.davRight) {
-                case READ_WRITE -> AddSharee.readWrite("mailto:" + administrator.username.asString());
-                case ADMINISTRATION -> AddSharee.administration("mailto:" + administrator.username.asString());
-                default -> throw new IllegalArgumentException("Unsupported resource administrator DAV right: " + administrator.davRight);
-            };
+        public AddSharee asAddSharee() {
+            return AddSharee.of(username, davRight);
         }
     }
 
@@ -107,6 +100,18 @@ public class ResourceService {
 
         public boolean isEmpty() {
             return toAddOrUpdate.isEmpty() && toRemove.isEmpty();
+        }
+
+        public List<AddSharee> listAddSharees() {
+            return toAddOrUpdate.stream()
+                .map(ResourceAdministrator::asAddSharee)
+                .toList();
+        }
+
+        public List<CalendarSharingUpdate.RemoveSharee> listRemoveSharees() {
+            return toRemove.stream()
+                .map(CalendarSharingUpdate.RemoveSharee::of)
+                .toList();
         }
     }
 
@@ -199,13 +204,11 @@ public class ResourceService {
         if (changes.isEmpty()) {
             return Mono.empty();
         }
-        List<RemoveSharee> removals = changes.toRemove().stream()
-            .map(username -> new RemoveSharee("mailto:" + username.asString()))
-            .toList();
         return calDavClient.updateCalendarShares(domainId, CalendarURL.from(resourceId.asOpenPaaSId()),
-                new CalendarSharingUpdate(new Share(changes.toAddOrUpdate().stream()
-                    .map(ResourceAdministrator::asAddSharee)
-                    .toList(), removals)))
+                CalendarSharingUpdate.builder()
+                    .grantAll(changes.listAddSharees())
+                    .revokeAll(changes.listRemoveSharees())
+                    .build())
             .doOnError(err -> LOGGER.error("Error patching CalDAV delegation for resource {}", resourceId.value(), err));
     }
 

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalDavClientTest.java
@@ -51,7 +51,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linagora.calendar.api.CalendarUtil;
 import com.linagora.calendar.dav.CalDavClient.CalendarAccess;
 import com.linagora.calendar.dav.CalDavClient.CalendarPropertiesUpdate;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
 import com.linagora.calendar.dav.CalDavClient.NewCalendar;
 import com.linagora.calendar.dav.FreeBusyQueryResponseObject.BusyInterval;
 import com.linagora.calendar.dav.dto.CalendarDetailsResponse;
@@ -326,9 +325,8 @@ public class CalDavClientTest {
         String calendarId = UUID.randomUUID().toString();
         CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
         String delegateMailto = "mailto:" + delegate.username().asString();
-        CalendarSharingUpdate sharingUpdate = new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
-            List.of(CalendarSharingUpdate.AddSharee.readWrite(delegateMailto)),
-            List.of()));
+        CalendarSharingUpdate sharingUpdate = CalendarSharingUpdate.grant(
+            CalendarSharingUpdate.AddSharee.of(delegateMailto, DavRight.READ_WRITE));
 
         testee.createNewCalendar(owner.username(), owner.id(), new NewCalendar(calendarId, "Shared calendar", "#0000FF", "")).block();
         testee.updateCalendarShares(owner.username(), calendarURL, sharingUpdate).block();
@@ -580,10 +578,7 @@ public class CalDavClientTest {
         OpenPaaSId calendarId = teamCalendar.id().asOpenPaaSId();
         CalendarURL teamCalendarURL = CalendarURL.from(calendarId);
         String teamCalendarPrincipalUri = "principals/team-calendars/" + teamCalendar.id().value();
-        CalendarSharingUpdate sharingUpdate = new CalendarSharingUpdate(
-            new CalendarSharingUpdate.Share(
-                List.of(CalendarSharingUpdate.AddSharee.readWrite("mailto:" + member.username().asString())),
-                List.of()));
+        CalendarSharingUpdate sharingUpdate = CalendarSharingUpdate.grant(member.username(), DavRight.READ_WRITE);
 
         testee.updateCalendarShares(domain.id(), teamCalendarURL, sharingUpdate).block();
 
@@ -1647,10 +1642,7 @@ public class CalDavClientTest {
         CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
 
         testee.updateCalendarShares(owner.username(), calendarURL,
-            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
-                List.of(new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
-                    Optional.empty(), Optional.of(true), Optional.empty())),
-                List.of()))).block();
+            CalendarSharingUpdate.grant(delegate.username(), DavRight.READ_WRITE)).block();
 
         assertThat(testee.findUserCalendars(delegate.username(), delegate.id()).collectList().block())
             .anyMatch(url -> !url.calendarId().equals(delegate.id()));
@@ -1664,15 +1656,10 @@ public class CalDavClientTest {
         testee.createNewCalendar(owner.username(), owner.id(), new NewCalendar(calendarId, "Shared calendar", "#0000FF", "")).block();
         CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
         testee.updateCalendarShares(owner.username(), calendarURL,
-            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
-                List.of(new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
-                    Optional.empty(), Optional.of(true), Optional.empty())),
-                List.of()))).block();
+            CalendarSharingUpdate.grant(delegate.username(), DavRight.READ_WRITE)).block();
 
         testee.updateCalendarShares(owner.username(), calendarURL,
-            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
-                List.of(),
-                List.of(new CalendarSharingUpdate.RemoveSharee("mailto:" + delegate.username().asString()))))).block();
+            CalendarSharingUpdate.revoke(delegate.username())).block();
 
         assertThat(testee.findUserCalendars(delegate.username(), delegate.id()).collectList().block())
             .allMatch(url -> url.calendarId().equals(delegate.id()));
@@ -1699,8 +1686,7 @@ public class CalDavClientTest {
         OpenPaaSUser owner = createOpenPaaSUser();
         OpenPaaSUser delegate = createOpenPaaSUser();
         CalendarURL delegatedCalendar = shareCalendar(owner, delegate,
-            new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
-                Optional.empty(), Optional.of(true), Optional.empty()));
+            CalendarSharingUpdate.AddSharee.of(delegate.username(), DavRight.READ_WRITE));
 
         assertThat(testee.resolveCalendarAccess(delegate.username(), delegatedCalendar).block()).isEqualTo(CalendarAccess.WRITABLE);
     }
@@ -1710,8 +1696,7 @@ public class CalDavClientTest {
         OpenPaaSUser owner = createOpenPaaSUser();
         OpenPaaSUser delegate = createOpenPaaSUser();
         CalendarURL delegatedCalendar = shareCalendar(owner, delegate,
-            new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
-                Optional.of(true), Optional.empty(), Optional.empty()));
+            CalendarSharingUpdate.AddSharee.of(delegate.username(), DavRight.READ));
 
         assertThat(testee.resolveCalendarAccess(delegate.username(), delegatedCalendar).block()).isEqualTo(CalendarAccess.READ_ONLY);
     }
@@ -1721,8 +1706,7 @@ public class CalDavClientTest {
         OpenPaaSUser owner = createOpenPaaSUser();
         OpenPaaSUser delegate = createOpenPaaSUser();
         CalendarURL delegatedCalendar = shareCalendar(owner, delegate,
-            new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
-                Optional.empty(), Optional.empty(), Optional.of(true)));
+            CalendarSharingUpdate.AddSharee.of(delegate.username(), DavRight.ADMINISTRATION));
 
         assertThat(testee.resolveCalendarAccess(delegate.username(), delegatedCalendar).block()).isEqualTo(CalendarAccess.WRITABLE);
     }
@@ -1733,7 +1717,7 @@ public class CalDavClientTest {
         CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(calendarId));
 
         testee.updateCalendarShares(owner.username(), calendarURL,
-            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(List.of(sharee), List.of()))).block();
+            CalendarSharingUpdate.grant(sharee)).block();
 
         return testee.findUserCalendars(delegate.username(), delegate.id()).collectList().block().stream()
             .filter(url -> !url.calendarId().equals(delegate.id()))
@@ -1748,10 +1732,7 @@ public class CalDavClientTest {
         CalendarURL calendarURL = new CalendarURL(owner.id(), new OpenPaaSId(UUID.randomUUID().toString()));
 
         assertThatThrownBy(() -> testee.updateCalendarShares(owner.username(), calendarURL,
-            new CalendarSharingUpdate(new CalendarSharingUpdate.Share(
-                List.of(new CalendarSharingUpdate.AddSharee("mailto:" + delegate.username().asString(),
-                    Optional.of(true), Optional.empty(), Optional.empty())),
-                List.of()))).block())
+            CalendarSharingUpdate.grant(delegate.username(), DavRight.READ)).block())
             .isInstanceOf(CalendarNotFoundException.class);
     }
 }

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSharingUpdateTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/CalendarSharingUpdateTest.java
@@ -1,0 +1,89 @@
+/********************************************************************
+ *  As a subpart of Twake Mail, this file is edited by Linagora.    *
+ *                                                                  *
+ *  https://twake-mail.com/                                         *
+ *  https://linagora.com                                            *
+ *                                                                  *
+ *  This file is subject to The Affero Gnu Public License           *
+ *  version 3.                                                      *
+ *                                                                  *
+ *  This program is distributed in the hope that it will be         *
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied      *
+ *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR         *
+ *  PURPOSE. See the GNU Affero General Public License for          *
+ *  more details.                                                   *
+ ********************************************************************/
+
+package com.linagora.calendar.dav;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.james.core.Username;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class CalendarSharingUpdateTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void shouldSerializeToSabreWireFormat() throws Exception {
+        CalendarSharingUpdate update = CalendarSharingUpdate.builder()
+            .grant(Username.of("viewer@example.com"), DavRight.READ)
+            .grant(Username.of("member@example.com"), DavRight.READ_WRITE)
+            .grant(Username.of("manager@example.com"), DavRight.ADMINISTRATION)
+            .revoke(Username.of("removed@example.com"))
+            .build();
+
+        assertThatJson(OBJECT_MAPPER.writeValueAsString(update)).isEqualTo("""
+            {
+              "share": {
+                "set": [
+                  {"dav:href": "mailto:viewer@example.com", "dav:read": true},
+                  {"dav:href": "mailto:member@example.com", "dav:read-write": true},
+                  {"dav:href": "mailto:manager@example.com", "dav:administration": true}
+                ],
+                "remove": [
+                  {"dav:href": "mailto:removed@example.com"}
+                ]
+              }
+            }
+            """);
+    }
+
+    @Test
+    void shouldDeserializeDavRightFromSabreWireFormat() throws Exception {
+        CalendarSharingUpdate actual = OBJECT_MAPPER.readValue("""
+            {
+              "share": {
+                "set": [{"dav:href": "mailto:member@example.com", "dav:read-write": true}],
+                "remove": []
+              }
+            }
+            """, CalendarSharingUpdate.class);
+
+        assertThat(actual.share().set())
+            .containsExactly(CalendarSharingUpdate.AddSharee.of(
+                Username.of("member@example.com"), DavRight.READ_WRITE));
+    }
+
+    @Test
+    void shouldRejectMoreThanOneEnabledDavRight() {
+        assertThatThrownBy(() -> OBJECT_MAPPER.readValue("""
+            {
+              "share": {
+                "set": [{
+                  "dav:href": "mailto:member@example.com",
+                  "dav:read": true,
+                  "dav:read-write": true
+                }],
+                "remove": []
+              }
+            }
+            """, CalendarSharingUpdate.class))
+            .hasRootCauseInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Exactly one of 'dav:read', 'dav:read-write', 'dav:administration' must be true");
+    }
+}

--- a/calendar-dav/src/test/java/com/linagora/calendar/dav/ResourceServiceTest.java
+++ b/calendar-dav/src/test/java/com/linagora/calendar/dav/ResourceServiceTest.java
@@ -38,9 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.AddSharee;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.Share;
+import com.linagora.calendar.dav.CalendarSharingUpdate.AddSharee;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.MemoryOpenPaaSUserDAO;
 import com.linagora.calendar.storage.OpenPaaSDomain;
@@ -84,9 +82,9 @@ class ResourceServiceTest {
         Resource resource = createResource(creator);
 
         share(resource.id(),
-            AddSharee.readWrite(mailto(readWriteUser)),
-            AddSharee.read(mailto(reader)),
-            AddSharee.administration(mailto(davAdmin)));
+            AddSharee.of(readWriteUser.username(), DavRight.READ_WRITE),
+            AddSharee.of(reader.username(), DavRight.READ),
+            AddSharee.of(davAdmin.username(), DavRight.ADMINISTRATION));
 
         List<ResourceService.ResourceAdministrator> actual = testee.listAdministrators(resource)
             .block();
@@ -105,8 +103,8 @@ class ResourceServiceTest {
         Resource resource = createResource(creator);
 
         share(resource.id(),
-            AddSharee.readWrite(mailto(readWriteUser)),
-            AddSharee.administration(mailto(davAdmin)));
+            AddSharee.of(readWriteUser.username(), DavRight.READ_WRITE),
+            AddSharee.of(davAdmin.username(), DavRight.ADMINISTRATION));
 
         ResourceService.ResourceWithAdministration actual = testee.retrieveWithAdministration(resource.id(), ONLY_ACTIVE)
             .block();
@@ -141,8 +139,8 @@ class ResourceServiceTest {
         ResourceService resolver = new ResourceService(memoryUserDAO, resourceDAO, calDavClient);
 
         share(resource.id(),
-            AddSharee.readWrite(mailto(resolvedUser)),
-            AddSharee.readWrite(mailto(unresolvedUser)));
+            AddSharee.of(resolvedUser.username(), DavRight.READ_WRITE),
+            AddSharee.of(unresolvedUser.username(), DavRight.READ_WRITE));
 
         List<OpenPaaSUser> actual = resolver.listAdminUsers(resource)
             .block();
@@ -159,8 +157,8 @@ class ResourceServiceTest {
         Resource resource = createResource(creator);
 
         share(resource.id(),
-            AddSharee.readWrite(mailto(readWriteUser)),
-            AddSharee.read(mailto(reader)));
+            AddSharee.of(readWriteUser.username(), DavRight.READ_WRITE),
+            AddSharee.of(reader.username(), DavRight.READ));
 
         assertThat(testee.isAdministrator(resource, readWriteUser.username()).block())
             .isTrue();
@@ -214,11 +212,7 @@ class ResourceServiceTest {
     private void share(ResourceId resourceId, AddSharee... sharees) {
         calDavClient.updateCalendarShares(domain.id(),
             CalendarURL.from(resourceId.asOpenPaaSId()),
-            new CalendarSharingUpdate(new Share(List.of(sharees), List.of())))
+            CalendarSharingUpdate.grant(sharees))
             .block();
-    }
-
-    private String mailto(OpenPaaSUser user) {
-        return "mailto:" + user.username().asString();
     }
 }

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/TeamCalendarMemberRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/TeamCalendarMemberRoutes.java
@@ -21,8 +21,6 @@ import static org.apache.james.webadmin.Constants.SEPARATOR;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
@@ -38,8 +36,8 @@ import org.eclipse.jetty.http.HttpStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Preconditions;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.AddSharee;
+import com.linagora.calendar.dav.CalendarSharingUpdate;
+import com.linagora.calendar.dav.CalendarSharingUpdate.AddSharee;
 import com.linagora.calendar.dav.DavClientException;
 import com.linagora.calendar.storage.MailtoUri;
 import com.linagora.calendar.storage.OpenPaaSUserDAO;
@@ -64,8 +62,6 @@ public class TeamCalendarMemberRoutes implements Routes {
         + SEPARATOR + "team-calendars"
         + SEPARATOR + TEAM_CALENDAR_ID_PARAM
         + SEPARATOR + "members";
-    private static final Predicate<Optional<Boolean>> ENABLED_DAV_RIGHT = right -> right.orElse(false);
-
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
 
     public record TeamCalendarMemberResponse(String username, String role, String davRight) {
@@ -139,20 +135,12 @@ public class TeamCalendarMemberRoutes implements Routes {
     private Mono<Void> validateAddSharees(Domain domain, List<AddSharee> sharees) {
         return Flux.fromIterable(sharees)
             .flatMap(sharee -> {
-                validateSingleDavRight(sharee);
                 Username username = parseMemberUsername(domain, sharee.davHref());
                 return userDAO.retrieve(username)
                     .switchIfEmpty(Mono.error(() -> new IllegalArgumentException("Candidate member not found: " + username.asString())))
                     .then();
             })
             .then();
-    }
-
-    private void validateSingleDavRight(AddSharee sharee) {
-        long enabledRights = Stream.of(sharee.read(), sharee.readWrite(), sharee.administration())
-            .filter(ENABLED_DAV_RIGHT)
-            .count();
-        Preconditions.checkArgument(enabledRights == 1, "Exactly one of 'dav:read', 'dav:read-write', 'dav:administration' must be true");
     }
 
     private Username parseMemberUsername(Domain domain, String davHref) {
@@ -180,7 +168,11 @@ public class TeamCalendarMemberRoutes implements Routes {
         try {
             return OBJECT_MAPPER.readValue(request.bodyAsBytes(), type);
         } catch (Exception exception) {
-            String detail = Optional.ofNullable(ExceptionUtils.getRootCause(exception))
+            Throwable rootCause = ExceptionUtils.getRootCause(exception);
+            if (rootCause instanceof CalendarSharingUpdate.InvalidDavRightException) {
+                throw new IllegalArgumentException(rootCause.getMessage(), exception);
+            }
+            String detail = Optional.ofNullable(rootCause)
                 .map(Throwable::getMessage)
                 .orElse(exception.getMessage());
             throw new IllegalArgumentException("Invalid request body: " + detail, exception);

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/UserCalendarRoutes.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/UserCalendarRoutes.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Preconditions;
 import com.linagora.calendar.dav.CalDavClient;
+import com.linagora.calendar.dav.CalendarSharingUpdate;
 import com.linagora.calendar.dav.DavClientException;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.OpenPaaSId;
@@ -175,7 +176,7 @@ public class UserCalendarRoutes implements Routes {
 
     private String updateInvitees(Request request, Response response) {
         OpenPaaSUser user = retrieveUser(request);
-        CalDavClient.CalendarSharingUpdate sharingUpdate = parseBody(request, CalDavClient.CalendarSharingUpdate.class);
+        CalendarSharingUpdate sharingUpdate = parseBody(request, CalendarSharingUpdate.class);
         CalendarURL calendarURL = retrieveExistingCalendar(request, user);
 
         wrapDavErrors(() -> calDavClient.updateCalendarShares(user.username(), calendarURL, sharingUpdate).block());

--- a/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/TeamCalendarMemberService.java
+++ b/calendar-webadmin/src/main/java/com/linagora/calendar/webadmin/service/TeamCalendarMemberService.java
@@ -19,6 +19,7 @@
 package com.linagora.calendar.webadmin.service;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
@@ -28,8 +29,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linagora.calendar.dav.CalDavClient;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
+import com.linagora.calendar.dav.CalendarSharingUpdate;
 import com.linagora.calendar.dav.DavClientException;
+import com.linagora.calendar.dav.DavRight;
 import com.linagora.calendar.dav.dto.CalendarDetailsResponse.CalendarInvite;
 import com.linagora.calendar.storage.CalendarURL;
 import com.linagora.calendar.storage.MailtoUri;
@@ -44,18 +46,16 @@ public class TeamCalendarMemberService {
     private static final Map<String, String> WITH_RIGHTS = Map.of("withRights", "true");
 
     public enum TeamCalendarRole {
-        VIEWER("viewer", "dav:read", 2),
-        MEMBER("member", "dav:read-write", 3),
-        MANAGER("manager", "dav:administration", 5);
+        VIEWER("viewer", DavRight.READ),
+        MEMBER("member", DavRight.READ_WRITE),
+        MANAGER("manager", DavRight.ADMINISTRATION);
 
         private final String value;
-        private final String davRight;
-        private final int davAccess;
+        private final DavRight davRight;
 
-        TeamCalendarRole(String value, String davRight, int davAccess) {
+        TeamCalendarRole(String value, DavRight davRight) {
             this.value = value;
             this.davRight = davRight;
-            this.davAccess = davAccess;
         }
 
         public String value() {
@@ -63,14 +63,19 @@ public class TeamCalendarMemberService {
         }
 
         public String davRight() {
-            return davRight;
+            return davRight.value();
         }
 
         public static TeamCalendarRole fromDavAccess(int davAccess) {
-            return Stream.of(values())
-                .filter(role -> role.davAccess == davAccess)
-                .findFirst()
+            return DavRight.fromAccess(davAccess)
+                .flatMap(TeamCalendarRole::fromDavRight)
                 .orElseThrow(() -> new IllegalArgumentException("Unsupported DAV delegation access: " + davAccess));
+        }
+
+        private static Optional<TeamCalendarRole> fromDavRight(DavRight davRight) {
+            return Stream.of(values())
+                .filter(role -> role.davRight == davRight)
+                .findFirst();
         }
     }
 

--- a/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/service/TeamCalendarMemberServiceTest.java
+++ b/calendar-webadmin/src/test/java/com/linagora/calendar/webadmin/service/TeamCalendarMemberServiceTest.java
@@ -34,10 +34,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linagora.calendar.dav.CalDavClient;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.AddSharee;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.RemoveSharee;
-import com.linagora.calendar.dav.CalDavClient.CalendarSharingUpdate.Share;
+import com.linagora.calendar.dav.CalendarSharingUpdate;
+import com.linagora.calendar.dav.DavRight;
 import com.linagora.calendar.dav.SabreDavExtension;
 import com.linagora.calendar.dav.SabreDavProvisioningService;
 import com.linagora.calendar.dav.dto.CalendarDetailsResponse;
@@ -128,14 +126,12 @@ class TeamCalendarMemberServiceTest {
                                                 OpenPaaSUser member,
                                                 OpenPaaSUser manager,
                                                 List<OpenPaaSUser> removedUsers) {
-        return new CalendarSharingUpdate(new Share(
-            List.of(
-                AddSharee.read(mailto(viewer)),
-                AddSharee.readWrite(mailto(member)),
-                AddSharee.administration(mailto(manager))),
-            removedUsers.stream()
-                .map(user -> new RemoveSharee(mailto(user)))
-                .toList()));
+        CalendarSharingUpdate.Builder builder = CalendarSharingUpdate.builder()
+            .grant(viewer.username(), DavRight.READ)
+            .grant(member.username(), DavRight.READ_WRITE)
+            .grant(manager.username(), DavRight.ADMINISTRATION);
+        removedUsers.forEach(user -> builder.revoke(user.username()));
+        return builder.build();
     }
 
     private String mailto(OpenPaaSUser user) {


### PR DESCRIPTION
The previous CalendarSharingUpdate model exposed SabreDAV's wire format
directly to callers. Creating sharing updates required nested Share,
AddSharee and RemoveSharee objects, as well as multiple Optional<Boolean>
values to represent a single DAV right.

This produced excessive boilerplate at call sites and made it difficult
to distinguish granted and revoked sharees when reading the code.

Extract CalendarSharingUpdate from CalDavClient and introduce an
expressive builder API with grant, grantAll, revoke and revokeAll
operations. Represent each added sharee with a single DavRight and keep
the SabreDAV-specific JSON mapping inside the model.

Also centralize DAV-right validation and mailto URI construction, and
simplify ResourceService sharing update creation.