### PR TITLE
ISSUE-1005 ItipEmailNotificationPublisher should send email notification to booker when organizer decline event

### DIFF
--- a/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDiffCalculator.java
+++ b/calendar-amqp/src/main/java/com/linagora/calendar/amqp/CalendarDiffCalculator.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
@@ -136,8 +137,9 @@ public class CalendarDiffCalculator {
 
         Optional<List<PropertyChange>> changes = computePropertyChanges(previousEvent, currentEvent);
         boolean organizerAcceptedTransition = organizerAcceptedTransition(previousEvent, currentEvent);
+        boolean organizerDeclinedBookingTransition = organizerDeclinedBookingTransition(previousEvent, currentEvent);
         boolean attendeePartStatChanged = attendeePartStatChanged(recipient, previousEvent, currentEvent);
-        boolean hasNoRelevantChanges = recipientWasAttending && recipientIsAttendingNow && changes.isEmpty() && !organizerAcceptedTransition && !attendeePartStatChanged;
+        boolean hasNoRelevantChanges = recipientWasAttending && recipientIsAttendingNow && changes.isEmpty() && !organizerAcceptedTransition && !organizerDeclinedBookingTransition && !attendeePartStatChanged;
         if (hasNoRelevantChanges) {
             return ImmutableList.of();
         }
@@ -222,6 +224,45 @@ public class CalendarDiffCalculator {
 
                 return wasDeclinedOrNeedAction && isNowAccepted;
             })
+            .orElse(false);
+    }
+
+    /**
+     * A publicly created booking the organizer turns down. The refusal is the answer the booker has
+     * been waiting for, so it has to be notified even though no other property moved: the organizer
+     * PARTSTAT is the only difference between the two versions.
+     *
+     * <p>Restricted to bookings on purpose. Outside that flow a declining organizer keeps the
+     * previous behaviour and notifies nobody, so ordinary meetings are unaffected.
+     */
+    private static boolean organizerDeclinedBookingTransition(VEvent previousEvent, VEvent currentEvent) {
+        if (!publiclyCreated(currentEvent)) {
+            return false;
+        }
+
+        return EventParseUtils.getOrganizer(previousEvent)
+            .map(organizer -> {
+                // Only from NEEDS-ACTION: DECLINED -> DECLINED is a no-op, not an answer.
+                boolean wasNotDeclined = EventParseUtils.getAttendees(previousEvent)
+                    .stream()
+                    .filter(person -> person.email().equals(organizer.email()))
+                    .flatMap(person -> person.partStat().stream())
+                    .noneMatch(stat -> stat.equals(PartStat.DECLINED));
+
+                boolean isNowDeclined = EventParseUtils.getAttendees(currentEvent)
+                    .stream()
+                    .filter(person -> person.email().equals(organizer.email()))
+                    .flatMap(person -> person.partStat().stream())
+                    .anyMatch(stat -> stat.equals(PartStat.DECLINED));
+
+                return wasNotDeclined && isNowDeclined;
+            })
+            .orElse(false);
+    }
+
+    private static boolean publiclyCreated(VEvent event) {
+        return EventParseUtils.getPropertyValueIgnoreCase(event, EventEmailConsumer.X_PUBLICLY_CREATED_HEADER)
+            .map(BooleanUtils::toBoolean)
             .orElse(false);
     }
 

--- a/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDiffCalculatorTest.java
+++ b/calendar-amqp/src/test/java/com/linagora/calendar/amqp/CalendarDiffCalculatorTest.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linagora.calendar.amqp.CalendarDiffCalculator.EventDiff;
 import com.linagora.calendar.amqp.CalendarDiffCalculator.StringPropertyChange;
@@ -921,6 +923,63 @@ class CalendarDiffCalculatorTest {
                     assertThat(diff.isNewEvent()).isFalse();
                     assertThat(diff.serializeChanges()).isEmpty();
                 });
+        }
+    }
+
+    @Nested
+    class OrganizerDeclinedBookingTransition {
+
+        private String ics(String organizerPartStat, String publiclyCreated) {
+            return """
+                BEGIN:VCALENDAR
+                VERSION:2.0
+                PRODID:-//Test//Test//EN
+                METHOD:REQUEST
+                BEGIN:VEVENT
+                UID:uid-declined-booking@test
+                DTSTART:20260401T100000Z
+                DTEND:20260401T110000Z
+                SUMMARY:Booked slot
+                ATTENDEE;PARTSTAT={organizerPartStat};ROLE=CHAIR:mailto:alice@example.com
+                ATTENDEE;PARTSTAT=ACCEPTED:mailto:bob@example.com
+                ORGANIZER:mailto:alice@example.com
+                {publiclyCreated}
+                END:VEVENT
+                END:VCALENDAR
+                """.replace("{organizerPartStat}", organizerPartStat)
+                .replace("{publiclyCreated}", publiclyCreated);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ACCEPTED", "NEEDS-ACTION", "TENTATIVE"})
+        void organizerDecliningBookingReturnsDiffEvenWithoutOtherChanges(String organizerPartStat) {
+            List<EventDiff> diffs = CalendarDiffCalculator.calculate(RECIPIENT,
+                parse(ics("DECLINED", "X-PUBLICLY-CREATED:true")),
+                parse(ics(organizerPartStat, "X-PUBLICLY-CREATED:true")));
+
+            assertThat(diffs).singleElement()
+                .satisfies(diff -> {
+                    assertThat(diff.isNewEvent()).isFalse();
+                    assertThat(diff.serializeChanges()).isEmpty();
+                });
+        }
+
+        @Test
+        void organizerDecliningOrdinaryMeetingReturnsNoDiff() {
+            List<EventDiff> diffs = CalendarDiffCalculator.calculate(RECIPIENT,
+                parse(ics("DECLINED", "DESCRIPTION:Not a booking")),
+                parse(ics("NEEDS-ACTION", "DESCRIPTION:Not a booking")));
+
+            assertThat(diffs).isEmpty();
+        }
+
+        @Test
+        void alreadyDeclinedBookingReturnsNoDiff() {
+            List<EventDiff> diffs = CalendarDiffCalculator.calculate(RECIPIENT,
+                parse(ics("DECLINED", "X-PUBLICLY-CREATED:true")),
+                parse(ics("DECLINED", "X-PUBLICLY-CREATED:true")));
+
+            assertThat(diffs).isEmpty();
         }
     }
 


### PR DESCRIPTION
This update follows https://github.com/linagora/esn-sabre/pull/458 to fully allow sending email notification to booker when organizer decline event