### PR TITLE
Set distinct User-Agent headers for DAV clients

### DIFF
--- a/calendar-dav/src/main/java/com/linagora/calendar/dav/DavClient.java
+++ b/calendar-dav/src/main/java/com/linagora/calendar/dav/DavClient.java
@@ -38,21 +38,27 @@ import reactor.netty.http.client.HttpClient;
 public abstract class DavClient {
     protected static final Duration DEFAULT_RESPONSE_TIMEOUT = Duration.ofSeconds(10);
     protected static final String TWAKE_CALENDAR_TOKEN_HEADER_NAME = "TwakeCalendarToken";
+    private static final String USER_AGENT = "twake-calendar-side-service " + HttpClient.USER_AGENT;
 
     protected final HttpClient client;
     protected final DavConfiguration config;
     protected final TechnicalTokenService technicalTokenService;
 
     protected DavClient(DavConfiguration config, TechnicalTokenService technicalTokenService) throws SSLException {
+        this(config, technicalTokenService, USER_AGENT);
+    }
+
+    protected DavClient(DavConfiguration config, TechnicalTokenService technicalTokenService, String userAgent) throws SSLException {
         this.config = config;
-        this.client = createHttpClient(config.trustAllSslCerts().orElse(false));
+        this.client = createHttpClient(config.trustAllSslCerts().orElse(false), userAgent);
         this.technicalTokenService = technicalTokenService;
     }
 
-    protected HttpClient createHttpClient(boolean trustAllSslCerts) throws SSLException {
+    protected HttpClient createHttpClient(boolean trustAllSslCerts, String userAgent) throws SSLException {
         HttpClient client = HttpClient.create()
             .baseUrl(config.baseUrl().toString())
-            .responseTimeout(config.responseTimeout().orElse(DEFAULT_RESPONSE_TIMEOUT));
+            .responseTimeout(config.responseTimeout().orElse(DEFAULT_RESPONSE_TIMEOUT))
+            .headers(headers -> headers.set(HttpHeaderNames.USER_AGENT, userAgent));
         if (trustAllSslCerts) {
             SslContext sslContext = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
             return client.secure(sslContextSpec -> sslContextSpec.sslContext(sslContext));

--- a/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/DavProxy.java
+++ b/calendar-rest-api/src/main/java/com/linagora/calendar/restapi/DavProxy.java
@@ -39,19 +39,21 @@ import io.netty.handler.codec.http.HttpStatusClass;
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufFlux;
 import reactor.netty.NettyOutbound;
+import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
 import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
 
 public class DavProxy extends DavClient {
     public static final Logger LOGGER = LoggerFactory.getLogger(DavProxy.class);
+    private static final String USER_AGENT = "twake-calendar-dav-proxy " + HttpClient.USER_AGENT;
     private final Authenticator authenticator;
     private final MetricFactory metricFactory;
 
     @Inject
     public DavProxy(Authenticator authenticator, DavConfiguration davConfiguration,
                     MetricFactory metricFactory, TechnicalTokenService technicalTokenService) throws SSLException {
-        super(davConfiguration, technicalTokenService);
+        super(davConfiguration, technicalTokenService, USER_AGENT);
 
         this.authenticator = authenticator;
         this.metricFactory = metricFactory;


### PR DESCRIPTION
## Why

Make it easy to distinguish direct calendar-side-service DAV traffic  when debug log in esn-sabre

## Expected esn-sabre logs

```text
DEBUG User-Agent: twake-calendar-side-service ReactorNetty/<version>
DEBUG User-Agent: twake-calendar-dav-proxy ReactorNetty/<version>
```